### PR TITLE
Make Schema constructable from initializer lists

### DIFF
--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -28,6 +28,14 @@ using namespace realm;
 
 ObjectSchema::~ObjectSchema() = default;
 
+ObjectSchema::ObjectSchema(std::string name, std::string primary_key, std::initializer_list<Property> properties)
+: name(std::move(name))
+, properties(properties)
+, primary_key(std::move(primary_key))
+{
+    set_primary_key_property();
+}
+
 ObjectSchema::ObjectSchema(const Group *group, const std::string &name) : name(name) {
     ConstTableRef table = ObjectStore::table_for_object_type(group, name);
 
@@ -50,13 +58,7 @@ ObjectSchema::ObjectSchema(const Group *group, const std::string &name) : name(n
     }
 
     primary_key = realm::ObjectStore::get_primary_key_for_object(group, name);
-    if (primary_key.length()) {
-        auto primary_key_prop = primary_key_property();
-        if (!primary_key_prop) {
-            throw InvalidPrimaryKeyException(name, primary_key);
-        }
-        primary_key_prop->is_primary = true;
-    }
+    set_primary_key_property();
 }
 
 Property *ObjectSchema::property_for_name(StringData name) {
@@ -70,4 +72,15 @@ Property *ObjectSchema::property_for_name(StringData name) {
 
 const Property *ObjectSchema::property_for_name(StringData name) const {
     return const_cast<ObjectSchema *>(this)->property_for_name(name);
+}
+
+void ObjectSchema::set_primary_key_property()
+{
+    if (primary_key.length()) {
+        auto primary_key_prop = primary_key_property();
+        if (!primary_key_prop) {
+            throw InvalidPrimaryKeyException(name, primary_key);
+        }
+        primary_key_prop->is_primary = true;
+    }
 }

--- a/src/object_schema.hpp
+++ b/src/object_schema.hpp
@@ -31,6 +31,7 @@ namespace realm {
     class ObjectSchema {
     public:
         ObjectSchema() = default;
+        ObjectSchema(std::string name, std::string primary_key, std::initializer_list<Property> properties);
         ~ObjectSchema();
 
         // create object schema from existing table
@@ -49,6 +50,9 @@ namespace realm {
         const Property *primary_key_property() const {
             return property_for_name(primary_key);
         }
+
+    private:
+        void set_primary_key_property();
     };
 }
 

--- a/src/property.hpp
+++ b/src/property.hpp
@@ -53,7 +53,7 @@ namespace realm {
         bool is_indexed = false;
         bool is_nullable = false;
 
-        size_t table_column;
+        size_t table_column = -1;
         bool requires_index() const { return is_primary || is_indexed; }
     };
 

--- a/src/schema.hpp
+++ b/src/schema.hpp
@@ -31,6 +31,7 @@ private:
 public:
     // Create a schema from a vector of ObjectSchema
     Schema(base types);
+    Schema(std::initializer_list<ObjectSchema> types) : Schema(base(types)) { }
 
     // find an ObjectSchema by name
     iterator find(std::string const& name);


### PR DESCRIPTION
This enables the following syntax for defining object schemas, which is useful for writing tests:

```
Schema schema = {
    {"origin", "", {
        {"array", PropertyTypeArray, "target"}
    }},
    {"target", "", {
        {"prop1", PropertyTypeInt},
        {"prop2", PropertyTypeFloat},
    }},
};
```
