### PR TITLE
Fix the initial ref count for WeakRealmNotifier

### DIFF
--- a/src/impl/apple/weak_realm_notifier.cpp
+++ b/src/impl/apple/weak_realm_notifier.cpp
@@ -34,7 +34,7 @@ WeakRealmNotifier::WeakRealmNotifier(const std::shared_ptr<Realm>& realm, bool c
     };
 
     CFRunLoopSourceContext ctx{};
-    ctx.info = new RefCountedWeakPointer{realm, {1}};
+    ctx.info = new RefCountedWeakPointer{realm, {0}};
     ctx.perform = [](void* info) {
         if (auto realm = static_cast<RefCountedWeakPointer*>(info)->realm.lock()) {
             realm->notify();


### PR DESCRIPTION
Adding the run loop source to the run loop retains it, so the initial refcount should be 0, not 1.
