### PR TITLE
Fix building tests in Xcode

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,6 +69,6 @@ target_include_directories(realm-object-store-static PUBLIC ${INCLUDE_DIRS})
 target_link_libraries(realm-object-store-static PUBLIC realm ${CF_LIBRARY})
 
 # A dynamic library, linking together the prebuilt object files.
-add_library(realm-object-store SHARED $<TARGET_OBJECTS:realm-object-store-objects>)
+add_library(realm-object-store SHARED $<TARGET_OBJECTS:realm-object-store-objects> placeholder.cpp)
 target_include_directories(realm-object-store PUBLIC ${INCLUDE_DIRS})
 target_link_libraries(realm-object-store PRIVATE realm ${CF_LIBRARY})

--- a/src/placeholder.cpp
+++ b/src/placeholder.cpp
@@ -1,0 +1,1 @@
+// This file is intentionally left blank.


### PR DESCRIPTION
The Xcode project generated by CMake doesn't create the dylib when built as the dylib target does not contain any source files. Adding an empty placeholder .cpp file to the target is sufficient to convince Xcode to produce the dylib.

/cc @tgoyne 
