### PR TITLE
Remove the Query version of Results::index_of()

### DIFF
--- a/src/results.cpp
+++ b/src/results.cpp
@@ -190,9 +190,6 @@ size_t Results::index_of(size_t row_ndx)
         case Mode::Table:
             return row_ndx;
         case Mode::Query:
-            if (!m_sort)
-                return m_query.count(row_ndx, row_ndx + 1) ? m_query.count(0, row_ndx) : not_found;
-            REALM_FALLTHROUGH;
         case Mode::TableView:
             update_tableview();
             return m_table_view.find_by_source_ndx(row_ndx);


### PR DESCRIPTION
It didn't work for queries based on a LinkView because for those the arguments to count() are indexes in the LinkView rather than table rows, and there's currently no way to check if a query is based on a LinkView.
