### PR TITLE
Fix a potential leak within WeakRealmNotifier

### DIFF
--- a/src/impl/apple/weak_realm_notifier.cpp
+++ b/src/impl/apple/weak_realm_notifier.cpp
@@ -69,6 +69,8 @@ WeakRealmNotifier::WeakRealmNotifier(WeakRealmNotifier&& rgt)
 WeakRealmNotifier& WeakRealmNotifier::operator=(WeakRealmNotifier&& rgt)
 {
     WeakRealmNotifierBase::operator=(std::move(rgt));
+
+    invalidate();
     m_runloop = rgt.m_runloop;
     m_signal = rgt.m_signal;
     rgt.m_runloop = nullptr;
@@ -78,6 +80,11 @@ WeakRealmNotifier& WeakRealmNotifier::operator=(WeakRealmNotifier&& rgt)
 }
 
 WeakRealmNotifier::~WeakRealmNotifier()
+{
+    invalidate();
+}
+
+void WeakRealmNotifier::invalidate()
 {
     if (m_signal) {
         CFRunLoopSourceInvalidate(m_signal);

--- a/src/impl/apple/weak_realm_notifier.hpp
+++ b/src/impl/apple/weak_realm_notifier.hpp
@@ -40,6 +40,8 @@ public:
     void notify();
 
 private:
+    void invalidate();
+
     CFRunLoopRef m_runloop;
     CFRunLoopSourceRef m_signal;
 };


### PR DESCRIPTION
Ensure that `WeakRealmNotifier`'s move-assignment operator releases its old runloop and source before taking on the new ones.

Fixes #74.

/cc @tgoyne 
