### PR TITLE
Move cmake_minimum_required() to the correct place

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,8 @@
+cmake_minimum_required(VERSION 3.2.0)
+
 set(CMAKE_BUILD_TYPE Debug CACHE STRING "")
 project(realm-object-store)
 
-cmake_minimum_required(VERSION 3.2.0)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/CMake")
 
 include(CompilerFlags)


### PR DESCRIPTION
It has to be before the call to project() or it doesn't do anything.

@bdash
