### PR TITLE
Add basic string formatting for error messages

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,8 @@ set(SOURCES
     impl/results_notifier.cpp
     impl/transact_log_handler.cpp
     parser/parser.cpp
-    parser/query_builder.cpp)
+    parser/query_builder.cpp
+    util/format.cpp)
 
 set(HEADERS
     collection_notifications.hpp
@@ -37,7 +38,8 @@ set(HEADERS
     impl/weak_realm_notifier_base.hpp
     parser/parser.hpp
     parser/query_builder.hpp
-    util/atomic_shared_ptr.hpp)
+    util/atomic_shared_ptr.hpp
+    util/format.hpp)
 
 if(APPLE)
     list(APPEND SOURCES

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -21,9 +21,8 @@
 #include "impl/list_notifier.hpp"
 #include "impl/realm_coordinator.hpp"
 #include "results.hpp"
+#include "util/format.hpp"
 
-#include <realm/link_view.hpp>
-#include <realm/util/to_string.hpp>
 #include <stdexcept>
 
 using namespace realm;
@@ -54,8 +53,7 @@ void List::verify_valid_row(size_t row_ndx, bool insertion) const
 {
     size_t size = m_link_view->size();
     if (row_ndx > size || (!insertion && row_ndx == size)) {
-        throw std::out_of_range("Index " + util::to_string(row_ndx) + " is outside of range 0..." +
-                                util::to_string(size) + ".");
+        throw std::out_of_range(util::format("Index %1 is outside of range 0...%2.", row_ndx, size));
     }
 }
 

--- a/src/parser/query_builder.cpp
+++ b/src/parser/query_builder.cpp
@@ -19,10 +19,11 @@
 #include "query_builder.hpp"
 #include "parser.hpp"
 
-#include <realm.hpp>
 #include "object_store.hpp"
 #include "schema.hpp"
+#include "util/format.hpp"
 
+#include <realm.hpp>
 #include <assert.h>
 
 namespace realm {
@@ -30,12 +31,12 @@ namespace query_builder {
 using namespace parser;
 
 template<typename T>
-T stot(const std::string s) {
+T stot(std::string const& s) {
     std::istringstream iss(s);
     T value;
     iss >> value;
     if (iss.fail()) {
-        throw std::invalid_argument("Cannot convert string '" + s + "'");
+        throw std::invalid_argument(util::format("Cannot convert string '%1'", s));
     }
     return value;
 }
@@ -95,12 +96,13 @@ struct PropertyExpression
         for (size_t index = 0; index < key_path.size(); index++) {
             if (prop) {
                 precondition(prop->type == PropertyType::Object || prop->type == PropertyType::Array,
-                             (std::string)"Property '" + key_path[index] + "' is not a link in object of type '" + desc->name + "'");
+                             util::format("Property '%1' is not a link in object of type '%2'", key_path[index], desc->name));
                 indexes.push_back(prop->table_column);
 
             }
             prop = desc->property_for_name(key_path[index]);
-            precondition(prop != nullptr, "No property '" + key_path[index] + "' on object of type '" + desc->name + "'");
+            precondition(prop != nullptr,
+                         util::format("No property '%1' on object of type '%2'", key_path[index], desc->name));
 
             if (prop->object_type.size()) {
                 desc = schema.find(prop->object_type);
@@ -432,9 +434,8 @@ void do_add_comparison_to_query(Query &query, const Schema &schema, const Object
         case PropertyType::Array:
             add_link_constraint_to_query(query, cmp.op, expr, link_argument(lhs, rhs, args));
             break;
-        default: {
-            throw std::runtime_error((std::string)"Object type " + string_for_property_type(type) + " not supported");
-        }
+        default:
+            throw std::runtime_error(util::format("Object type '%1' not supported", string_for_property_type(type)));
     }
 }
 

--- a/src/parser/query_builder.hpp
+++ b/src/parser/query_builder.hpp
@@ -22,8 +22,6 @@
 #include "parser.hpp"
 #include "object_accessor.hpp"
 
-#include <realm/util/to_string.hpp>
-
 namespace realm {
 class Query;
 class Schema;
@@ -68,10 +66,7 @@ class ArgumentConverter : public Arguments {
     ContextType m_ctx;
 
     ValueType &argument_at(size_t index) {
-        if (index >= m_arguments.size()) {
-            throw std::out_of_range((std::string)"Argument index " + util::to_string(index) + " out of range 0.." + util::to_string(m_arguments.size()-1));
-        }
-        return m_arguments[index];
+        return m_arguments.at(index);
     }
 };
 }

--- a/src/results.cpp
+++ b/src/results.cpp
@@ -21,6 +21,7 @@
 #include "impl/realm_coordinator.hpp"
 #include "impl/results_notifier.hpp"
 #include "object_store.hpp"
+#include "util/format.hpp"
 
 #include <stdexcept>
 
@@ -324,6 +325,7 @@ size_t Results::index_of(size_t row_ndx)
 
 template<typename Int, typename Float, typename Double, typename Timestamp>
 util::Optional<Mixed> Results::aggregate(size_t column, bool return_none_for_empty,
+                                         const char* name,
                                          Int agg_int, Float agg_float,
                                          Double agg_double, Timestamp agg_timestamp)
 {
@@ -362,13 +364,13 @@ util::Optional<Mixed> Results::aggregate(size_t column, bool return_none_for_emp
         case type_Float: return do_agg(agg_float);
         case type_Int: return do_agg(agg_int);
         default:
-            throw UnsupportedColumnTypeException{column, m_table};
+            throw UnsupportedColumnTypeException{column, m_table, name};
     }
 }
 
 util::Optional<Mixed> Results::max(size_t column)
 {
-    return aggregate(column, true,
+    return aggregate(column, true, "max",
                      [=](auto const& table) { return table.maximum_int(column); },
                      [=](auto const& table) { return table.maximum_float(column); },
                      [=](auto const& table) { return table.maximum_double(column); },
@@ -377,7 +379,7 @@ util::Optional<Mixed> Results::max(size_t column)
 
 util::Optional<Mixed> Results::min(size_t column)
 {
-    return aggregate(column, true,
+    return aggregate(column, true, "min",
                      [=](auto const& table) { return table.minimum_int(column); },
                      [=](auto const& table) { return table.minimum_float(column); },
                      [=](auto const& table) { return table.minimum_double(column); },
@@ -386,20 +388,20 @@ util::Optional<Mixed> Results::min(size_t column)
 
 util::Optional<Mixed> Results::sum(size_t column)
 {
-    return aggregate(column, false,
+    return aggregate(column, false, "sum",
                      [=](auto const& table) { return table.sum_int(column); },
                      [=](auto const& table) { return table.sum_float(column); },
                      [=](auto const& table) { return table.sum_double(column); },
-                     [=](auto const&) -> util::None { throw UnsupportedColumnTypeException{column, m_table}; });
+                     [=](auto const&) -> util::None { throw UnsupportedColumnTypeException{column, m_table, "sum"}; });
 }
 
 util::Optional<Mixed> Results::average(size_t column)
 {
-    return aggregate(column, true,
+    return aggregate(column, true, "average",
                      [=](auto const& table) { return table.average_int(column); },
                      [=](auto const& table) { return table.average_float(column); },
                      [=](auto const& table) { return table.average_double(column); },
-                     [=](auto const&) -> util::None { throw UnsupportedColumnTypeException{column, m_table}; });
+                     [=](auto const&) -> util::None { throw UnsupportedColumnTypeException{column, m_table, "average"}; });
 }
 
 void Results::clear()
@@ -544,8 +546,14 @@ void Results::Internal::set_table_view(Results& results, realm::TableView &&tv)
     REALM_ASSERT(results.m_table_view.is_attached());
 }
 
-Results::UnsupportedColumnTypeException::UnsupportedColumnTypeException(size_t column, const Table* table)
-: std::runtime_error((std::string)"Operation not supported on '" + table->get_column_name(column).data() + "' columns")
+Results::OutOfBoundsIndexException::OutOfBoundsIndexException(size_t r, size_t c)
+: std::out_of_range(util::format("Requested index %1 greater than max %2", r, c))
+, requested(r), valid_count(c) {}
+
+Results::UnsupportedColumnTypeException::UnsupportedColumnTypeException(size_t column, const Table* table, const char* operation)
+: std::runtime_error(util::format("Cannot %1 property '%2': operation not supported for '%3' properties",
+                                  operation, table->get_column_name(column),
+                                  string_for_property_type(static_cast<PropertyType>(table->get_column_type(column)))))
 , column_index(column)
 , column_name(table->get_column_name(column))
 , column_type(table->get_column_type(column))

--- a/src/results.hpp
+++ b/src/results.hpp
@@ -25,7 +25,6 @@
 
 #include <realm/table_view.hpp>
 #include <realm/util/optional.hpp>
-#include <realm/util/to_string.hpp>
 
 namespace realm {
 template<typename T> class BasicRowExpr;
@@ -138,18 +137,13 @@ public:
 
     // The Results object has been invalidated (due to the Realm being invalidated)
     // All non-noexcept functions can throw this
-    struct InvalidatedException : public std::runtime_error
-    {
+    struct InvalidatedException : public std::runtime_error {
         InvalidatedException() : std::runtime_error("Access to invalidated Results objects") {}
     };
 
     // The input index parameter was out of bounds
-    struct OutOfBoundsIndexException : public std::out_of_range
-    {
-        OutOfBoundsIndexException(size_t r, size_t c) :
-            std::out_of_range((std::string)"Requested index " + util::to_string(r) +
-                              " greater than max " + util::to_string(c)),
-            requested(r), valid_count(c) {}
+    struct OutOfBoundsIndexException : public std::out_of_range {
+        OutOfBoundsIndexException(size_t r, size_t c);
         const size_t requested;
         const size_t valid_count;
     };
@@ -161,8 +155,8 @@ public:
 
     // The input Row object belongs to a different table
     struct IncorrectTableException : public std::runtime_error {
-        IncorrectTableException(StringData e, StringData a, const std::string &error) :
-            std::runtime_error(error), expected(e), actual(a) {}
+        IncorrectTableException(StringData e, StringData a, const std::string &error)
+        : std::runtime_error(error), expected(e), actual(a) {}
         const StringData expected;
         const StringData actual;
     };
@@ -173,7 +167,7 @@ public:
         StringData column_name;
         DataType column_type;
 
-        UnsupportedColumnTypeException(size_t column, const Table* table);
+        UnsupportedColumnTypeException(size_t column, const Table* table, const char* operation);
     };
 
     // Create an async query from this Results
@@ -220,6 +214,7 @@ private:
 
     template<typename Int, typename Float, typename Double, typename Timestamp>
     util::Optional<Mixed> aggregate(size_t column, bool return_none_for_empty,
+                                    const char* name,
                                     Int agg_int, Float agg_float,
                                     Double agg_double, Timestamp agg_timestamp);
 

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -23,6 +23,7 @@
 #include "impl/transact_log_handler.hpp"
 #include "object_store.hpp"
 #include "schema.hpp"
+#include "util/format.hpp"
 
 #include <realm/commit_log.hpp>
 #include <realm/group_shared.hpp>
@@ -75,19 +76,18 @@ REALM_NOINLINE static void translate_file_exception(StringData path, bool read_o
     }
     catch (util::File::PermissionDenied const& ex) {
         throw RealmFileException(RealmFileException::Kind::PermissionDenied, ex.get_path(),
-                                 "Unable to open a realm at path '" + ex.get_path() +
-                                 "'. Please use a path where your app has " + (read_only ? "read" : "read-write") + " permissions.",
+                                 util::format("Unable to open a realm at path '%1'. Please use a path where your app has %2 permissions.",
+                                              ex.get_path(), read_only ? "read" : "read-write"),
                                  ex.what());
     }
     catch (util::File::Exists const& ex) {
         throw RealmFileException(RealmFileException::Kind::Exists, ex.get_path(),
-                                 "File at path '" + ex.get_path() + "' already exists.",
+                                 util::format("File at path '%1' already exists", ex.get_path()),
                                  ex.what());
     }
     catch (util::File::NotFound const& ex) {
         throw RealmFileException(RealmFileException::Kind::NotFound, ex.get_path(),
-                                 "Directory at path '" + ex.get_path() + "' does not exist.",
-                                 ex.what());
+                                 util::format("Directory at path '%1' does not exists", ex.get_path()), ex.what());
     }
     catch (util::File::AccessError const& ex) {
         // Errors for `open()` include the path, but other errors don't. We
@@ -100,13 +100,13 @@ REALM_NOINLINE static void translate_file_exception(StringData path, bool read_o
             underlying.replace(pos - 1, ex.get_path().size() + 2, "");
         }
         throw RealmFileException(RealmFileException::Kind::AccessError, ex.get_path(),
-                                 "Unable to open a realm at path '" + ex.get_path() + "': " + underlying,
-                                 ex.what());
+                                 util::format("Unable to open a realm at path '%1': %2", ex.get_path(), underlying), ex.what());
     }
     catch (IncompatibleLockFile const& ex) {
         throw RealmFileException(RealmFileException::Kind::IncompatibleLockFile, path,
                                  "Realm file is currently open in another process "
-                                 "which cannot share access with this process. All processes sharing a single file must be the same architecture.",
+                                 "which cannot share access with this process. "
+                                 "All processes sharing a single file must be the same architecture.",
                                  ex.what());
     }
     catch (FileFormatUpgradeRequired const& ex) {

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -217,12 +217,12 @@ namespace realm {
 
     class MismatchedConfigException : public std::runtime_error {
     public:
-        MismatchedConfigException(std::string message) : std::runtime_error(message) {}
+        MismatchedConfigException(std::string message) : std::runtime_error(move(message)) {}
     };
 
     class InvalidTransactionException : public std::runtime_error {
     public:
-        InvalidTransactionException(std::string message) : std::runtime_error(message) {}
+        InvalidTransactionException(std::string message) : std::runtime_error(move(message)) {}
     };
 
     class IncorrectThreadException : public std::runtime_error {
@@ -232,7 +232,7 @@ namespace realm {
 
     class UninitializedRealmException : public std::runtime_error {
     public:
-        UninitializedRealmException(std::string message) : std::runtime_error(message) {}
+        UninitializedRealmException(std::string message) : std::runtime_error(move(message)) {}
     };
 
     class InvalidEncryptionKeyException : public std::runtime_error {

--- a/src/util/format.cpp
+++ b/src/util/format.cpp
@@ -1,0 +1,82 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "util/format.hpp"
+
+#include <sstream>
+
+#include <realm/string_data.hpp>
+#include <realm/util/assert.hpp>
+
+namespace realm { namespace _impl {
+Printable::Printable(StringData value) : m_type(Type::String), m_string(value.data()) { }
+
+void Printable::print(std::ostream& out) const
+{
+    switch (m_type) {
+        case Printable::Type::Bool:
+            out << (m_uint ? "true" : "false");
+            break;
+        case Printable::Type::Uint:
+            out << m_uint;
+            break;
+        case Printable::Type::Int:
+            out << m_int;
+            break;
+        case Printable::Type::String:
+            out << m_string;
+            break;
+    }
+}
+
+std::string format(const char* fmt, std::initializer_list<Printable> values)
+{
+    std::stringstream ss;
+    while (*fmt) {
+        auto next = strchr(fmt, '%');
+
+        // emit the rest of the format string if there are no more percents
+        if (!next) {
+            ss << fmt;
+            break;
+        }
+
+        // emit everything up to the next percent
+        ss.write(fmt, next - fmt);
+        ++next;
+        REALM_ASSERT(*next);
+
+        // %% produces a single escaped %
+        if (*next == '%') {
+            ss << '%';
+            fmt = next + 1;
+            continue;
+        }
+        REALM_ASSERT(isdigit(*next));
+
+        // The const_cast is safe because stroul does not actually modify
+        // the pointed-to string, but it lacks a const overload
+        auto index = strtoul(next, const_cast<char**>(&fmt), 10) - 1;
+        REALM_ASSERT(index < values.size());
+        (values.begin() + index)->print(ss);
+    }
+    return ss.str();
+}
+
+} // namespace _impl
+} // namespace realm

--- a/src/util/format.hpp
+++ b/src/util/format.hpp
@@ -1,0 +1,75 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_UTIL_FORMAT_HPP
+#define REALM_UTIL_FORMAT_HPP
+
+#include <cstdint>
+#include <iosfwd>
+#include <initializer_list>
+#include <string>
+
+namespace realm {
+class StringData;
+
+namespace _impl {
+class Printable {
+public:
+    Printable(bool value) : m_type(Type::Bool), m_uint(value) { }
+    Printable(unsigned char value) : m_type(Type::Uint), m_uint(value) { }
+    Printable(unsigned int value) : m_type(Type::Uint), m_uint(value) { }
+    Printable(unsigned long value) : m_type(Type::Uint), m_uint(value) { }
+    Printable(unsigned long long value) : m_type(Type::Uint), m_uint(value) { }
+    Printable(char value) : m_type(Type::Int), m_int(value) { }
+    Printable(int value) : m_type(Type::Int), m_int(value) { }
+    Printable(long value) : m_type(Type::Int), m_int(value) { }
+    Printable(long long value) : m_type(Type::Int), m_int(value) { }
+    Printable(const char* value) : m_type(Type::String), m_string(value) { }
+    Printable(std::string const& value) : m_type(Type::String), m_string(value.c_str()) { }
+    Printable(StringData value);
+
+    void print(std::ostream& out) const;
+
+private:
+    enum class Type {
+        Bool,
+        Int,
+        Uint,
+        String
+    } m_type;
+
+    union {
+        uintmax_t m_uint;
+        intmax_t m_int;
+        const char* m_string;
+    };
+};
+std::string format(const char* fmt, std::initializer_list<Printable>);
+} // namespace _impl
+
+namespace util {
+template<typename... Args>
+std::string format(const char* fmt, Args&&... args)
+{
+    return _impl::format(fmt, {_impl::Printable(args)...});
+}
+
+} // namespace util
+} // namespace realm
+
+#endif // REALM_UTIL_FORMAT_HPP


### PR DESCRIPTION
The main motivation for this is that building error messages via string
concatenation is tedious and makes it hard to judge what the actual message
looks like when there are a lot of parts being inserted, to the extent that
I've been tempted to leave out some potentially useful information because the
code was getting unwieldy.

It also has some small functional benefits: bools are printed as true/false
rather than 1/0, and it is optimized for minimizing the compiled size.
Currently it cuts ~30 KB off librealm-object-store.dylib even with the addition
of new functionality.
