### PR TITLE
End the read transaction after schema init

### DIFF
--- a/shared_realm.cpp
+++ b/shared_realm.cpp
@@ -171,6 +171,13 @@ SharedRealm Realm::get_shared_realm(Config config)
             else {
                 realm->update_schema(std::move(target_schema), target_schema_version);
             }
+
+            if (!m_config.read_only) {
+                // End the read transaction created to validation/update the
+                // schema to avoid pinning the version even if the user never
+                // actually reads data
+                invalidate();
+            }
         }
     }
 

--- a/shared_realm.hpp
+++ b/shared_realm.hpp
@@ -88,6 +88,7 @@ namespace realm {
         void commit_transaction();
         void cancel_transaction();
         bool is_in_transaction() const { return m_in_transaction; }
+        bool is_in_read_transaction() const { return !!m_group; }
 
         bool refresh();
         void set_auto_refresh(bool auto_refresh) { m_auto_refresh = auto_refresh; }


### PR DESCRIPTION
In obj-c this was oddly effective at helping users avoid the file-size explosion due to accidental version pinning, and there's no real downside (begin_read() is pretty cheap).
