### PR TITLE
Remove an incorrect std::move()

### DIFF
--- a/src/parser/parser.cpp
+++ b/src/parser/parser.cpp
@@ -331,7 +331,7 @@ Predicate parse(const std::string &query)
     if (out_predicate.type == Predicate::Type::And && out_predicate.cpnd.sub_predicates.size() == 1) {
         return std::move(out_predicate.cpnd.sub_predicates.back());
     }
-    return std::move(out_predicate);
+    return out_predicate;
 }
 
 void analyze_grammar()


### PR DESCRIPTION
Returning a local variable implicitly converts it to an rvalue and explicitly calling std::move() prevents RVO.
