### PR TITLE
Build both dynamic and static libraries of the object store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,6 @@ cmake_install.cmake
 rules.ninja
 
 # Build products
-src/librealm-object-store.*
+src/librealm-object-store.dylib
+src/librealm-object-store-static.a
 tests/tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ include(RealmCore)
 set(REALM_CORE_VERSION "0.100.1" CACHE STRING "")
 use_realm_core(${REALM_CORE_VERSION})
 
-include_directories(${REALM_CORE_INCLUDE_DIR} src external/pegtl)
+set(PEGTL_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/pegtl)
 
 add_subdirectory(src)
 add_subdirectory(tests)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,5 +55,20 @@ else()
         impl/generic/external_commit_helper.hpp)
 endif()
 
-add_library(realm-object-store SHARED ${SOURCES} ${HEADERS})
-target_link_libraries(realm-object-store realm ${CF_LIBRARY})
+set(INCLUDE_DIRS ${REALM_CORE_INCLUDE_DIR} ${PEGTL_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})
+
+# An object library to group together the compilation of the source files.
+add_library(realm-object-store-objects OBJECT ${SOURCES} ${HEADERS})
+add_dependencies(realm-object-store-objects realm)
+set_target_properties(realm-object-store-objects PROPERTIES POSITION_INDEPENDENT_CODE 1)
+target_include_directories(realm-object-store-objects PUBLIC ${INCLUDE_DIRS})
+
+# A static library, aggregating the prebuilt object files.
+add_library(realm-object-store-static STATIC $<TARGET_OBJECTS:realm-object-store-objects>)
+target_include_directories(realm-object-store-static PUBLIC ${INCLUDE_DIRS})
+target_link_libraries(realm-object-store-static PUBLIC realm ${CF_LIBRARY})
+
+# A dynamic library, linking together the prebuilt object files.
+add_library(realm-object-store SHARED $<TARGET_OBJECTS:realm-object-store-objects>)
+target_include_directories(realm-object-store PUBLIC ${INCLUDE_DIRS})
+target_link_libraries(realm-object-store PRIVATE realm ${CF_LIBRARY})


### PR DESCRIPTION
The dynamic library makes it easy to verify that there are no linker errors when building the object store, while the static library is easier for a binding to consume.

This also tweaks how the library targets are defined to ensure that other CMake projects that pull in the libraries automatically get the right include paths and link to the appropriate libraries.
