### PR TITLE
Move things which are not part of the API to an impl directory/namespace

### DIFF
--- a/impl/apple/external_commit_helper.cpp
+++ b/impl/apple/external_commit_helper.cpp
@@ -30,6 +30,7 @@
 #include <sstream>
 
 using namespace realm;
+using namespace realm::_impl;
 
 namespace {
 // Write a byte to a pipe to notify anyone waiting for data on the pipe

--- a/impl/apple/external_commit_helper.hpp
+++ b/impl/apple/external_commit_helper.hpp
@@ -26,6 +26,7 @@
 namespace realm {
 class Realm;
 
+namespace _impl {
 class ExternalCommitHelper {
 public:
     ExternalCommitHelper(Realm* realm);
@@ -87,6 +88,7 @@ private:
     FdHolder m_shutdown_write_fd;
 };
 
+} // namespace _impl
 } // namespace realm
 
 #endif /* REALM_EXTERNAL_COMMIT_HELPER_HPP */

--- a/impl/transact_log_handler.cpp
+++ b/impl/transact_log_handler.cpp
@@ -316,6 +316,7 @@ public:
 } // anonymous namespace
 
 namespace realm {
+namespace _impl {
 namespace transaction {
 void advance(SharedGroup& sg, ClientHistory& history, RealmDelegate* delegate) {
     TransactLogHandler(delegate, sg, [&](auto&&... args) {
@@ -344,4 +345,5 @@ void cancel(SharedGroup& sg, ClientHistory& history, RealmDelegate* delegate) {
 }
 
 } // namespace transaction
+} // namespace _impl
 } // namespace realm

--- a/impl/transact_log_handler.hpp
+++ b/impl/transact_log_handler.hpp
@@ -24,6 +24,7 @@ class RealmDelegate;
 class SharedGroup;
 class ClientHistory;
 
+namespace _impl {
 namespace transaction {
 // Advance the read transaction version, with change notifications sent to delegate
 // Must not be called from within a write transaction.
@@ -41,6 +42,7 @@ void commit(SharedGroup& sg, ClientHistory& history, RealmDelegate* delegate);
 // for reverting to the old values sent to delegate
 void cancel(SharedGroup& sg, ClientHistory& history, RealmDelegate* delegate);
 } // namespace transaction
+} // namespace _impl
 } // namespace realm
 
 #endif /* REALM_TRANSACT_LOG_HANDLER_HPP */

--- a/shared_realm.cpp
+++ b/shared_realm.cpp
@@ -29,6 +29,7 @@
 #include <mutex>
 
 using namespace realm;
+using namespace realm::_impl;
 
 RealmCache Realm::s_global_cache;
 

--- a/shared_realm.hpp
+++ b/shared_realm.hpp
@@ -28,12 +28,15 @@
 
 namespace realm {
     class ClientHistory;
-    class ExternalCommitHelper;
     class Realm;
     class RealmCache;
     class RealmDelegate;
     typedef std::shared_ptr<Realm> SharedRealm;
     typedef std::weak_ptr<Realm> WeakRealm;
+
+    namespace _impl {
+        class ExternalCommitHelper;
+    }
 
     class Realm : public std::enable_shared_from_this<Realm>
     {
@@ -114,7 +117,7 @@ namespace realm {
 
         Group *m_group = nullptr;
 
-        std::shared_ptr<ExternalCommitHelper> m_notifier;
+        std::shared_ptr<_impl::ExternalCommitHelper> m_notifier;
 
       public:
         std::unique_ptr<RealmDelegate> m_delegate;


### PR DESCRIPTION
Currently just transact_log_handler and external_commit_helper.
