### PR TITLE
Split SchemaValidationException into SchemaValidationException and SchemaMismatchException

### DIFF
--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -171,7 +171,7 @@ void ObjectStore::verify_schema(Schema const& actual_schema, Schema& target_sche
         errors.insert(errors.end(), more_errors.begin(), more_errors.end());
     }
     if (errors.size()) {
-        throw SchemaValidationException(errors);
+        throw SchemaMismatchException(errors);
     }
 }
 
@@ -524,7 +524,16 @@ DuplicatePrimaryKeyValueException::DuplicatePrimaryKeyValueException(std::string
 SchemaValidationException::SchemaValidationException(std::vector<ObjectSchemaValidationException> const& errors) :
     m_validation_errors(errors)
 {
-    m_what ="Migration is required due to the following errors: ";
+    m_what = "Schema validation failed due to the following errors: ";
+    for (auto const& error : errors) {
+        m_what += std::string("\n- ") + error.what();
+    }
+}
+
+SchemaMismatchException::SchemaMismatchException(std::vector<ObjectSchemaValidationException> const& errors) :
+m_validation_errors(errors)
+{
+    m_what = "Migration is required due to the following errors: ";
     for (auto const& error : errors) {
         m_what += std::string("\n- ") + error.what();
     }

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -160,6 +160,14 @@ namespace realm {
         std::vector<ObjectSchemaValidationException> m_validation_errors;
     };
 
+    class SchemaMismatchException : public ObjectStoreException {
+    public:
+        SchemaMismatchException(std::vector<ObjectSchemaValidationException> const& errors);
+        std::vector<ObjectSchemaValidationException> const& validation_errors() const { return m_validation_errors; }
+    private:
+        std::vector<ObjectSchemaValidationException> m_validation_errors;
+    };
+
     class ObjectSchemaValidationException : public ObjectStoreException {
       public:
         ObjectSchemaValidationException(std::string const& object_type) : m_object_type(object_type) {}


### PR DESCRIPTION
Because SchemaValidationException is thrown both case that a schema definition is incorrect and case that two schema definitions are mismatched.
In the former case, the migration does not solve the problem. But the exception message shows "Migration is required..."

Therefore the latter as MismatchException, to distinguish between the two cases.
