### PR TITLE
Bool and NSDate properties can be indexed.

### DIFF
--- a/src/property.hpp
+++ b/src/property.hpp
@@ -55,6 +55,7 @@ namespace realm {
 
         size_t table_column = -1;
         bool requires_index() const { return is_primary || is_indexed; }
+        bool is_indexable() const { return type == PropertyTypeInt || type == PropertyTypeBool || type == PropertyTypeString || type == PropertyTypeDate; }
     };
 
     static inline const char *string_for_property_type(PropertyType type) {

--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -89,7 +89,7 @@ void Schema::validate() const
 
             // check indexable
             if (prop.is_indexed) {
-                if (prop.type != PropertyTypeString && prop.type != PropertyTypeInt) {
+                if (!prop.is_indexable()) {
                     exceptions.emplace_back(PropertyTypeNotIndexableException(object.name, prop));
                 }
             }


### PR DESCRIPTION
Core supports indexing Bool and NSDate properties.
realm-java also supports indexing Bool and NSDate properties.
It is better to align the specification with realm-java.
