### PR TITLE
Redesign schema handling and add additive-only mode

### DIFF
--- a/src/binding_context.hpp
+++ b/src/binding_context.hpp
@@ -106,19 +106,20 @@ public:
 
     // Change information for a single field of a row
     struct ColumnInfo {
-        // Did this column change?
-        bool changed = false;
-        // For LinkList columns, what kind of change occurred?
-        // Always None for other column types
+        // The index of this column prior to the changes in the tracked
+        // transaction, or -1 for newly inserted columns.
+        size_t initial_column_index = -1;
+        // What kind of change occurred?
+        // Always Set or None for everything but LinkList columns.
         enum class Kind {
             None,   // No change
-            Set,    // The entries at `indices` were assigned to
+            Set,    // The value or entries at `indices` were assigned to
             Insert, // New values were inserted at each of the indices given
             Remove, // Values were removed at each of the indices given
             SetAll  // The entire LinkList has been replaced with a new set of values
         } kind = Kind::None;
-        // The indices where things happened for Set, Insert and Remove
-        // Not used for None and SetAll
+        // The indices where things happened for Set, Insert and Remove on
+        // LinkList columns. Not used for other types or for None or SetAll.
         IndexSet indices;
     };
 

--- a/src/impl/list_notifier.hpp
+++ b/src/impl/list_notifier.hpp
@@ -39,9 +39,6 @@ private:
     // when the LinkView itself is deleted
     size_t m_prev_size;
 
-    // The column index of the LinkView
-    size_t m_col_ndx;
-
     // The actual change, calculated in run() and delivered in prepare_handover()
     CollectionChangeBuilder m_change;
     TransactionChangeInfo* m_info;

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -99,8 +99,6 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
     }
 
     auto realm = std::make_shared<Realm>(std::move(config));
-    realm->init(shared_from_this());
-
     if (!config.read_only() && !m_notifier && config.automatic_change_notifications) {
         try {
             m_notifier = std::make_unique<ExternalCommitHelper>(*this);
@@ -109,6 +107,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
             throw RealmFileException(RealmFileException::Kind::AccessError, config.path, ex.code().message(), "");
         }
     }
+    realm->init(shared_from_this());
 
     m_weak_realm_notifiers.emplace_back(realm, m_config.cache);
     return realm;

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -86,7 +86,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
         // Realm::update_schema() handles complaining about schema mismatches
     }
 
-    if (config.schema_mode > SchemaMode::ResetFile)
+    if (config.schema_mode > SchemaMode::Additive)
         throw "not implemented";
 
     if (config.cache) {

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -86,9 +86,6 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
         // Realm::update_schema() handles complaining about schema mismatches
     }
 
-    if (config.schema_mode > SchemaMode::Additive)
-        throw "not implemented";
-
     if (config.cache) {
         for (auto& cached_realm : m_weak_realm_notifiers) {
             if (cached_realm.is_cached_for_current_thread()) {

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -98,7 +98,9 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
         }
     }
 
-    auto realm = std::make_shared<Realm>(std::move(config), shared_from_this());
+    auto realm = std::make_shared<Realm>(std::move(config));
+    realm->init(shared_from_this());
+
     if (!config.read_only() && !m_notifier && config.automatic_change_notifications) {
         try {
             m_notifier = std::make_unique<ExternalCommitHelper>(*this);
@@ -109,13 +111,6 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
     }
 
     m_weak_realm_notifiers.emplace_back(realm, m_config.cache);
-
-    if (realm->config().schema) {
-        realm->update_schema(std::move(*realm->config().schema),
-                             realm->config().schema_version,
-                             std::move(realm->config().migration_function));
-    }
-
     return realm;
 }
 

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -86,7 +86,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
         // Realm::update_schema() handles complaining about schema mismatches
     }
 
-    if (config.schema_mode > SchemaMode::ReadOnly)
+    if (config.schema_mode > SchemaMode::ResetFile)
         throw "not implemented";
 
     if (config.cache) {

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -50,7 +50,7 @@ public:
     std::shared_ptr<Realm> get_realm();
 
     const Schema* get_schema() const noexcept;
-    uint64_t get_schema_version() const noexcept { return m_config.schema_version; }
+    uint64_t get_schema_version() const noexcept { return m_schema_version; }
     const std::string& get_path() const noexcept { return m_config.path; }
     const std::vector<char>& get_encryption_key() const noexcept { return m_config.encryption_key; }
     bool is_in_memory() const noexcept { return m_config.in_memory; }
@@ -78,8 +78,8 @@ public:
     // Called by m_notifier when there's a new commit to send notifications for
     void on_change();
 
-    // Update the schema in the cached config
-    void update_schema(Schema const& new_schema);
+    // Update the cached schema
+    void update_schema(Schema const& new_schema, uint64_t new_schema_version);
 
     static void register_notifier(std::shared_ptr<CollectionNotifier> notifier);
 
@@ -90,6 +90,8 @@ public:
 
 private:
     Realm::Config m_config;
+    Schema m_schema;
+    uint64_t m_schema_version = -1;
 
     std::mutex m_realm_mutex;
     std::vector<WeakRealmNotifier> m_weak_realm_notifiers;

--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -21,6 +21,7 @@
 #include "binding_context.hpp"
 #include "impl/collection_notifier.hpp"
 #include "index_set.hpp"
+#include "shared_realm.hpp"
 
 #include <realm/group_shared.hpp>
 #include <realm/lang_bind_helper.hpp>
@@ -71,16 +72,21 @@ class TransactLogValidationMixin {
     // the current set of modifications
     bool schema_error_unless_new_table()
     {
-        if (std::find(begin(m_new_tables), end(m_new_tables), m_current_table) == end(m_new_tables)) {
-            schema_error();
+        if (schema_mode == SchemaMode::Additive) {
+            return true;
         }
-        return true;
+        if (std::find(begin(m_new_tables), end(m_new_tables), m_current_table) != end(m_new_tables)) {
+            return true;
+        }
+        schema_error();
     }
 
 protected:
     size_t current_table() const noexcept { return m_current_table; }
 
 public:
+    SchemaMode schema_mode;
+
     // Schema changes which don't involve a change in the schema version are
     // allowed
     bool add_search_index(size_t) { return true; }
@@ -97,11 +103,14 @@ public:
                 ++table;
         }
         m_new_tables.push_back(table_ndx);
+        m_current_table = table_ndx;
         return true;
     }
     bool insert_column(size_t, DataType, StringData, bool) { return schema_error_unless_new_table(); }
     bool insert_link_column(size_t, DataType, StringData, size_t, size_t) { return schema_error_unless_new_table(); }
     bool set_link_type(size_t, LinkType) { return schema_error_unless_new_table(); }
+    bool move_column(size_t, size_t) { return schema_error_unless_new_table(); }
+    bool move_group_level_table(size_t, size_t) { return schema_error_unless_new_table(); }
 
     // Removing or renaming things while a Realm is open is never supported
     bool erase_group_level_table(size_t, size_t) { schema_error(); }
@@ -109,8 +118,6 @@ public:
     bool erase_column(size_t) { schema_error(); }
     bool erase_link_column(size_t, size_t, size_t) { schema_error(); }
     bool rename_column(size_t, StringData) { schema_error(); }
-    bool move_column(size_t, size_t) { schema_error(); }
-    bool move_group_level_table(size_t, size_t) { schema_error(); }
 
     bool select_descriptor(int levels, const size_t*)
     {
@@ -147,8 +154,44 @@ public:
 // A transaction log handler that just validates that all operations made are
 // ones supported by the object store
 struct TransactLogValidator : public TransactLogValidationMixin, public MarkDirtyMixin<TransactLogValidator> {
+    TransactLogValidator(SchemaMode schema_mode) { this->schema_mode = schema_mode; }
     void mark_dirty(size_t, size_t) { }
 };
+
+// Move the value at container[from] to container[to], shifting everything in
+// between, or do nothing if either are out of bounds
+template<typename Container>
+void rotate(Container& container, size_t from, size_t to)
+{
+    REALM_ASSERT(from != to);
+    if (from >= container.size() && to >= container.size())
+        return;
+    if (from >= container.size() || to >= container.size())
+        container.resize(std::max(from, to) + 1);
+    if (from < to)
+        std::rotate(begin(container) + from, begin(container) + to, begin(container) + to + 1);
+    else
+        std::rotate(begin(container) + to, begin(container) + from, begin(container) + from + 1);
+}
+
+// Insert a default-initialized value at pos if there is anything after pos in the container.
+template<typename Container>
+void insert_empty_at(Container& container, size_t pos)
+{
+    if (pos < container.size())
+        container.insert(container.begin() + pos, typename Container::value_type{});
+}
+
+// Shift `value` to reflect a move from `from` to `to`
+void adjust_for_move(size_t& value, size_t from, size_t to)
+{
+    if (value == from)
+        value = to;
+    else if (value > from && value < to)
+        --value;
+    else if (value < from && value > to)
+        ++value;
+}
 
 // Extends TransactLogValidator to also track changes and report it to the
 // binding context if any properties are being observed
@@ -166,28 +209,22 @@ class TransactLogObserver : public TransactLogValidationMixin, public MarkDirtyM
     // Change information for the currently selected LinkList, if any
     ColumnInfo* m_active_linklist = nullptr;
 
-    // Tables which were created during the transaction being processed, which
-    // can have columns inserted without a schema version bump
-    std::vector<size_t> m_new_tables;
-
     // Get the change info for the given column, creating it if needed
     static ColumnInfo& get_change(ObserverState& state, size_t i)
     {
-        if (state.changes.size() <= i) {
-            state.changes.resize(std::max(state.changes.size() * 2, i + 1));
-        }
+        expand_to(state, i);
         return state.changes[i];
     }
 
-    // Loop over the columns which were changed in an observer state
-    template<typename Func>
-    static void for_each(ObserverState& state, Func&& f)
+    static void expand_to(ObserverState& state, size_t i)
     {
-        for (size_t i = 0; i < state.changes.size(); ++i) {
-            auto const& change = state.changes[i];
-            if (change.changed) {
-                f(i, change);
-            }
+        auto old_size = state.changes.size();
+        if (old_size <= i) {
+            auto new_size = std::max(state.changes.size() * 2, i + 1);
+            state.changes.resize(new_size);
+            size_t base = old_size == 0 ? 0 : state.changes[old_size - 1].initial_column_index + 1;
+            for (size_t i = old_size; i < new_size; ++i)
+                state.changes[i].initial_column_index = i - old_size + base;
         }
     }
 
@@ -201,29 +238,21 @@ class TransactLogObserver : public TransactLogValidationMixin, public MarkDirtyM
 
 public:
     template<typename Func>
-    TransactLogObserver(BindingContext* context, SharedGroup& sg, Func&& func, bool validate_schema_changes)
+    TransactLogObserver(BindingContext* context, SharedGroup& sg, Func&& func, util::Optional<SchemaMode> schema_mode)
     : m_context(context)
     {
-        if (!context) {
-            if (validate_schema_changes) {
-                func(TransactLogValidator());
-            }
-            else {
-                func();
-            }
-            return;
+        auto old_version = sg.get_version_of_current_transaction();
+        if (context) {
+            m_observers = context->get_observed_rows();
         }
-
-        m_observers = context->get_observed_rows();
         if (m_observers.empty()) {
-            auto old_version = sg.get_version_of_current_transaction();
-            if (validate_schema_changes) {
-                func(TransactLogValidator());
+            if (schema_mode) {
+                func(TransactLogValidator(*schema_mode));
             }
             else {
                 func();
             }
-            if (old_version != sg.get_version_of_current_transaction()) {
+            if (context && old_version != sg.get_version_of_current_transaction()) {
                 context->did_change({}, {});
             }
             return;
@@ -238,7 +267,7 @@ public:
     {
         auto it = lower_bound(begin(m_observers), end(m_observers), ObserverState{current_table(), row_ndx, nullptr});
         if (it != end(m_observers) && it->table_ndx == current_table() && it->row_ndx == row_ndx) {
-            get_change(*it, col_ndx).changed = true;
+            get_change(*it, col_ndx).kind = ColumnInfo::Kind::Set;
         }
     }
 
@@ -259,9 +288,14 @@ public:
         return true;
     }
 
-    bool insert_empty_rows(size_t, size_t, size_t, bool)
+    bool insert_empty_rows(size_t row_ndx, size_t num_rows, size_t prior_size, bool)
     {
-        // rows are only inserted at the end, so no need to do anything
+        if (row_ndx != prior_size) {
+            for (auto& observer : m_observers) {
+                if (observer.row_ndx >= row_ndx)
+                    observer.row_ndx += num_rows;
+            }
+        }
         return true;
     }
 
@@ -320,7 +354,6 @@ public:
 
         if (o->kind == ColumnInfo::Kind::None) {
             o->kind = kind;
-            o->changed = true;
             o->indices.add(index);
         }
         else if (o->kind == kind) {
@@ -388,7 +421,6 @@ public:
         o->indices.set(old_size);
 
         o->kind = ColumnInfo::Kind::Remove;
-        o->changed = true;
         return true;
     }
 
@@ -404,7 +436,6 @@ public:
 
         if (o->kind == ColumnInfo::Kind::None) {
             o->kind = ColumnInfo::Kind::Set;
-            o->changed = true;
         }
         if (o->kind == ColumnInfo::Kind::Set) {
             for (size_t i = from; i <= to; ++i)
@@ -416,6 +447,39 @@ public:
         }
         return true;
     }
+
+    bool insert_column(size_t ndx, DataType, StringData, bool)
+    {
+        for (auto& observer : m_observers) {
+            if (observer.table_ndx == current_table()) {
+                expand_to(observer, ndx);
+                insert_empty_at(observer.changes, ndx);
+            }
+        }
+        return true;
+    }
+
+    bool move_column(size_t from, size_t to)
+    {
+        for (auto& observer : m_observers) {
+            if (observer.table_ndx == current_table()) {
+                // have to initialize the columns one past the moved one so that
+                // we can later initialize any more columns after that
+                expand_to(observer, std::max(from, to) + 1);
+                rotate(observer.changes, from, to);
+            }
+        }
+        return true;
+    }
+
+    bool move_group_level_table(size_t from, size_t to)
+    {
+        for (auto& observer : m_observers)
+            adjust_for_move(observer.table_ndx, from, to);
+        return true;
+    }
+
+    bool insert_link_column(size_t ndx, DataType type, StringData name, size_t, size_t) { return insert_column(ndx, type, name, false); }
 };
 
 // Extends TransactLogValidator to track changes made to LinkViews
@@ -566,24 +630,71 @@ public:
             change->clear(std::numeric_limits<size_t>::max());
         return true;
     }
+
+    bool insert_column(size_t ndx, DataType, StringData, bool)
+    {
+        for (auto& list : m_info.lists) {
+            if (list.table_ndx == current_table() && list.col_ndx >= ndx)
+                ++list.col_ndx;
+        }
+        return true;
+    }
+
+    bool insert_group_level_table(size_t ndx, size_t, StringData)
+    {
+        for (auto& list : m_info.lists) {
+            if (list.table_ndx >= ndx)
+                ++list.table_ndx;
+        }
+        insert_empty_at(m_info.tables, ndx);
+        insert_empty_at(m_info.table_moves_needed, ndx);
+        insert_empty_at(m_info.table_modifications_needed, ndx);
+        return true;
+    }
+
+    bool move_column(size_t from, size_t to)
+    {
+        for (auto& list : m_info.lists) {
+            if (list.table_ndx == current_table())
+                adjust_for_move(list.col_ndx, from, to);
+        }
+        return true;
+    }
+
+    bool move_group_level_table(size_t from, size_t to)
+    {
+        for (auto& list : m_info.lists)
+            adjust_for_move(list.table_ndx, from, to);
+        rotate(m_info.tables, from, to);
+        rotate(m_info.table_modifications_needed, from, to);
+        rotate(m_info.table_moves_needed, from, to);
+        return true;
+    }
+
+    bool insert_link_column(size_t ndx, DataType type, StringData name, size_t, size_t) { return insert_column(ndx, type, name, false); }
 };
 } // anonymous namespace
 
 namespace realm {
 namespace _impl {
 namespace transaction {
-void advance(SharedGroup& sg, BindingContext* context, SharedGroup::VersionID version)
+void advance(SharedGroup& sg, BindingContext* context, SchemaMode schema_mode, SharedGroup::VersionID version)
 {
     TransactLogObserver(context, sg, [&](auto&&... args) {
         LangBindHelper::advance_read(sg, std::move(args)..., version);
-    }, true);
+    }, schema_mode);
 }
 
-void begin(SharedGroup& sg, BindingContext* context, bool validate_schema_changes)
+void begin_without_validation(SharedGroup& sg)
+{
+    LangBindHelper::promote_to_write(sg);
+}
+
+void begin(SharedGroup& sg, BindingContext* context, SchemaMode schema_mode)
 {
     TransactLogObserver(context, sg, [&](auto&&... args) {
         LangBindHelper::promote_to_write(sg, std::move(args)...);
-    }, validate_schema_changes);
+    }, schema_mode);
 }
 
 void commit(SharedGroup& sg, BindingContext* context)
@@ -599,7 +710,7 @@ void cancel(SharedGroup& sg, BindingContext* context)
 {
     TransactLogObserver(context, sg, [&](auto&&... args) {
         LangBindHelper::rollback_and_continue_as_read(sg, std::move(args)...);
-    }, false);
+    }, util::none);
 }
 
 void advance(SharedGroup& sg,

--- a/src/impl/transact_log_handler.hpp
+++ b/src/impl/transact_log_handler.hpp
@@ -23,6 +23,7 @@
 
 namespace realm {
 class BindingContext;
+enum class SchemaMode : uint8_t;
 
 namespace _impl {
 struct TransactionChangeInfo;
@@ -31,13 +32,14 @@ namespace transaction {
 // Advance the read transaction version, with change notifications sent to delegate
 // Must not be called from within a write transaction.
 void advance(SharedGroup& sg, BindingContext* binding_context,
+             SchemaMode schema_mode,
              SharedGroup::VersionID version=SharedGroup::VersionID{});
 
 // Begin a write transaction
 // If the read transaction version is not up to date, will first advance to the
 // most recent read transaction and sent notifications to delegate
-void begin(SharedGroup& sg, BindingContext* binding_context,
-           bool validate_schema_changes=true);
+void begin(SharedGroup& sg, BindingContext* binding_context, SchemaMode schema_mode);
+void begin_without_validation(SharedGroup& sg);
 
 // Commit a write transaction
 void commit(SharedGroup& sg, BindingContext* binding_context);

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -51,8 +51,8 @@ const ObjectSchema& List::get_object_schema() const
 
     if (!m_object_schema) {
         auto object_type = ObjectStore::object_type_for_table_name(m_link_view->get_target_table().get_name());
-        auto it = m_realm->config().schema->find(object_type);
-        REALM_ASSERT(it != m_realm->config().schema->end());
+        auto it = m_realm->schema().find(object_type);
+        REALM_ASSERT(it != m_realm->schema().end());
         m_object_schema = &*it;
     }
     return *m_object_schema;

--- a/src/object_accessor.hpp
+++ b/src/object_accessor.hpp
@@ -283,16 +283,15 @@ namespace realm {
             case PropertyType::Date:
                 return Accessor::from_timestamp(ctx, m_row.get_timestamp(column));
             case PropertyType::Object: {
-                auto linkObjectSchema = m_realm->config().schema->find(property.object_type);
+                auto linkObjectSchema = m_realm->schema().find(property.object_type);
                 TableRef table = ObjectStore::table_for_object_type(m_realm->read_group(), linkObjectSchema->name);
                 if (m_row.is_null_link(property.table_column)) {
                     return Accessor::null_value(ctx);
                 }
                 return Accessor::from_object(ctx, std::move(Object(m_realm, *linkObjectSchema, table->get(m_row.get_link(column)))));
             }
-            case PropertyType::Array: {
-                return Accessor::from_list(ctx, std::move(List(m_realm, static_cast<LinkViewRef>(m_row.get_linklist(column)))));
-            }
+            case PropertyType::Array:
+                return Accessor::from_list(ctx, List(m_realm, static_cast<LinkViewRef>(m_row.get_linklist(column))));
             case PropertyType::LinkingObjects: {
                 auto target_object_schema = m_realm->config().schema->find(property.object_type);
                 auto link_property = target_object_schema->property_for_name(property.link_origin_property_name);
@@ -332,8 +331,7 @@ namespace realm {
             }
 
             if (!try_update && row_index != realm::not_found) {
-                throw DuplicatePrimaryKeyValueException(object_schema.name, *primary_prop,
-                    "Attempting to create an object of type '" + object_schema.name + "' with an exising primary key value.");
+                throw std::logic_error("Attempting to create an object of type '" + object_schema.name + "' with an existing primary key value.");
             }
         }
 

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -20,6 +20,9 @@
 
 #include "object_store.hpp"
 #include "property.hpp"
+#include "schema.hpp"
+
+#include "util/format.hpp"
 
 #include <realm/data_type.hpp>
 #include <realm/table.hpp>
@@ -43,15 +46,18 @@ ASSERT_PROPERTY_TYPE_VALUE(Array, LinkList);
 ObjectSchema::ObjectSchema() = default;
 ObjectSchema::~ObjectSchema() = default;
 
-ObjectSchema::ObjectSchema(std::string name, std::string primary_key, std::initializer_list<Property> persisted_properties)
+ObjectSchema::ObjectSchema(std::string name, std::initializer_list<Property> persisted_properties)
 : name(std::move(name))
 , persisted_properties(persisted_properties)
-, primary_key(std::move(primary_key))
 {
-    set_primary_key_property();
+    for (auto const& prop : persisted_properties) {
+        if (prop.is_primary) {
+            primary_key = prop.name;
+        }
+    }
 }
 
-ObjectSchema::ObjectSchema(const Group *group, const std::string &name) : name(name) {
+ObjectSchema::ObjectSchema(Group const& group, const std::string &name) : name(name) {
     ConstTableRef table = ObjectStore::table_for_object_type(group, name);
 
     size_t count = table->get_column_count();
@@ -61,7 +67,6 @@ ObjectSchema::ObjectSchema(const Group *group, const std::string &name) : name(n
         property.name = table->get_column_name(col).data();
         property.type = (PropertyType)table->get_column_type(col);
         property.is_indexed = table->has_search_index(col);
-        property.is_primary = false;
         property.is_nullable = table->is_nullable(col) || property.type == PropertyType::Object;
         property.table_column = col;
         if (property.type == PropertyType::Object || property.type == PropertyType::Array) {
@@ -97,10 +102,114 @@ const Property *ObjectSchema::property_for_name(StringData name) const {
 void ObjectSchema::set_primary_key_property()
 {
     if (primary_key.length()) {
-        auto primary_key_prop = primary_key_property();
-        if (!primary_key_prop) {
-            throw InvalidPrimaryKeyException(name, primary_key);
+        if (auto primary_key_prop = primary_key_property()) {
+            primary_key_prop->is_primary = true;
         }
-        primary_key_prop->is_primary = true;
     }
+}
+
+static void validate_property(Schema const& schema,
+                              std::string const& object_name,
+                              Property const& prop,
+                              Property const** primary,
+                              std::vector<ObjectSchemaValidationException>& exceptions)
+{
+    // check nullablity
+    if (prop.is_nullable && !prop.type_is_nullable()) {
+        exceptions.emplace_back("Property '%1.%2' of type '%3' cannot be nullable.",
+                                object_name, prop.name, string_for_property_type(prop.type));
+    }
+    else if (prop.type == PropertyType::Object && !prop.is_nullable) {
+        exceptions.emplace_back("Property '%1.%2' of type 'Object' must be nullable.", object_name, prop.name);
+    }
+
+    // check primary keys
+    if (prop.is_primary) {
+        if (!prop.is_indexable()) {
+            exceptions.emplace_back("Property '%1.%2' of type '%3' cannot be made the primary key.",
+                                    object_name, prop.name, string_for_property_type(prop.type));
+        }
+        if (*primary) {
+            exceptions.emplace_back("Properties'%1' and '%2' are both marked as the primary key of '%3'.",
+                                    prop.name, (*primary)->name, object_name);
+        }
+        *primary = &prop;
+    }
+
+    // check indexable
+    if (prop.is_indexed && !prop.is_indexable()) {
+        exceptions.emplace_back("Property '%1.%2' of type '%3' cannot be indexed.",
+                                object_name, prop.name, string_for_property_type(prop.type));
+    }
+
+    // check that only link properties have object types
+    if (prop.type != PropertyType::LinkingObjects && !prop.link_origin_property_name.empty()) {
+        exceptions.emplace_back("Property '%1.%2' of type '%3' cannot have an origin property name.",
+                                object_name, prop.name, string_for_property_type(prop.type));
+    }
+    else if (prop.type == PropertyType::LinkingObjects && prop.link_origin_property_name.empty()) {
+        exceptions.emplace_back("Property '%1.%2' of type '%3' must have an origin property name.",
+                                object_name, prop.name, string_for_property_type(prop.type));
+    }
+
+    if (prop.type != PropertyType::Object && prop.type != PropertyType::Array && prop.type != PropertyType::LinkingObjects) {
+        if (!prop.object_type.empty()) {
+            exceptions.emplace_back("Property '%1.%2' of type '%3' cannot have an object type.",
+                                    object_name, prop.name, string_for_property_type(prop.type));
+        }
+        return;
+    }
+
+
+    // check that the object_type is valid for link properties
+    auto it = schema.find(prop.object_type);
+    if (it == schema.end()) {
+        exceptions.emplace_back("Property '%1.%2' of type '%3' has unknown object type '%4'",
+                                object_name, prop.name, string_for_property_type(prop.type), prop.object_type);
+        return;
+    }
+    if (prop.type != PropertyType::LinkingObjects) {
+        return;
+    }
+
+    const Property *origin_property = it->property_for_name(prop.link_origin_property_name);
+    if (!origin_property) {
+        exceptions.emplace_back("Property '%1.%2' declared as origin of linking objects property '%3.%4' does not exist",
+                                prop.object_type, prop.link_origin_property_name,
+                                object_name, prop.name);
+    }
+    else if (origin_property->type != PropertyType::Object && origin_property->type != PropertyType::Array) {
+        exceptions.emplace_back("Property '%1.%2' declared as origin of linking objects property '%3.%4' is not a link",
+                                prop.object_type, prop.link_origin_property_name,
+                                object_name, prop.name);
+    }
+    else if (origin_property->object_type != object_name) {
+        exceptions.emplace_back("Property '%1.%2' declared as origin of linking objects property '%3.%4' links to type '%5'",
+                                prop.object_type, prop.link_origin_property_name,
+                                object_name, prop.name, origin_property->object_type);
+    }
+}
+
+void ObjectSchema::validate(Schema const& schema, std::vector<ObjectSchemaValidationException>& exceptions) const
+{
+    const Property *primary = nullptr;
+    for (auto const& prop : persisted_properties) {
+        validate_property(schema, name, prop, &primary, exceptions);
+    }
+    for (auto const& prop : computed_properties) {
+        validate_property(schema, name, prop, &primary, exceptions);
+    }
+
+    if (!primary_key.empty() && !primary && !primary_key_property()) {
+        exceptions.emplace_back("Specified primary key '%1.%2' does not exist.", name, primary_key);
+    }
+}
+
+namespace realm {
+bool operator==(ObjectSchema const& a, ObjectSchema const& b)
+{
+    return std::tie(a.name, a.primary_key, a.persisted_properties, a.computed_properties)
+        == std::tie(b.name, b.primary_key, b.persisted_properties, b.computed_properties);
+
+}
 }

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -25,6 +25,7 @@
 #include "util/format.hpp"
 
 #include <realm/data_type.hpp>
+#include <realm/group.hpp>
 #include <realm/table.hpp>
 
 using namespace realm;
@@ -57,8 +58,14 @@ ObjectSchema::ObjectSchema(std::string name, std::initializer_list<Property> per
     }
 }
 
-ObjectSchema::ObjectSchema(Group const& group, const std::string &name) : name(name) {
-    ConstTableRef table = ObjectStore::table_for_object_type(group, name);
+ObjectSchema::ObjectSchema(Group const& group, StringData name, size_t index) : name(name) {
+    ConstTableRef table;
+    if (index < group.size()) {
+        table = group.get_table(index);
+    }
+    else {
+        table = ObjectStore::table_for_object_type(group, name);
+    }
 
     size_t count = table->get_column_count();
     persisted_properties.reserve(count);

--- a/src/object_schema.hpp
+++ b/src/object_schema.hpp
@@ -38,7 +38,7 @@ public:
 
     // create object schema from existing table
     // if no table is provided it is looked up in the group
-    ObjectSchema(Group const& group, const std::string &name);
+    ObjectSchema(Group const& group, StringData name, size_t index=-1);
 
     std::string name;
     std::vector<Property> persisted_properties;

--- a/src/object_schema.hpp
+++ b/src/object_schema.hpp
@@ -26,17 +26,19 @@
 
 namespace realm {
 class Group;
+class Schema;
+struct ObjectSchemaValidationException;
 struct Property;
 
 class ObjectSchema {
 public:
     ObjectSchema();
-    ObjectSchema(std::string name, std::string primary_key, std::initializer_list<Property> persisted_properties);
+    ObjectSchema(std::string name, std::initializer_list<Property> persisted_properties);
     ~ObjectSchema();
 
     // create object schema from existing table
     // if no table is provided it is looked up in the group
-    ObjectSchema(const Group *group, const std::string &name);
+    ObjectSchema(Group const& group, const std::string &name);
 
     std::string name;
     std::vector<Property> persisted_properties;
@@ -51,6 +53,10 @@ public:
     const Property *primary_key_property() const {
         return property_for_name(primary_key);
     }
+
+    void validate(Schema const& schema, std::vector<ObjectSchemaValidationException>& exceptions) const;
+
+    friend bool operator==(ObjectSchema const& a, ObjectSchema const& b);
 
 private:
     void set_primary_key_property();

--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -77,6 +77,19 @@ auto table_for_object_schema(Group& group, ObjectSchema const& object_schema)
     return ObjectStore::table_for_object_type(group, object_schema.name);
 }
 
+void add_index(Table& table, size_t col)
+{
+    try {
+        table.add_search_index(col);
+    }
+    catch (LogicError const&) {
+        throw std::logic_error(util::format("Cannot index property '%1.%2': indexing properties of type '%3' is not yet implemented.",
+                                            ObjectStore::object_type_for_table_name(table.get_name()),
+                                            table.get_column_name(col),
+                                            string_for_property_type((PropertyType)table.get_column_type(col))));
+    }
+}
+
 void insert_column(Group& group, Table& table, Property const& property, size_t col_ndx)
 {
     if (property.type == PropertyType::Object || property.type == PropertyType::Array) {
@@ -87,7 +100,7 @@ void insert_column(Group& group, Table& table, Property const& property, size_t 
     else {
         table.insert_column(col_ndx, DataType(property.type), property.name, property.is_nullable);
         if (property.requires_index())
-            table.add_search_index(col_ndx);
+            add_index(table, col_ndx);
     }
 }
 
@@ -184,19 +197,6 @@ void validate_primary_column_uniqueness(Group const& group)
         validate_primary_column_uniqueness(group,
                                            pk_table->get_string(c_primaryKeyObjectClassColumnIndex, i),
                                            pk_table->get_string(c_primaryKeyPropertyNameColumnIndex, i));
-    }
-}
-
-void add_index(Table& table, size_t col)
-{
-    try {
-        table.add_search_index(col);
-    }
-    catch (LogicError const&) {
-        throw std::logic_error(util::format("Cannot index property '%1.%2': indexing properties of type '%3' is not yet implemented.",
-                                            ObjectStore::object_type_for_table_name(table.get_name()),
-                                            table.get_column_name(col),
-                                            string_for_property_type((PropertyType)table.get_column_type(col))));
     }
 }
 } // anonymous namespace

--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -653,10 +653,11 @@ void ObjectStore::apply_schema_changes(Group& group, Schema& schema, uint64_t& s
 
 Schema ObjectStore::schema_from_group(Group const& group) {
     std::vector<ObjectSchema> schema;
+    schema.reserve(group.size());
     for (size_t i = 0; i < group.size(); i++) {
-        std::string object_type = object_type_for_table_name(group.get_table_name(i));
-        if (object_type.length()) {
-            schema.emplace_back(group, object_type);
+        auto object_type = object_type_for_table_name(group.get_table_name(i));
+        if (object_type.size()) {
+            schema.emplace_back(group, object_type, i);
         }
     }
     return schema;

--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -31,6 +31,8 @@
 
 using namespace realm;
 
+const uint64_t ObjectStore::NotVersioned = std::numeric_limits<uint64_t>::max();
+
 namespace {
 const char * const c_metadataTableName = "metadata";
 const char * const c_versionColumnName = "version";
@@ -45,22 +47,15 @@ const size_t c_primaryKeyPropertyNameColumnIndex =  1;
 const size_t c_zeroRowIndex = 0;
 
 const char c_object_table_prefix[] = "class_";
-}
 
-const uint64_t ObjectStore::NotVersioned = std::numeric_limits<uint64_t>::max();
-
-bool ObjectStore::has_metadata_tables(const Group *group) {
-    return group->get_table(c_primaryKeyTableName) && group->get_table(c_metadataTableName);
-}
-
-void ObjectStore::create_metadata_tables(Group *group) {
-    TableRef table = group->get_or_add_table(c_primaryKeyTableName);
+void create_metadata_tables(Group& group) {
+    TableRef table = group.get_or_add_table(c_primaryKeyTableName);
     if (table->get_column_count() == 0) {
         table->add_column(type_String, c_primaryKeyObjectClassColumnName);
         table->add_column(type_String, c_primaryKeyPropertyNameColumnName);
     }
 
-    table = group->get_or_add_table(c_metadataTableName);
+    table = group.get_or_add_table(c_metadataTableName);
     if (table->get_column_count() == 0) {
         table->add_column(type_Int, c_versionColumnName);
 
@@ -70,33 +65,13 @@ void ObjectStore::create_metadata_tables(Group *group) {
     }
 }
 
-uint64_t ObjectStore::get_schema_version(const Group *group) {
-    ConstTableRef table = group->get_table(c_metadataTableName);
-    if (!table || table->get_column_count() == 0) {
-        return ObjectStore::NotVersioned;
-    }
-    return table->get_int(c_versionColumnIndex, c_zeroRowIndex);
-}
-
-void ObjectStore::set_schema_version(Group *group, uint64_t version) {
-    TableRef table = group->get_or_add_table(c_metadataTableName);
+void set_schema_version(Group& group, uint64_t version) {
+    TableRef table = group.get_or_add_table(c_metadataTableName);
     table->set_int(c_versionColumnIndex, c_zeroRowIndex, version);
 }
 
-StringData ObjectStore::get_primary_key_for_object(const Group *group, StringData object_type) {
-    ConstTableRef table = group->get_table(c_primaryKeyTableName);
-    if (!table) {
-        return "";
-    }
-    size_t row = table->find_first_string(c_primaryKeyObjectClassColumnIndex, object_type);
-    if (row == not_found) {
-        return "";
-    }
-    return table->get_string(c_primaryKeyPropertyNameColumnIndex, row);
-}
-
-void ObjectStore::set_primary_key_for_object(Group *group, StringData object_type, StringData primary_key) {
-    TableRef table = group->get_table(c_primaryKeyTableName);
+void set_primary_key_for_object(Group& group, StringData object_type, StringData primary_key) {
+    TableRef table = group.get_table(c_primaryKeyTableName);
 
     // get row or create if new object and populate
     size_t row = table->find_first_string(c_primaryKeyObjectClassColumnIndex, object_type);
@@ -116,6 +91,143 @@ void ObjectStore::set_primary_key_for_object(Group *group, StringData object_typ
     }
 }
 
+template<typename Group>
+auto table_for_object_schema(Group& group, ObjectSchema const& object_schema)
+{
+    return ObjectStore::table_for_object_type(group, object_schema.name);
+}
+
+void insert_column(Group& group, Table& table, Property const& property, size_t col_ndx)
+{
+    if (property.type == PropertyType::Object || property.type == PropertyType::Array) {
+        auto target_name = ObjectStore::table_name_for_object_type(property.object_type);
+        TableRef link_table = group.get_or_add_table(target_name);
+        table.insert_column_link(col_ndx, DataType(property.type), property.name, *link_table);
+    }
+    else {
+        table.insert_column(col_ndx, DataType(property.type), property.name, property.is_nullable);
+        if (property.requires_index())
+            table.add_search_index(col_ndx);
+    }
+}
+
+void add_column(Group& group, Table& table, Property const& property)
+{
+    insert_column(group, table, property, table.get_column_count());
+}
+
+void replace_column(Group& group, Table& table, Property const& old_property, Property const& new_property)
+{
+    insert_column(group, table, new_property, old_property.table_column);
+    table.remove_column(old_property.table_column + 1);
+}
+
+TableRef create_table(Group& group, ObjectSchema const& object_schema)
+{
+    auto name = ObjectStore::table_name_for_object_type(object_schema.name);
+    auto table = group.get_or_add_table(name);
+    if (table->get_column_count() > 0) {
+        return table;
+    }
+
+    for (auto const& prop : object_schema.persisted_properties) {
+        add_column(group, *table, prop);
+    }
+
+    set_primary_key_for_object(group, object_schema.name, object_schema.primary_key);
+
+    return table;
+}
+
+void copy_property_values(Property const& prop, Table& table)
+{
+    auto copy_property_values = [&](auto getter, auto setter) {
+        for (size_t i = 0, count = table.size(); i < count; i++) {
+            (table.*setter)(prop.table_column, i, (table.*getter)(prop.table_column + 1, i));
+        }
+    };
+
+    switch (prop.type) {
+        case PropertyType::Int:
+            copy_property_values(&Table::get_int, &Table::set_int);
+            break;
+        case PropertyType::Bool:
+            copy_property_values(&Table::get_bool, &Table::set_bool);
+            break;
+        case PropertyType::Float:
+            copy_property_values(&Table::get_float, &Table::set_float);
+            break;
+        case PropertyType::Double:
+            copy_property_values(&Table::get_double, &Table::set_double);
+            break;
+        case PropertyType::String:
+            copy_property_values(&Table::get_string, &Table::set_string);
+            break;
+        case PropertyType::Data:
+            copy_property_values(&Table::get_binary, &Table::set_binary);
+            break;
+        case PropertyType::Date:
+            copy_property_values(&Table::get_timestamp, &Table::set_timestamp);
+            break;
+        default:
+            break;
+    }
+}
+
+void make_property_optional(Group& group, Table& table, Property property)
+{
+    property.is_nullable = true;
+    insert_column(group, table, property, property.table_column);
+    copy_property_values(property, table);
+    table.remove_column(property.table_column + 1);
+}
+
+void make_property_required(Group& group, Table& table, Property property)
+{
+    property.is_nullable = false;
+    insert_column(group, table, property, property.table_column);
+    table.remove_column(property.table_column + 1);
+}
+
+void validate_primary_column_uniqueness(Group const& group, StringData object_type, StringData primary_property)
+{
+    auto table = ObjectStore::table_for_object_type(group, object_type);
+    if (table->get_distinct_view(table->get_column_index(primary_property)).size() != table->size()) {
+        throw DuplicatePrimaryKeyValueException(object_type, primary_property);
+    }
+}
+
+void validate_primary_column_uniqueness(Group const& group)
+{
+    auto pk_table = group.get_table(c_primaryKeyTableName);
+    for (size_t i = 0, count = pk_table->size(); i < count; ++i) {
+        validate_primary_column_uniqueness(group,
+                                           pk_table->get_string(c_primaryKeyObjectClassColumnIndex, i),
+                                           pk_table->get_string(c_primaryKeyPropertyNameColumnIndex, i));
+    }
+}
+} // anonymous namespace
+
+uint64_t ObjectStore::get_schema_version(Group const& group) {
+    ConstTableRef table = group.get_table(c_metadataTableName);
+    if (!table || table->get_column_count() == 0) {
+        return ObjectStore::NotVersioned;
+    }
+    return table->get_int(c_versionColumnIndex, c_zeroRowIndex);
+}
+
+StringData ObjectStore::get_primary_key_for_object(Group const& group, StringData object_type) {
+    ConstTableRef table = group.get_table(c_primaryKeyTableName);
+    if (!table) {
+        return "";
+    }
+    size_t row = table->find_first_string(c_primaryKeyObjectClassColumnIndex, object_type);
+    if (row == not_found) {
+        return "";
+    }
+    return table->get_string(c_primaryKeyPropertyNameColumnIndex, row);
+}
+
 StringData ObjectStore::object_type_for_table_name(StringData table_name) {
     if (table_name.begins_with(c_object_table_prefix)) {
         return table_name.substr(sizeof(c_object_table_prefix) - 1);
@@ -124,314 +236,305 @@ StringData ObjectStore::object_type_for_table_name(StringData table_name) {
 }
 
 std::string ObjectStore::table_name_for_object_type(StringData object_type) {
-    return std::string(c_object_table_prefix) + static_cast<std::string>(object_type);
+    return std::string(c_object_table_prefix) + object_type.data();
 }
 
-TableRef ObjectStore::table_for_object_type(Group *group, StringData object_type) {
+TableRef ObjectStore::table_for_object_type(Group& group, StringData object_type) {
     auto name = table_name_for_object_type(object_type);
-    return group->get_table(name);
+    return group.get_table(name);
 }
 
-ConstTableRef ObjectStore::table_for_object_type(const Group *group, StringData object_type) {
+ConstTableRef ObjectStore::table_for_object_type(Group const& group, StringData object_type) {
     auto name = table_name_for_object_type(object_type);
-    return group->get_table(name);
+    return group.get_table(name);
 }
 
-TableRef ObjectStore::table_for_object_type_create_if_needed(Group *group, StringData object_type, bool &created) {
-    auto name = table_name_for_object_type(object_type);
-    return group->get_or_add_table(name, &created);
-}
-
-static inline bool property_has_changed(Property const& p1, Property const& p2) {
-    return p1.type != p2.type
-        || p1.name != p2.name
-        || p1.object_type != p2.object_type
-        || p1.is_nullable != p2.is_nullable;
-}
-
-static inline bool property_can_be_migrated_to_nullable(const Property& old_property, const Property& new_property) {
-    return old_property.type == new_property.type
-        && !old_property.is_nullable
-        && new_property.is_nullable
-        && new_property.name == old_property.name;
-}
-
-void ObjectStore::verify_schema(Schema const& actual_schema, Schema& target_schema, bool allow_missing_tables) {
+namespace {
+struct MigrationChecker {
     std::vector<ObjectSchemaValidationException> errors;
-    for (auto &object_schema : target_schema) {
-        auto matching_schema = actual_schema.find(object_schema);
-        if (matching_schema == actual_schema.end()) {
-            if (!allow_missing_tables) {
-                errors.emplace_back(object_schema.name,
-                                    util::format("Missing table for object type '%1'.", object_schema.name));
-            }
-            continue;
-        }
 
-        auto more_errors = verify_object_schema(*matching_schema, object_schema);
-        errors.insert(errors.end(), more_errors.begin(), more_errors.end());
+    void operator()(schema_change::AddTable) { }
+
+    void operator()(schema_change::AddProperty op)
+    {
+        errors.emplace_back("Property '%1.%2' has been added.", op.object->name, op.property->name);
     }
-    if (errors.size()) {
-        throw SchemaMismatchException(errors);
+
+    void operator()(schema_change::RemoveProperty op)
+    {
+        errors.emplace_back("Property '%1.%2' has been removed.", op.object->name, op.property->name);
+    }
+
+    void operator()(schema_change::ChangePropertyType op)
+    {
+        errors.emplace_back("Property '%1.%2' has been changed from '%3' to '%4'.",
+                            op.object->name, op.new_property->name,
+                            string_for_property_type(op.old_property->type),
+                            string_for_property_type(op.new_property->type));
+    }
+
+    void operator()(schema_change::MakePropertyNullable op)
+    {
+        errors.emplace_back("Property '%1.%2' has been made optional.", op.object->name, op.property->name);
+    }
+
+    void operator()(schema_change::MakePropertyRequired op)
+    {
+        errors.emplace_back("Property '%1.%2' has been made required.", op.object->name, op.property->name);
+    }
+
+    void operator()(schema_change::ChangePrimaryKey op)
+    {
+        if (op.property && !op.object->primary_key.empty()) {
+            errors.emplace_back("Primary Key for class '%1 has changed from '%2' to '%3'.",
+                                op.object->name, op.object->primary_key, op.property->name);
+        }
+        else if (op.property) {
+            errors.emplace_back("Primary Key for class '%1 has been added.", op.object->name);
+        }
+        else {
+            errors.emplace_back("Primary Key for class '%1 has been removed.", op.object->name);
+        }
+    }
+};
+
+struct IndexUpdater {
+    Group& group;
+
+    void operator()(schema_change::AddIndex op) const
+    {
+        try {
+            table_for_object_schema(group, *op.object)->add_search_index(op.property->table_column);
+        }
+        catch (LogicError const&) {
+            throw std::logic_error(util::format("Cannot index property '%1.%2': indexing properties of type '%3' is not yet implemented.",
+                                                op.object->name, op.property->name, string_for_property_type(op.property->type)));
+        }
+    }
+
+    void operator()(schema_change::RemoveIndex op) const
+    {
+        table_for_object_schema(group, *op.object)->remove_search_index(op.property->table_column);
+    }
+};
+
+class TableHelper {
+public:
+    TableHelper(Group& g) : m_group(g) { }
+
+    Table& operator()(const ObjectSchema* object_schema)
+    {
+        if (object_schema != m_current_object_schema) {
+            m_current_table = table_for_object_schema(m_group, *object_schema);
+            m_current_object_schema = object_schema;
+        }
+        REALM_ASSERT(m_current_table);
+        return *m_current_table;
+    }
+
+private:
+    Group& m_group;
+    const ObjectSchema* m_current_object_schema = nullptr;
+    TableRef m_current_table;
+};
+
+template<typename ErrorType, typename Verifier>
+void verify_no_errors(Verifier&& verifier, std::vector<SchemaChange> const& changes)
+{
+    for (auto& change : changes) {
+        change.visit(verifier);
+    }
+
+    if (!verifier.errors.empty()) {
+        throw ErrorType(verifier.errors);
+    }
+}
+} // anonymous namespace
+
+void ObjectStore::verify_no_migration_required(std::vector<SchemaChange> const& changes)
+{
+    using namespace schema_change;
+    struct Verifier : MigrationChecker {
+        using MigrationChecker::operator();
+        void operator()(AddIndex) { }
+        void operator()(RemoveIndex) { }
+    } verifier;
+
+    for (auto& change : changes) {
+        change.visit(verifier);
+    }
+
+    if (!verifier.errors.empty()) {
+        throw SchemaMismatchException(verifier.errors);
     }
 }
 
-std::vector<ObjectSchemaValidationException> ObjectStore::verify_object_schema(ObjectSchema const& table_schema,
-                                                                               ObjectSchema& target_schema) {
-    std::vector<ObjectSchemaValidationException> exceptions;
+static void apply_non_migration_changes(Group& group, std::vector<SchemaChange> const& changes)
+{
+    using namespace schema_change;
+    struct Applier : MigrationChecker, IndexUpdater {
+        Applier(Group& group) : IndexUpdater{group} { }
+        using IndexUpdater::operator();
+        using MigrationChecker::operator();
+        void operator()(AddTable op) { create_table(group, *op.object); }
+    } applier{group};
 
-    // check to see if properties are the same
-    for (auto& current_prop : table_schema.persisted_properties) {
-        auto target_prop = target_schema.property_for_name(current_prop.name);
-
-        if (!target_prop) {
-            exceptions.emplace_back(MissingPropertyException(table_schema.name, current_prop));
-            continue;
-        }
-        if (property_has_changed(current_prop, *target_prop)) {
-            exceptions.emplace_back(MismatchedPropertiesException(table_schema.name, current_prop, *target_prop));
-            continue;
-        }
-
-        // create new property with aligned column
-        target_prop->table_column = current_prop.table_column;
+    for (auto& change : changes) {
+        change.visit(applier);
     }
 
-    // check for change to primary key
-    if (table_schema.primary_key != target_schema.primary_key) {
-        exceptions.emplace_back(ChangedPrimaryKeyException(table_schema.name, table_schema.primary_key, target_schema.primary_key));
-    }
-
-    // check for new missing properties
-    for (auto& target_prop : target_schema.persisted_properties) {
-        if (!table_schema.property_for_name(target_prop.name)) {
-            exceptions.emplace_back(ExtraPropertyException(table_schema.name, target_prop));
-        }
-    }
-
-    return exceptions;
-}
-
-template <typename T>
-static void copy_property_values(const Property& old_property, const Property& new_property, Table& table,
-                                 T (Table::*getter)(std::size_t, std::size_t) const noexcept,
-                                 void (Table::*setter)(std::size_t, std::size_t, T)) {
-    size_t old_column = old_property.table_column, new_column = new_property.table_column;
-    size_t count = table.size();
-    for (size_t i = 0; i < count; i++) {
-        (table.*setter)(new_column, i, (table.*getter)(old_column, i));
+    if (!applier.errors.empty()) {
+        throw SchemaMismatchException(applier.errors);
     }
 }
 
-static void copy_property_values(const Property& source, const Property& destination, Table& table) {
-    switch (destination.type) {
-        case PropertyType::Int:
-            copy_property_values(source, destination, table, &Table::get_int, &Table::set_int);
-            break;
-        case PropertyType::Bool:
-            copy_property_values(source, destination, table, &Table::get_bool, &Table::set_bool);
-            break;
-        case PropertyType::Float:
-            copy_property_values(source, destination, table, &Table::get_float, &Table::set_float);
-            break;
-        case PropertyType::Double:
-            copy_property_values(source, destination, table, &Table::get_double, &Table::set_double);
-            break;
-        case PropertyType::String:
-            copy_property_values(source, destination, table, &Table::get_string, &Table::set_string);
-            break;
-        case PropertyType::Data:
-            copy_property_values(source, destination, table, &Table::get_binary, &Table::set_binary);
-            break;
-        case PropertyType::Date:
-            copy_property_values(source, destination, table, &Table::get_timestamp, &Table::set_timestamp);
-            break;
-        default:
-            break;
+static void create_initial_tables(Group& group, std::vector<SchemaChange> const& changes)
+{
+    using namespace schema_change;
+    struct Applier : IndexUpdater {
+        Applier(Group& group) : IndexUpdater{group}, table{group} { }
+        TableHelper table;
+
+        using IndexUpdater::operator();
+        void operator()(AddTable op) { create_table(group, *op.object); }
+        void operator()(AddProperty op) { add_column(group, table(op.object), *op.property); }
+        void operator()(RemoveProperty op) { table(op.object).remove_column(op.property->table_column); }
+        void operator()(MakePropertyNullable op) { make_property_optional(group, table(op.object), *op.property); }
+        void operator()(MakePropertyRequired op) { make_property_required(group, table(op.object), *op.property); }
+        void operator()(ChangePrimaryKey op) { set_primary_key_for_object(group, op.object->name, op.property->name); }
+
+        void operator()(ChangePropertyType op)
+        {
+            insert_column(group, table(op.object), *op.new_property, op.old_property->table_column);
+            table(op.object).remove_column(op.old_property->table_column + 1);
+        }
+    } applier{group};
+
+    for (auto& change : changes) {
+        change.visit(applier);
     }
 }
 
-// set references to tables on targetSchema and create/update any missing or out-of-date tables
-// if update existing is true, updates existing tables, otherwise validates existing tables
-// NOTE: must be called from within write transaction
-void ObjectStore::create_tables(Group *group, Schema &target_schema, bool update_existing) {
-    // first pass to create missing tables
-    std::vector<ObjectSchema *> to_update;
-    for (auto& object_schema : target_schema) {
-        bool created = false;
-        ObjectStore::table_for_object_type_create_if_needed(group, object_schema.name, created);
+static void apply_pre_migration_changes(Group& group, std::vector<SchemaChange> const& changes)
+{
+    using namespace schema_change;
+    struct Applier : IndexUpdater {
+        Applier(Group& group) : IndexUpdater{group}, table{group} { }
+        TableHelper table;
 
-        // we will modify tables for any new objectSchema (table was created) or for all if update_existing is true
-        if (update_existing || created) {
-            to_update.push_back(&object_schema);
-        }
-    }
+        using IndexUpdater::operator();
+        void operator()(AddTable op) { create_table(group, *op.object); }
+        void operator()(AddProperty op) { add_column(group, table(op.object), *op.property); }
+        void operator()(RemoveProperty) { /* delayed until after the migration */ }
+        void operator()(ChangePropertyType op) { replace_column(group, table(op.object), *op.old_property, *op.new_property); }
+        void operator()(MakePropertyNullable op) { make_property_optional(group, table(op.object), *op.property); }
+        void operator()(MakePropertyRequired op) { make_property_required(group, table(op.object), *op.property); }
+        void operator()(ChangePrimaryKey op) { set_primary_key_for_object(group, op.object->name, op.property ? op.property->name : ""); }
+    } applier{group};
 
-    // second pass adds/removes columns for out of date tables
-    for (auto& target_object_schema : to_update) {
-        TableRef table = table_for_object_type(group, target_object_schema->name);
-        ObjectSchema current_schema(group, target_object_schema->name);
-        std::vector<Property> &target_props = target_object_schema->persisted_properties;
-
-        // handle columns changing from required to optional
-        for (auto& current_prop : current_schema.persisted_properties) {
-            auto target_prop = target_object_schema->property_for_name(current_prop.name);
-            if (!target_prop || !property_can_be_migrated_to_nullable(current_prop, *target_prop))
-                continue;
-
-            target_prop->table_column = current_prop.table_column;
-            current_prop.table_column = current_prop.table_column + 1;
-
-            table->insert_column(target_prop->table_column, DataType(target_prop->type), target_prop->name, target_prop->is_nullable);
-            copy_property_values(current_prop, *target_prop, *table);
-            table->remove_column(current_prop.table_column);
-
-            current_prop.table_column = target_prop->table_column;
-        }
-
-        bool inserted_placeholder_column = false;
-
-        // remove extra columns
-        size_t deleted = 0;
-        for (auto& current_prop : current_schema.persisted_properties) {
-            current_prop.table_column -= deleted;
-
-            auto target_prop = target_object_schema->property_for_name(current_prop.name);
-            if (!target_prop || (property_has_changed(current_prop, *target_prop)
-                                 && !property_can_be_migrated_to_nullable(current_prop, *target_prop))) {
-                if (deleted == current_schema.persisted_properties.size() - 1) {
-                    // We're about to remove the last column from the table. Insert a placeholder column to preserve
-                    // the number of rows in the table for the addition of new columns below.
-                    table->add_column(type_Bool, "placeholder");
-                    inserted_placeholder_column = true;
-                }
-
-                table->remove_column(current_prop.table_column);
-                ++deleted;
-                current_prop.table_column = npos;
-            }
-        }
-
-        // add missing columns
-        for (auto& target_prop : target_props) {
-            auto current_prop = current_schema.property_for_name(target_prop.name);
-
-            // add any new properties (no old column or old column was removed due to not matching)
-            if (!current_prop || current_prop->table_column == npos) {
-                switch (target_prop.type) {
-                        // for objects and arrays, we have to specify target table
-                    case PropertyType::Object:
-                    case PropertyType::Array: {
-                        TableRef link_table = ObjectStore::table_for_object_type(group, target_prop.object_type);
-                        REALM_ASSERT(link_table);
-                        target_prop.table_column = table->add_column_link(DataType(target_prop.type), target_prop.name, *link_table);
-                        break;
-                    }
-                    default:
-                        target_prop.table_column = table->add_column(DataType(target_prop.type),
-                                                                     target_prop.name,
-                                                                     target_prop.is_nullable);
-                        break;
-                }
-            }
-            else {
-                target_prop.table_column = current_prop->table_column;
-            }
-        }
-
-        if (inserted_placeholder_column) {
-            // We inserted a placeholder due to removing all columns from the table. Remove it, and update the indices
-            // of any columns that we inserted after it.
-            table->remove_column(0);
-            for (auto& target_prop : target_props) {
-                target_prop.table_column--;
-            }
-        }
-
-        // update table metadata
-        if (target_object_schema->primary_key.length()) {
-            // if there is a primary key set, check if it is the same as the old key
-            if (current_schema.primary_key != target_object_schema->primary_key) {
-                set_primary_key_for_object(group, target_object_schema->name, target_object_schema->primary_key);
-            }
-        }
-        else if (current_schema.primary_key.length()) {
-            // there is no primary key, so if there was one nil out
-            set_primary_key_for_object(group, target_object_schema->name, "");
-        }
+    for (auto& change : changes) {
+        change.visit(applier);
     }
 }
 
-bool ObjectStore::is_schema_at_version(const Group *group, uint64_t version) {
-    uint64_t old_version = get_schema_version(group);
-    if (old_version > version && old_version != NotVersioned) {
-        throw InvalidSchemaVersionException(old_version, version);
-    }
-    return old_version == version;
-}
+static void apply_post_migration_changes(Group& group, std::vector<SchemaChange> const& changes)
+{
+    using namespace schema_change;
+    struct Applier {
+        Group& group;
 
-bool ObjectStore::needs_update(Schema const& old_schema, Schema const& schema) {
-    for (auto const& target_schema : schema) {
-        auto matching_schema = old_schema.find(target_schema);
-        if (matching_schema == end(old_schema)) {
-            // Table doesn't exist
-            return true;
+        void operator()(RemoveProperty op)
+        {
+            auto table = table_for_object_schema(group, *op.object);
+            table->remove_column(op.property->table_column);
         }
 
-        if (matching_schema->persisted_properties.size() != target_schema.persisted_properties.size()) {
-            // If the number of properties don't match then a migration is required
-            return false;
-        }
-
-        // Check that all of the property indexes are up to date
-        for (size_t i = 0, count = target_schema.persisted_properties.size(); i < count; ++i) {
-            if (target_schema.persisted_properties[i].is_indexed != matching_schema->persisted_properties[i].is_indexed) {
-                return true;
+        void operator()(ChangePrimaryKey op)
+        {
+            if (op.property) {
+                validate_primary_column_uniqueness(group, op.object->name, op.property->name);
             }
         }
-    }
 
-    return false;
+        void operator()(AddTable op) { create_table(group, *op.object); }
+
+        void operator()(ChangePropertyType) { }
+        void operator()(MakePropertyNullable) { }
+        void operator()(MakePropertyRequired) { }
+        void operator()(AddProperty) { }
+        void operator()(AddIndex) { }
+        void operator()(RemoveIndex) { }
+    } applier{group};
+
+    for (auto& change : changes) {
+        change.visit(applier);
+    }
 }
 
-void ObjectStore::update_realm_with_schema(Group *group, Schema const& old_schema,
-                                           uint64_t version, Schema &schema,
-                                           MigrationFunction migration) {
-    // Recheck the schema version after beginning the write transaction as
-    // another process may have done the migration after we opened the read
-    // transaction
-    bool migrating = !is_schema_at_version(group, version);
-
-    // create tables
+void ObjectStore::apply_schema_changes(Group& group, Schema& schema, uint64_t& schema_version,
+                                       Schema const& target_schema, uint64_t target_schema_version,
+                                       std::vector<SchemaChange> const& changes, std::function<void()> migration_function)
+{
+    if (schema_version > target_schema_version && schema_version != ObjectStore::NotVersioned) {
+        throw InvalidSchemaVersionException(schema_version, target_schema_version);
+    }
     create_metadata_tables(group);
-    create_tables(group, schema, migrating);
 
-    if (!migrating) {
-        // If we aren't migrating, then verify that all of the tables which
-        // were already present are valid (newly created ones always are)
-        verify_schema(old_schema, schema, true);
-    }
-
-    update_indexes(group, schema);
-
-    if (!migrating) {
+    if (schema_version == target_schema_version) {
+        apply_non_migration_changes(group, changes);
+        schema = target_schema;
+        set_schema_columns(group, schema);
         return;
     }
 
-    // apply the migration block if provided and there's any old data
-    if (get_schema_version(group) != ObjectStore::NotVersioned) {
-        migration(group, schema);
-
-        validate_primary_column_uniqueness(group, schema);
+    if (schema_version == ObjectStore::NotVersioned) {
+        create_initial_tables(group, changes);
+        set_schema_version(group, target_schema_version);
+        schema_version = target_schema_version;
+        schema = target_schema;
+        set_schema_columns(group, schema);
+        return;
     }
 
-    set_schema_version(group, version);
+    apply_pre_migration_changes(group, changes);
+    if (migration_function) {
+        // Have to update the schema on the Realm before calling the migration
+        // function as the migration will need it
+        auto old_version = schema_version;
+        auto old_schema = schema;
+        schema_version = target_schema_version;
+        schema = target_schema;
+        set_schema_columns(group, schema);
+
+        try {
+            migration_function();
+
+            // Migration function may have changed the schema, so we need to re-read it
+            schema = schema_from_group(group);
+            validate_primary_column_uniqueness(group);
+        }
+        catch (...) {
+            schema = move(old_schema);
+            schema_version = old_version;
+            throw;
+        }
+
+        apply_post_migration_changes(group, schema.compare(target_schema));
+    }
+    else {
+        apply_post_migration_changes(group, changes);
+    }
+
+    set_schema_version(group, target_schema_version);
+    schema_version = target_schema_version;
+    schema = target_schema;
+    set_schema_columns(group, schema);
 }
 
-Schema ObjectStore::schema_from_group(const Group *group) {
+Schema ObjectStore::schema_from_group(Group const& group) {
     std::vector<ObjectSchema> schema;
-    for (size_t i = 0; i < group->size(); i++) {
-        std::string object_type = object_type_for_table_name(group->get_table_name(i));
+    for (size_t i = 0; i < group.size(); i++) {
+        std::string object_type = object_type_for_table_name(group.get_table_name(i));
         if (object_type.length()) {
             schema.emplace_back(group, object_type);
         }
@@ -439,61 +542,30 @@ Schema ObjectStore::schema_from_group(const Group *group) {
     return schema;
 }
 
-bool ObjectStore::update_indexes(Group *group, Schema &schema) {
-    bool changed = false;
+void ObjectStore::set_schema_columns(Group const& group, Schema& schema)
+{
     for (auto& object_schema : schema) {
-        TableRef table = table_for_object_type(group, object_schema.name);
+        auto table = table_for_object_schema(group, object_schema);
         if (!table) {
             continue;
         }
-
         for (auto& property : object_schema.persisted_properties) {
-            if (property.requires_index() == table->has_search_index(property.table_column)) {
-                continue;
-            }
-
-            changed = true;
-            if (property.requires_index()) {
-                try {
-                    table->add_search_index(property.table_column);
-                }
-                catch (LogicError const&) {
-                    throw PropertyTypeNotIndexableException(object_schema.name, property);
-                }
-            }
-            else {
-                table->remove_search_index(property.table_column);
-            }
-        }
-    }
-    return changed;
-}
-
-void ObjectStore::validate_primary_column_uniqueness(const Group *group, Schema const& schema) {
-    for (auto& object_schema : schema) {
-        auto primary_prop = object_schema.primary_key_property();
-        if (!primary_prop) {
-            continue;
-        }
-
-        ConstTableRef table = table_for_object_type(group, object_schema.name);
-        if (table->get_distinct_view(primary_prop->table_column).size() != table->size()) {
-            throw DuplicatePrimaryKeyValueException(object_schema.name, *primary_prop);
+            property.table_column = table->get_column_index(property.name);
         }
     }
 }
 
-void ObjectStore::delete_data_for_object(Group *group, StringData object_type) {
+void ObjectStore::delete_data_for_object(Group& group, StringData object_type) {
     TableRef table = table_for_object_type(group, object_type);
     if (table) {
-        group->remove_table(table->get_index_in_group());
+        group.remove_table(table->get_index_in_group());
         set_primary_key_for_object(group, object_type, "");
     }
 }
 
-bool ObjectStore::is_empty(const Group *group) {
-    for (size_t i = 0; i < group->size(); i++) {
-        ConstTableRef table = group->get_table(i);
+bool ObjectStore::is_empty(Group const& group) {
+    for (size_t i = 0; i < group.size(); i++) {
+        ConstTableRef table = group.get_table(i);
         std::string object_type = object_type_for_table_name(table->get_name());
         if (!object_type.length()) {
             continue;
@@ -505,152 +577,36 @@ bool ObjectStore::is_empty(const Group *group) {
     return true;
 }
 
-InvalidSchemaVersionException::InvalidSchemaVersionException(uint64_t old_version, uint64_t new_version) :
-    m_old_version(old_version), m_new_version(new_version)
+InvalidSchemaVersionException::InvalidSchemaVersionException(uint64_t old_version, uint64_t new_version)
+: logic_error(util::format("Provided schema version %1 is less than last set version %2.", new_version, old_version))
+, m_old_version(old_version), m_new_version(new_version)
 {
-    m_what = util::format("Provided schema version %1 is less than last set version %2.", new_version, old_version);
 }
 
-DuplicatePrimaryKeyValueException::DuplicatePrimaryKeyValueException(std::string const& object_type, Property const& property) :
-    m_object_type(object_type), m_property(property)
+DuplicatePrimaryKeyValueException::DuplicatePrimaryKeyValueException(std::string object_type, std::string property)
+: logic_error(util::format("Primary key property '%1.%2' has duplicate values after migration.", object_type, property))
+, m_object_type(object_type), m_property(property)
 {
-    m_what = util::format("Primary key property '%1' has duplicate values after migration.", property.name);
 }
 
 SchemaValidationException::SchemaValidationException(std::vector<ObjectSchemaValidationException> const& errors)
-: m_validation_errors(errors)
-{
-    m_what = "Schema validation failed due to the following errors:";
+: std::logic_error([&] {
+    std::string message = "Schema validation failed due to the following errors:";
     for (auto const& error : errors) {
-        m_what += std::string("\n- ") + error.what();
+        message += std::string("\n- ") + error.what();
     }
+    return message;
+}())
+{
 }
 
-SchemaMismatchException::SchemaMismatchException(std::vector<ObjectSchemaValidationException> const& errors) :
-    m_validation_errors(errors)
-{
-    m_what = "Migration is required due to the following errors:";
+SchemaMismatchException::SchemaMismatchException(std::vector<ObjectSchemaValidationException> const& errors)
+: std::logic_error([&] {
+    std::string message = "Migration is required due to the following errors:";
     for (auto const& error : errors) {
-        m_what += std::string("\n- ") + error.what();
+        message += std::string("\n- ") + error.what();
     }
-}
-
-PropertyTypeNotIndexableException::PropertyTypeNotIndexableException(std::string const& object_type,
-                                                                     Property const& property)
-: ObjectSchemaPropertyException(object_type, property)
+    return message;
+}())
 {
-    m_what = util::format("Can't index property %1.%2: indexing a property of type '%3' is currently not supported.",
-                          object_type, property.name, string_for_property_type(property.type));
-}
-
-ExtraPropertyException::ExtraPropertyException(std::string const& object_type, Property const& property) :
-    ObjectSchemaPropertyException(object_type, property)
-{
-    m_what = util::format("Property '%1' has been added to latest object model.", property.name);
-}
-
-MissingPropertyException::MissingPropertyException(std::string const& object_type, Property const& property) :
-    ObjectSchemaPropertyException(object_type, property)
-{
-    m_what = util::format("Property '%1' is missing from latest object model.", property.name);
-}
-
-InvalidNullabilityException::InvalidNullabilityException(std::string const& object_type, Property const& property) :
-    ObjectSchemaPropertyException(object_type, property)
-{
-    switch (property.type) {
-        case PropertyType::Object:
-            m_what = util::format("'Object' property '%1' must be nullable.", property.name);
-            break;
-        case PropertyType::Any:
-        case PropertyType::Array:
-        case PropertyType::LinkingObjects:
-            m_what = util::format("Property '%1' of type '%2' cannot be nullable.",
-                                  property.name, string_for_property_type(property.type));
-            break;
-        case PropertyType::Int:
-        case PropertyType::Bool:
-        case PropertyType::Data:
-        case PropertyType::Date:
-        case PropertyType::Float:
-        case PropertyType::Double:
-        case PropertyType::String:
-            REALM_ASSERT(false);
-    }
-}
-
-MissingObjectTypeException::MissingObjectTypeException(std::string const& object_type, Property const& property)
-: ObjectSchemaPropertyException(object_type, property)
-{
-    m_what = util::format("Target type '%1' doesn't exist for property '%2'.",
-                          property.object_type, property.name);
-}
-
-MismatchedPropertiesException::MismatchedPropertiesException(std::string const& object_type,
-                                                             Property const& old_property,
-                                                             Property const& new_property) :
-    ObjectSchemaValidationException(object_type), m_old_property(old_property), m_new_property(new_property)
-{
-    if (new_property.type != old_property.type) {
-        m_what = util::format("Property types for '%1' property do not match. Old type '%2', new type '%3'.",
-                              old_property.name,
-                              string_for_property_type(old_property.type),
-                              string_for_property_type(new_property.type));
-    }
-    else if (new_property.object_type != old_property.object_type) {
-        m_what = util::format("Target object type for property '%1' do not match. Old type '%2', new type '%3'.",
-                              old_property.name, old_property.object_type, new_property.object_type);
-    }
-    else if (new_property.is_nullable != old_property.is_nullable) {
-        m_what = util::format("Nullability for property '%1' has been changed from %2 to %3.",
-                              old_property.name,
-                              old_property.is_nullable, new_property.is_nullable);
-    }
-}
-
-ChangedPrimaryKeyException::ChangedPrimaryKeyException(std::string const& object_type,
-                                                       std::string const& old_primary,
-                                                       std::string const& new_primary)
-: ObjectSchemaValidationException(object_type), m_old_primary(old_primary), m_new_primary(new_primary)
-{
-    if (old_primary.size()) {
-        m_what = util::format("Property '%1' is no longer a primary key.", old_primary);
-    }
-    else {
-        m_what = util::format("Property '%1' has been made a primary key.", new_primary);
-    }
-}
-
-InvalidPrimaryKeyException::InvalidPrimaryKeyException(std::string const& object_type, std::string const& primary) :
-    ObjectSchemaValidationException(object_type), m_primary_key(primary)
-{
-    m_what = util::format("Specified primary key property '%1' does not exist.", primary);
-}
-
-DuplicatePrimaryKeysException::DuplicatePrimaryKeysException(std::string const& object_type)
-: ObjectSchemaValidationException(object_type)
-{
-    m_what = util::format("Duplicate primary keys for object '%1'.", object_type);
-}
-
-InvalidLinkingObjectsPropertyException::InvalidLinkingObjectsPropertyException(Type error_type, std::string const& object_type, Property const& property)
-: ObjectSchemaPropertyException(object_type, property)
-{
-    switch (error_type) {
-        case Type::OriginPropertyDoesNotExist:
-            m_what = util::format("Property '%1.%2' declared as origin of linking objects property '%3.%4' does not exist.",
-                                  property.object_type, property.link_origin_property_name,
-                                  object_type, property.name);
-            break;
-        case Type::OriginPropertyIsNotALink:
-            m_what = util::format("Property '%1.%2' declared as origin of linking objects property '%3.%4' is not a link.",
-                                  property.object_type, property.link_origin_property_name,
-                                  object_type, property.name);
-            break;
-        case Type::OriginPropertyInvalidLinkTarget:
-            m_what = util::format("Property '%1.%2' declared as origin of linking objects property '%3.%4' links to a different class.",
-                                  property.object_type, property.link_origin_property_name,
-                                  object_type, property.name);
-            break;
-    }
 }

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -58,6 +58,8 @@ public:
                                      Schema const& target_schema, uint64_t target_schema_version,
                                      std::vector<SchemaChange> const& changes, std::function<void()> migration_function={});
 
+    static bool needs_migration(std::vector<SchemaChange> const& changes);
+
     // get a table for an object type
     static realm::TableRef table_for_object_type(Group& group, StringData object_type);
     static realm::ConstTableRef table_for_object_type(Group const& group, StringData object_type);

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -75,13 +75,20 @@ public:
     // indicates if this group contains any objects
     static bool is_empty(Group const& group);
 
+    // renames the object_type's column of the old_name to the new name
+    static void rename_property(Group& group, Schema& schema, StringData object_type, StringData old_name, StringData new_name);
+
+    // get primary key property name for object type
+    static StringData get_primary_key_for_object(Group const& group, StringData object_type);
+
+    // sets primary key property for object type
+    // must be in write transaction to set
+    static void set_primary_key_for_object(Group& group, StringData object_type, StringData primary_key);
+
     static std::string table_name_for_object_type(StringData class_name);
     static StringData object_type_for_table_name(StringData table_name);
 
 private:
-    // get primary key property name for object type
-    static StringData get_primary_key_for_object(Group const& group, StringData object_type);
-
     friend class ObjectSchema;
 };
 

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -47,9 +47,12 @@ public:
     // get the last set schema version
     static uint64_t get_schema_version(Group const& group);
 
-    // check if any of the schema changes in the list require a migration, and
-    // if any do throw an exception
+    // check if all of the changes in the list can be applied automatically, or
+    // throw if any of them require a schema version bump and migration function
     static void verify_no_migration_required(std::vector<SchemaChange> const& changes);
+
+    // Similar to above, but returns a bool rather than throwing/not throwing
+    static bool needs_migration(std::vector<SchemaChange> const& changes);
 
     // check if any of the schema changes in the list are forbidden in
     // additive-only mode, and if any are throw an exception
@@ -66,8 +69,6 @@ public:
                                      Schema const& target_schema, uint64_t target_schema_version,
                                      SchemaMode mode, std::vector<SchemaChange> const& changes,
                                      std::function<void()> migration_function={});
-
-    static bool needs_migration(std::vector<SchemaChange> const& changes);
 
     // get a table for an object type
     static realm::TableRef table_for_object_type(Group& group, StringData object_type);

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -127,8 +127,8 @@ struct ObjectSchemaValidationException : public std::logic_error {
     ObjectSchemaValidationException(std::string message) : logic_error(std::move(message)) {}
 
     template<typename... Args>
-    ObjectSchemaValidationException(Args&&... args)
-    : std::logic_error(util::format(std::forward<Args>(args)...)) { }
+    ObjectSchemaValidationException(const char* fmt, Args&&... args)
+    : std::logic_error(util::format(fmt, std::forward<Args>(args)...)) { }
 };
 
 struct SchemaValidationException : public std::logic_error {

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -32,6 +32,7 @@ class Group;
 class Schema;
 class SchemaChange;
 class StringData;
+enum class SchemaMode : uint8_t;
 
 namespace util {
 template<typename... Args>
@@ -54,13 +55,16 @@ public:
     // additive-only mode, and if any are throw an exception
     static void verify_valid_additive_changes(std::vector<SchemaChange> const& changes);
 
+    // check if changes is empty, and throw an exception if not
+    static void verify_no_changes_required(std::vector<SchemaChange> const& changes);
+
     // updates a Realm from old_schema to the given target schema, creating and updating tables as needed
     // passed in target schema is updated with the correct column mapping
     // optionally runs migration function if schema is out of date
     // NOTE: must be performed within a write transaction
     static void apply_schema_changes(Group& group, Schema& schema, uint64_t& schema_version,
                                      Schema const& target_schema, uint64_t target_schema_version,
-                                     bool additive_mode, std::vector<SchemaChange> const& changes,
+                                     SchemaMode mode, std::vector<SchemaChange> const& changes,
                                      std::function<void()> migration_function={});
 
     static bool needs_migration(std::vector<SchemaChange> const& changes);

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -50,13 +50,18 @@ public:
     // if any do throw an exception
     static void verify_no_migration_required(std::vector<SchemaChange> const& changes);
 
+    // check if any of the schema changes in the list are forbidden in
+    // additive-only mode, and if any are throw an exception
+    static void verify_valid_additive_changes(std::vector<SchemaChange> const& changes);
+
     // updates a Realm from old_schema to the given target schema, creating and updating tables as needed
     // passed in target schema is updated with the correct column mapping
     // optionally runs migration function if schema is out of date
     // NOTE: must be performed within a write transaction
     static void apply_schema_changes(Group& group, Schema& schema, uint64_t& schema_version,
                                      Schema const& target_schema, uint64_t target_schema_version,
-                                     std::vector<SchemaChange> const& changes, std::function<void()> migration_function={});
+                                     bool additive_mode, std::vector<SchemaChange> const& changes,
+                                     std::function<void()> migration_function={});
 
     static bool needs_migration(std::vector<SchemaChange> const& changes);
 
@@ -127,6 +132,10 @@ struct SchemaValidationException : public std::logic_error {
 
 struct SchemaMismatchException : public std::logic_error {
     SchemaMismatchException(std::vector<ObjectSchemaValidationException> const& errors);
+};
+
+struct InvalidSchemaChangeException : public std::logic_error {
+    InvalidSchemaChangeException(std::vector<ObjectSchemaValidationException> const& errors);
 };
 } // namespace realm
 

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -28,231 +28,97 @@
 #include <vector>
 
 namespace realm {
-    class Group;
-    class ObjectSchema;
-    class ObjectSchemaValidationException;
-    class Schema;
-    class StringData;
+class Group;
+class Schema;
+class SchemaChange;
+class StringData;
 
-    class ObjectStore {
-      public:
-        // Schema version used for uninitialized Realms
-        static const uint64_t NotVersioned;
-
-        // get the last set schema version
-        static uint64_t get_schema_version(const Group *group);
-
-        // checks if the schema in the group is at the given version
-        static bool is_schema_at_version(const Group *group, uint64_t version);
-
-        // verify that schema from a group and a target schema are compatible
-        // updates the column mapping on all ObjectSchema properties of the target schema
-        // throws if the schema is invalid or does not match
-        static void verify_schema(Schema const& actual_schema, Schema& target_schema, bool allow_missing_tables = false);
-
-        // determines if a realm with the given old schema needs non-migration
-        // changes to make it compatible with the given target schema
-        static bool needs_update(Schema const& old_schema, Schema const& schema);
-
-        // updates a Realm from old_schema to the given target schema, creating and updating tables as needed
-        // passed in target schema is updated with the correct column mapping
-        // optionally runs migration function if schema is out of date
-        // NOTE: must be performed within a write transaction
-        typedef std::function<void(Group *, Schema &)> MigrationFunction;
-        static void update_realm_with_schema(Group *group, Schema const& old_schema, uint64_t version,
-                                             Schema &schema, MigrationFunction migration);
-
-        // get a table for an object type
-        static realm::TableRef table_for_object_type(Group *group, StringData object_type);
-        static realm::ConstTableRef table_for_object_type(const Group *group, StringData object_type);
-
-        // get existing Schema from a group
-        static Schema schema_from_group(const Group *group);
-
-        // deletes the table for the given type
-        static void delete_data_for_object(Group *group, StringData object_type);
-
-        // indicates if this group contains any objects
-        static bool is_empty(const Group *group);
-
-        static std::string table_name_for_object_type(StringData class_name);
-        static StringData object_type_for_table_name(StringData table_name);
-
-    private:
-        // set a new schema version
-        static void set_schema_version(Group *group, uint64_t version);
-
-        // check if the realm already has all metadata tables
-        static bool has_metadata_tables(const Group *group);
-
-        // create any metadata tables that don't already exist
-        // must be in write transaction to set
-        // returns true if it actually did anything
-        static void create_metadata_tables(Group *group);
-
-        // set references to tables on targetSchema and create/update any missing or out-of-date tables
-        // if update existing is true, updates existing tables, otherwise only adds and initializes new tables
-        static void create_tables(realm::Group *group, Schema &target_schema, bool update_existing);
-
-        // verify a target schema against an expected schema, setting the table_column property on each schema object
-        // updates the column mapping on the target_schema
-        // returns array of validation errors
-        static std::vector<ObjectSchemaValidationException> verify_object_schema(ObjectSchema const& expected,
-                                                                                 ObjectSchema &target_schema);
-
-        // get primary key property name for object type
-        static StringData get_primary_key_for_object(const Group *group, StringData object_type);
-
-        // sets primary key property for object type
-        // must be in write transaction to set
-        static void set_primary_key_for_object(Group *group, StringData object_type, StringData primary_key);
-
-        static TableRef table_for_object_type_create_if_needed(Group *group, StringData object_type, bool &created);
-
-        // returns if any indexes were changed
-        static bool update_indexes(Group *group, Schema &schema);
-
-        // validates that all primary key properties have unique values
-        static void validate_primary_column_uniqueness(const Group *group, Schema const& schema);
-
-        friend ObjectSchema;
-    };
-
-    // Base exception
-    class ObjectStoreException : public std::exception {
-      public:
-        ObjectStoreException() = default;
-        ObjectStoreException(const std::string &what) : m_what(what) {}
-        const char* what() const noexcept override { return m_what.c_str(); }
-      protected:
-        std::string m_what;
-    };
-
-    // Migration exceptions
-    class MigrationException : public ObjectStoreException {};
-
-    class InvalidSchemaVersionException : public MigrationException {
-      public:
-        InvalidSchemaVersionException(uint64_t old_version, uint64_t new_version);
-        uint64_t old_version() const { return m_old_version; }
-        uint64_t new_version() const { return m_new_version; }
-      private:
-        uint64_t m_old_version, m_new_version;
-    };
-
-    class DuplicatePrimaryKeyValueException : public MigrationException {
-      public:
-        DuplicatePrimaryKeyValueException(std::string const& object_type, Property const& property);
-        DuplicatePrimaryKeyValueException(std::string const& object_type, Property const& property, const std::string message);
-
-        std::string object_type() const { return m_object_type; }
-        Property const& property() const { return m_property; }
-      private:
-        std::string m_object_type;
-        Property m_property;
-    };
-
-    // Schema validation exceptions
-    class SchemaValidationException : public ObjectStoreException {
-      public:
-        SchemaValidationException(std::vector<ObjectSchemaValidationException> const& errors);
-        std::vector<ObjectSchemaValidationException> const& validation_errors() const { return m_validation_errors; }
-      private:
-        std::vector<ObjectSchemaValidationException> m_validation_errors;
-    };
-
-    class SchemaMismatchException : public ObjectStoreException {
-    public:
-        SchemaMismatchException(std::vector<ObjectSchemaValidationException> const& errors);
-        std::vector<ObjectSchemaValidationException> const& validation_errors() const { return m_validation_errors; }
-    private:
-        std::vector<ObjectSchemaValidationException> m_validation_errors;
-    };
-
-    class ObjectSchemaValidationException : public ObjectStoreException {
-      public:
-        ObjectSchemaValidationException(std::string const& object_type) : m_object_type(object_type) {}
-        ObjectSchemaValidationException(std::string const& object_type, std::string const& message) :
-            m_object_type(object_type) { m_what = message; }
-        std::string object_type() const { return m_object_type; }
-      protected:
-        std::string m_object_type;
-    };
-
-    class ObjectSchemaPropertyException : public ObjectSchemaValidationException {
-      public:
-        ObjectSchemaPropertyException(std::string const& object_type, Property const& property) :
-            ObjectSchemaValidationException(object_type), m_property(property) {}
-        Property const& property() const { return m_property; }
-      private:
-        Property m_property;
-    };
-
-    class PropertyTypeNotIndexableException : public ObjectSchemaPropertyException {
-      public:
-        PropertyTypeNotIndexableException(std::string const& object_type, Property const& property);
-    };
-
-    class ExtraPropertyException : public ObjectSchemaPropertyException {
-      public:
-        ExtraPropertyException(std::string const& object_type, Property const& property);
-    };
-
-    class MissingPropertyException : public ObjectSchemaPropertyException {
-      public:
-        MissingPropertyException(std::string const& object_type, Property const& property);
-    };
-
-    class InvalidNullabilityException : public ObjectSchemaPropertyException {
-      public:
-        InvalidNullabilityException(std::string const& object_type, Property const& property);
-    };
-
-    class MissingObjectTypeException : public ObjectSchemaPropertyException {
-    public:
-        MissingObjectTypeException(std::string const& object_type, Property const& property);
-    };
-
-    class DuplicatePrimaryKeysException : public ObjectSchemaValidationException {
-    public:
-        DuplicatePrimaryKeysException(std::string const& object_type);
-    };
-
-    class MismatchedPropertiesException : public ObjectSchemaValidationException {
-      public:
-        MismatchedPropertiesException(std::string const& object_type, Property const& old_property, Property const& new_property);
-        Property const& old_property() const { return m_old_property; }
-        Property const& new_property() const { return m_new_property; }
-      private:
-        Property m_old_property, m_new_property;
-    };
-
-    class ChangedPrimaryKeyException : public ObjectSchemaValidationException {
-      public:
-        ChangedPrimaryKeyException(std::string const& object_type, std::string const& old_primary, std::string const& new_primary);
-        std::string old_primary() const { return m_old_primary; }
-        std::string new_primary() const { return m_new_primary; }
-      private:
-        std::string m_old_primary, m_new_primary;
-    };
-
-    class InvalidPrimaryKeyException : public ObjectSchemaValidationException {
-      public:
-        InvalidPrimaryKeyException(std::string const& object_type, std::string const& primary_key);
-        std::string primary_key() const { return m_primary_key; }
-      private:
-        std::string m_primary_key;
-    };
-
-    class InvalidLinkingObjectsPropertyException : public ObjectSchemaPropertyException {
-    public:
-        enum class Type {
-            OriginPropertyDoesNotExist,
-            OriginPropertyIsNotALink,
-            OriginPropertyInvalidLinkTarget,
-        };
-        InvalidLinkingObjectsPropertyException(Type error_type, std::string const& object_type, Property const& property);
-    };
+namespace util {
+template<typename... Args>
+std::string format(const char* fmt, Args&&... args);
 }
+
+class ObjectStore {
+public:
+    // Schema version used for uninitialized Realms
+    static const uint64_t NotVersioned;
+
+    // get the last set schema version
+    static uint64_t get_schema_version(Group const& group);
+
+    // check if any of the schema changes in the list require a migration, and
+    // if any do throw an exception
+    static void verify_no_migration_required(std::vector<SchemaChange> const& changes);
+
+    // updates a Realm from old_schema to the given target schema, creating and updating tables as needed
+    // passed in target schema is updated with the correct column mapping
+    // optionally runs migration function if schema is out of date
+    // NOTE: must be performed within a write transaction
+    static void apply_schema_changes(Group& group, Schema& schema, uint64_t& schema_version,
+                                     Schema const& target_schema, uint64_t target_schema_version,
+                                     std::vector<SchemaChange> const& changes, std::function<void()> migration_function={});
+
+    // get a table for an object type
+    static realm::TableRef table_for_object_type(Group& group, StringData object_type);
+    static realm::ConstTableRef table_for_object_type(Group const& group, StringData object_type);
+
+    // get existing Schema from a group
+    static Schema schema_from_group(Group const& group);
+
+    static void set_schema_columns(Group const& group, Schema& schema);
+
+    // deletes the table for the given type
+    static void delete_data_for_object(Group& group, StringData object_type);
+
+    // indicates if this group contains any objects
+    static bool is_empty(Group const& group);
+
+    static std::string table_name_for_object_type(StringData class_name);
+    static StringData object_type_for_table_name(StringData table_name);
+
+private:
+    // get primary key property name for object type
+    static StringData get_primary_key_for_object(Group const& group, StringData object_type);
+
+    friend class ObjectSchema;
+};
+
+class InvalidSchemaVersionException : public std::logic_error {
+public:
+    InvalidSchemaVersionException(uint64_t old_version, uint64_t new_version);
+    uint64_t old_version() const { return m_old_version; }
+    uint64_t new_version() const { return m_new_version; }
+private:
+    uint64_t m_old_version, m_new_version;
+};
+
+class DuplicatePrimaryKeyValueException : public std::logic_error {
+public:
+    DuplicatePrimaryKeyValueException(std::string object_type, std::string property);
+
+    std::string const& object_type() const { return m_object_type; }
+    std::string const& property() const { return m_property; }
+private:
+    std::string m_object_type;
+    std::string m_property;
+};
+
+// Schema validation exceptions
+struct ObjectSchemaValidationException : public std::logic_error {
+    ObjectSchemaValidationException(std::string message) : logic_error(std::move(message)) {}
+
+    template<typename... Args>
+    ObjectSchemaValidationException(Args&&... args)
+    : std::logic_error(util::format(std::forward<Args>(args)...)) { }
+};
+
+struct SchemaValidationException : public std::logic_error {
+    SchemaValidationException(std::vector<ObjectSchemaValidationException> const& errors);
+};
+
+struct SchemaMismatchException : public std::logic_error {
+    SchemaMismatchException(std::vector<ObjectSchemaValidationException> const& errors);
+};
+} // namespace realm
 
 #endif /* defined(REALM_OBJECT_STORE_HPP) */

--- a/src/property.hpp
+++ b/src/property.hpp
@@ -104,12 +104,14 @@ namespace realm {
     inline bool operator==(Property const& lft, Property const& rgt)
     {
         // note: not checking table_column
-        return lft.name == rgt.name
-            && lft.type == rgt.type
-            && lft.object_type == rgt.object_type
+        // ordered roughly by the cost of the check
+        return lft.type == rgt.type
             && lft.is_primary == rgt.is_primary
+            && lft.is_nullable == rgt.is_nullable
             && lft.requires_index() == rgt.requires_index()
-            && lft.is_nullable == rgt.is_nullable;
+            && lft.name == rgt.name
+            && lft.object_type == rgt.object_type
+            && lft.link_origin_property_name == rgt.link_origin_property_name;
     }
 
     static const char *string_for_property_type(PropertyType type)

--- a/src/property.hpp
+++ b/src/property.hpp
@@ -36,6 +36,8 @@ namespace realm {
         LinkingObjects  = 14,
     };
 
+    static const char *string_for_property_type(PropertyType type);
+
     struct Property {
         std::string name;
         PropertyType type;
@@ -68,6 +70,20 @@ namespace realm {
                 || type == PropertyType::Object;
         }
 
+        std::string type_string() const
+        {
+            switch (type) {
+                case PropertyType::Object:
+                    return "<" + object_type + ">";
+                case PropertyType::Array:
+                    return "array<" + object_type + ">";
+                case PropertyType::LinkingObjects:
+                    return "linking objects<" + object_type + ">";
+                default:
+                    return string_for_property_type(type);
+            }
+        }
+
 #if __GNUC__ < 5
         // GCC 4.9 does not support C++14 braced-init with NSDMIs
         Property(std::string name="", PropertyType type=PropertyType::Int,
@@ -96,7 +112,7 @@ namespace realm {
             && lft.is_nullable == rgt.is_nullable;
     }
 
-    static inline const char *string_for_property_type(PropertyType type)
+    static const char *string_for_property_type(PropertyType type)
     {
         switch (type) {
             case PropertyType::String:

--- a/src/property.hpp
+++ b/src/property.hpp
@@ -47,12 +47,25 @@ namespace realm {
 
         size_t table_column = -1;
         bool requires_index() const { return is_primary || is_indexed; }
+
         bool is_indexable() const
         {
             return type == PropertyType::Int
                 || type == PropertyType::Bool
                 || type == PropertyType::Date
                 || type == PropertyType::String;
+        }
+
+        bool type_is_nullable() const
+        {
+            return type == PropertyType::Int
+                || type == PropertyType::Bool
+                || type == PropertyType::Float
+                || type == PropertyType::Double
+                || type == PropertyType::Date
+                || type == PropertyType::String
+                || type == PropertyType::Data
+                || type == PropertyType::Object;
         }
 
 #if __GNUC__ < 5
@@ -72,7 +85,19 @@ namespace realm {
 #endif
     };
 
-    static inline const char *string_for_property_type(PropertyType type) {
+    inline bool operator==(Property const& lft, Property const& rgt)
+    {
+        // note: not checking table_column
+        return lft.name == rgt.name
+            && lft.type == rgt.type
+            && lft.object_type == rgt.object_type
+            && lft.is_primary == rgt.is_primary
+            && lft.requires_index() == rgt.requires_index()
+            && lft.is_nullable == rgt.is_nullable;
+    }
+
+    static inline const char *string_for_property_type(PropertyType type)
+    {
         switch (type) {
             case PropertyType::String:
                 return "string";

--- a/src/results.cpp
+++ b/src/results.cpp
@@ -151,8 +151,8 @@ const ObjectSchema& Results::get_object_schema() const
 
     if (!m_object_schema) {
         REALM_ASSERT(m_realm);
-        auto it = m_realm->config().schema->find(get_object_type());
-        REALM_ASSERT(it != m_realm->config().schema->end());
+        auto it = m_realm->schema().find(get_object_type());
+        REALM_ASSERT(it != m_realm->schema().end());
         m_object_schema = &*it;
     }
 
@@ -528,7 +528,7 @@ Results Results::snapshot() &&
 
 void Results::prepare_async()
 {
-    if (m_realm->config().read_only) {
+    if (m_realm->config().read_only()) {
         throw InvalidTransactionException("Cannot create asynchronous query for read-only Realms");
     }
     if (m_realm->is_in_transaction()) {

--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -20,18 +20,35 @@
 
 #include "object_schema.hpp"
 #include "object_store.hpp"
+#include "object_schema.hpp"
+#include "property.hpp"
 
 #include <algorithm>
 
 using namespace realm;
 
+namespace realm {
+bool operator==(Schema const& a, Schema const& b)
+{
+    return static_cast<Schema::base const&>(a) == static_cast<Schema::base const&>(b);
+}
+}
+
 static bool compare_by_name(ObjectSchema const& lft, ObjectSchema const& rgt) {
     return lft.name < rgt.name;
 }
 
+Schema::Schema() = default;
+Schema::~Schema() = default;
+Schema::Schema(Schema const&) = default;
+Schema::Schema(Schema &&) = default;
+Schema& Schema::operator=(Schema const&) = default;
+Schema& Schema::operator=(Schema&&) = default;
+
 Schema::Schema(std::initializer_list<ObjectSchema> types) : Schema(base(types)) { }
 
-Schema::Schema(base types) : base(std::move(types)) {
+Schema::Schema(base types) : base(std::move(types))
+{
     std::sort(begin(), end(), compare_by_name);
 }
 
@@ -65,66 +82,116 @@ void Schema::validate() const
 {
     std::vector<ObjectSchemaValidationException> exceptions;
     for (auto const& object : *this) {
-        const Property *primary = nullptr;
-
-        std::vector<Property> all_properties = object.persisted_properties;
-        all_properties.insert(all_properties.end(), object.computed_properties.begin(), object.computed_properties.end());
-
-        for (auto const& prop : all_properties) {
-            // check object_type existence
-            if (!prop.object_type.empty()) {
-                auto it = find(prop.object_type);
-                if (it == end()) {
-                    exceptions.emplace_back(MissingObjectTypeException(object.name, prop));
-                }
-                // validate linking objects property.
-                else if (!prop.link_origin_property_name.empty()) {
-                    using ErrorType = InvalidLinkingObjectsPropertyException::Type;
-                    util::Optional<ErrorType> error;
-
-                    const Property *origin_property = it->property_for_name(prop.link_origin_property_name);
-                    if (!origin_property) {
-                        error = ErrorType::OriginPropertyDoesNotExist;
-                    }
-                    else if (origin_property->type != PropertyType::Object && origin_property->type != PropertyType::Array) {
-                        error = ErrorType::OriginPropertyIsNotALink;
-                    }
-                    else if (origin_property->object_type != object.name) {
-                        error = ErrorType::OriginPropertyInvalidLinkTarget;
-                    }
-
-                    if (error) {
-                        exceptions.emplace_back(InvalidLinkingObjectsPropertyException(*error, object.name, prop));
-                    }
-                }
-            }
-
-            // check nullablity
-            if (prop.is_nullable) {
-                if (prop.type == PropertyType::Array || prop.type == PropertyType::Any || prop.type == PropertyType::LinkingObjects) {
-                    exceptions.emplace_back(InvalidNullabilityException(object.name, prop));
-                }
-            }
-            else if (prop.type == PropertyType::Object) {
-                exceptions.emplace_back(InvalidNullabilityException(object.name, prop));
-            }
-
-            // check primary keys
-            if (prop.is_primary) {
-                if (primary) {
-                    exceptions.emplace_back(DuplicatePrimaryKeysException(object.name));
-                }
-                primary = &prop;
-            }
-
-            // check indexable
-            if (prop.is_indexed && !prop.is_indexable()) {
-                exceptions.emplace_back(PropertyTypeNotIndexableException(object.name, prop));
-            }
-        }
+        object.validate(*this, exceptions);
     }
 
     if (exceptions.size()) {
         throw SchemaValidationException(exceptions);
     }
 }
+
+static void compare(ObjectSchema const& existing_schema,
+                    ObjectSchema const& target_schema,
+                    std::vector<SchemaChange>& changes)
+{
+    for (auto& current_prop : existing_schema.persisted_properties) {
+        auto target_prop = target_schema.property_for_name(current_prop.name);
+
+        if (!target_prop) {
+            changes.emplace_back(schema_change::RemoveProperty{&existing_schema, &current_prop});
+            continue;
+        }
+        if (current_prop.type != target_prop->type || current_prop.object_type != target_prop->object_type) {
+            changes.emplace_back(schema_change::ChangePropertyType{&existing_schema, &current_prop, target_prop});
+            continue;
+        }
+        if (current_prop.is_nullable != target_prop->is_nullable) {
+            if (current_prop.is_nullable)
+                changes.emplace_back(schema_change::MakePropertyRequired{&existing_schema, &current_prop});
+            else
+                changes.emplace_back(schema_change::MakePropertyNullable{&existing_schema, &current_prop});
+        }
+        if (target_prop->requires_index()) {
+            if (!current_prop.is_indexed)
+                changes.emplace_back(schema_change::AddIndex{&existing_schema, &current_prop});
+        }
+        else if (current_prop.requires_index()) {
+            changes.emplace_back(schema_change::RemoveIndex{&existing_schema, &current_prop});
+        }
+    }
+
+    if (existing_schema.primary_key != target_schema.primary_key) {
+        changes.emplace_back(schema_change::ChangePrimaryKey{&existing_schema, target_schema.primary_key_property()});
+    }
+
+    for (auto& target_prop : target_schema.persisted_properties) {
+        if (!existing_schema.property_for_name(target_prop.name)) {
+            changes.emplace_back(schema_change::AddProperty{&existing_schema, &target_prop});
+        }
+    }
+}
+
+std::vector<SchemaChange> Schema::compare(Schema const& target_schema) const
+{
+    std::vector<SchemaChange> changes;
+    for (auto &object_schema : target_schema) {
+        auto matching_schema = find(object_schema);
+        if (matching_schema == end()) {
+            changes.emplace_back(schema_change::AddTable{&object_schema});
+            continue;
+        }
+
+        ::compare(*matching_schema, object_schema, changes);
+    }
+    return changes;
+}
+
+void Schema::copy_table_columns_from(realm::Schema const& other)
+{
+    for (auto& source_schema : other) {
+        auto matching_schema = find(source_schema);
+        if (matching_schema == end()) {
+            continue;
+        }
+
+        for (auto& current_prop : source_schema.persisted_properties) {
+            auto target_prop = matching_schema->property_for_name(current_prop.name);
+            if (target_prop) {
+                target_prop->table_column = current_prop.table_column;
+            }
+        }
+    }
+}
+
+namespace realm {
+bool operator==(SchemaChange const& lft, SchemaChange const& rgt)
+{
+    if (lft.m_kind != rgt.m_kind)
+        return false;
+
+    using namespace schema_change;
+    struct Visitor {
+        SchemaChange const& value;
+
+        #define REALM_SC_COMPARE(type, ...) \
+            bool operator()(type rgt) const \
+            { \
+                auto cmp = [](auto&& v) { return std::tie(__VA_ARGS__); }; \
+                return cmp(value.type) == cmp(rgt); \
+            }
+
+        REALM_SC_COMPARE(AddIndex, v.object, v.property)
+        REALM_SC_COMPARE(AddProperty, v.object, v.property)
+        REALM_SC_COMPARE(AddTable, v.object)
+        REALM_SC_COMPARE(ChangePrimaryKey, v.object, v.property)
+        REALM_SC_COMPARE(ChangePropertyType, v.object, v.old_property, v.new_property)
+        REALM_SC_COMPARE(MakePropertyNullable, v.object, v.property)
+        REALM_SC_COMPARE(MakePropertyRequired, v.object, v.property)
+        REALM_SC_COMPARE(RemoveIndex, v.object, v.property)
+        REALM_SC_COMPARE(RemoveProperty, v.object, v.property)
+
+        #undef REALM_SC_COMPARE
+    } visitor{lft};
+    return rgt.visit(visitor);
+}
+} // namespace realm

--- a/src/schema.hpp
+++ b/src/schema.hpp
@@ -23,15 +23,24 @@
 #include <vector>
 
 namespace realm {
+class SchemaChange;
 class ObjectSchema;
+struct Property;
 
 class Schema : private std::vector<ObjectSchema> {
 private:
     using base = std::vector<ObjectSchema>;
 public:
+    Schema();
+    ~Schema();
     // Create a schema from a vector of ObjectSchema
     Schema(base types);
     Schema(std::initializer_list<ObjectSchema> types);
+
+    Schema(Schema const&);
+    Schema(Schema &&);
+    Schema& operator=(Schema const&);
+    Schema& operator=(Schema&&);
 
     // find an ObjectSchema by name
     iterator find(std::string const& name);
@@ -45,6 +54,13 @@ public:
     // valid, links link to types that actually exist, etc.)
     void validate() const;
 
+    // Get the changes which must be applied to this schema to produce the passed-in schema
+    std::vector<SchemaChange> compare(Schema const&) const;
+
+    void copy_table_columns_from(Schema const&);
+
+    friend bool operator==(Schema const&, Schema const&);
+
     using base::iterator;
     using base::const_iterator;
     using base::begin;
@@ -52,6 +68,97 @@ public:
     using base::empty;
     using base::size;
 };
+
+namespace schema_change {
+    struct AddTable {
+        const ObjectSchema* object;
+    };
+
+    struct AddProperty {
+        const ObjectSchema* object;
+        const Property* property;
+    };
+
+    struct RemoveProperty {
+        const ObjectSchema* object;
+        const Property* property;
+    };
+
+    struct ChangePropertyType {
+        const ObjectSchema* object;
+        const Property* old_property;
+        const Property* new_property;
+    };
+
+    struct MakePropertyNullable {
+        const ObjectSchema* object;
+        const Property* property;
+    };
+
+    struct MakePropertyRequired {
+        const ObjectSchema* object;
+        const Property* property;
+    };
+
+    struct AddIndex {
+        const ObjectSchema* object;
+        const Property* property;
+    };
+
+    struct RemoveIndex {
+        const ObjectSchema* object;
+        const Property* property;
+    };
+
+    struct ChangePrimaryKey {
+        const ObjectSchema* object;
+        const Property* property;
+    };
+}
+
+#define REALM_FOR_EACH_SCHEMA_CHANGE_TYPE(macro) \
+    macro(AddTable) \
+    macro(AddProperty) \
+    macro(RemoveProperty) \
+    macro(ChangePropertyType) \
+    macro(MakePropertyNullable) \
+    macro(MakePropertyRequired) \
+    macro(AddIndex) \
+    macro(RemoveIndex) \
+    macro(ChangePrimaryKey) \
+
+class SchemaChange {
+public:
+#define REALM_SCHEMA_CHANGE_CONSTRUCTOR(name) \
+    SchemaChange(schema_change::name value) : m_kind(Kind::name) { name = value; }
+        REALM_FOR_EACH_SCHEMA_CHANGE_TYPE(REALM_SCHEMA_CHANGE_CONSTRUCTOR)
+#undef REALM_SCHEMA_CHANGE_CONSTRUCTOR
+
+    template<typename Visitor>
+    auto visit(Visitor&& visitor) const {
+        switch (m_kind) {
+#define REALM_SWITCH_CASE(name) case Kind::name: return visitor(name);
+        REALM_FOR_EACH_SCHEMA_CHANGE_TYPE(REALM_SWITCH_CASE)
+#undef REALM_SWITCH_CASE
+        }
+    }
+
+    friend bool operator==(SchemaChange const& lft, SchemaChange const& rgt);
+private:
+    enum class Kind {
+#define REALM_SCHEMA_CHANGE_TYPE(name) name,
+        REALM_FOR_EACH_SCHEMA_CHANGE_TYPE(REALM_SCHEMA_CHANGE_TYPE)
+#undef REALM_SCHEMA_CHANGE_TYPE
+
+    } m_kind;
+    union {
+#define REALM_DEFINE_FIELD(name) schema_change::name name;
+        REALM_FOR_EACH_SCHEMA_CHANGE_TYPE(REALM_DEFINE_FIELD)
+#undef REALM_DEFINE_FIELD
+    };
+};
+
+#undef REALM_FOR_EACH_SCHEMA_CHANGE_TYPE
 }
 
 #endif /* defined(REALM_SCHEMA_HPP) */

--- a/src/schema.hpp
+++ b/src/schema.hpp
@@ -141,6 +141,7 @@ public:
         REALM_FOR_EACH_SCHEMA_CHANGE_TYPE(REALM_SWITCH_CASE)
 #undef REALM_SWITCH_CASE
         }
+        __builtin_unreachable();
     }
 
     friend bool operator==(SchemaChange const& lft, SchemaChange const& rgt);

--- a/src/schema.hpp
+++ b/src/schema.hpp
@@ -70,50 +70,50 @@ public:
 };
 
 namespace schema_change {
-    struct AddTable {
-        const ObjectSchema* object;
-    };
+struct AddTable {
+    const ObjectSchema* object;
+};
 
-    struct AddProperty {
-        const ObjectSchema* object;
-        const Property* property;
-    };
+struct AddProperty {
+    const ObjectSchema* object;
+    const Property* property;
+};
 
-    struct RemoveProperty {
-        const ObjectSchema* object;
-        const Property* property;
-    };
+struct RemoveProperty {
+    const ObjectSchema* object;
+    const Property* property;
+};
 
-    struct ChangePropertyType {
-        const ObjectSchema* object;
-        const Property* old_property;
-        const Property* new_property;
-    };
+struct ChangePropertyType {
+    const ObjectSchema* object;
+    const Property* old_property;
+    const Property* new_property;
+};
 
-    struct MakePropertyNullable {
-        const ObjectSchema* object;
-        const Property* property;
-    };
+struct MakePropertyNullable {
+    const ObjectSchema* object;
+    const Property* property;
+};
 
-    struct MakePropertyRequired {
-        const ObjectSchema* object;
-        const Property* property;
-    };
+struct MakePropertyRequired {
+    const ObjectSchema* object;
+    const Property* property;
+};
 
-    struct AddIndex {
-        const ObjectSchema* object;
-        const Property* property;
-    };
+struct AddIndex {
+    const ObjectSchema* object;
+    const Property* property;
+};
 
-    struct RemoveIndex {
-        const ObjectSchema* object;
-        const Property* property;
-    };
+struct RemoveIndex {
+    const ObjectSchema* object;
+    const Property* property;
+};
 
-    struct ChangePrimaryKey {
-        const ObjectSchema* object;
-        const Property* property;
-    };
+struct ChangePrimaryKey {
+    const ObjectSchema* object;
+    const Property* property;
+};
 }
 
 #define REALM_FOR_EACH_SCHEMA_CHANGE_TYPE(macro) \

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -275,6 +275,7 @@ void Realm::update_schema(Schema schema, uint64_t version, MigrationFunction mig
                 }
                 return false;
         }
+        __builtin_unreachable();
     };
 
     if (no_changes_required())

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -198,7 +198,8 @@ public:
 
     ~Realm();
 
-    Realm(Config config, std::shared_ptr<_impl::RealmCoordinator> coordinator);
+    Realm(Config config);
+    void init(std::shared_ptr<_impl::RealmCoordinator> coordinator);
 
     // Expose some internal functionality to other parts of the ObjectStore
     // without making it public to everyone
@@ -224,7 +225,7 @@ public:
                                  std::unique_ptr<Group>& read_only_group,
                                  Realm* realm);
 
-  private:
+private:
     Config m_config;
     std::thread::id m_thread_id = std::this_thread::get_id();
     bool m_auto_refresh = true;
@@ -253,7 +254,7 @@ public:
 
     void add_schema_change_handler();
 
-  public:
+public:
     std::unique_ptr<BindingContext> m_binding_context;
 
     // FIXME private

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -19,237 +19,301 @@
 #ifndef REALM_REALM_HPP
 #define REALM_REALM_HPP
 
+#include "schema.hpp"
+
+#include <realm/util/optional.hpp>
+
 #include <memory>
-#include <string>
 #include <thread>
-#include <vector>
 
 namespace realm {
-    class BinaryData;
-    class BindingContext;
-    class Group;
-    class Realm;
-    class Replication;
-    class Schema;
-    class SharedGroup;
-    class StringData;
-    typedef std::shared_ptr<Realm> SharedRealm;
-    typedef std::weak_ptr<Realm> WeakRealm;
+class BinaryData;
+class BindingContext;
+class Group;
+class Realm;
+class Replication;
+class SharedGroup;
+class StringData;
+typedef std::shared_ptr<Realm> SharedRealm;
+typedef std::weak_ptr<Realm> WeakRealm;
 
-    namespace _impl {
-        class CollectionNotifier;
-        class ListNotifier;
-        class RealmCoordinator;
-        class ResultsNotifier;
-    }
-
-    namespace util {
-        template<typename T> class Optional;
-    }
-
-    class Realm : public std::enable_shared_from_this<Realm> {
-      public:
-        typedef std::function<void(SharedRealm old_realm, SharedRealm realm)> MigrationFunction;
-
-        struct Config {
-            std::string path;
-            // User-supplied encryption key. Must be either empty or 64 bytes.
-            std::vector<char> encryption_key;
-
-            // Optional schema for the file. If nullptr, the existing schema
-            // from the file opened will be used. If present, the file will be
-            // migrated to the schema if needed.
-            std::unique_ptr<Schema> schema;
-            uint64_t schema_version;
-
-            MigrationFunction migration_function;
-
-            bool read_only = false;
-            bool in_memory = false;
-
-            // The following are intended for internal/testing purposes and
-            // should not be publicly exposed in binding APIs
-
-            // If false, always return a new Realm instance, and don't return
-            // that Realm instance for other requests for a cached Realm. Useful
-            // for dynamic Realms and for tests that need multiple instances on
-            // one thread
-            bool cache = true;
-            // Throw an exception rather than automatically upgrading the file
-            // format. Used by the browser to warn the user that it'll modify
-            // the file.
-            bool disable_format_upgrade = false;
-            // Disable the background worker thread for producing change
-            // notifications. Useful for tests for those notifications so that
-            // everything can be done deterministically on one thread, and
-            // speeds up tests that don't need notifications.
-            bool automatic_change_notifications = true;
-
-            Config();
-            Config(Config&&);
-            Config(const Config& c);
-            ~Config();
-
-            Config& operator=(Config const&);
-            Config& operator=(Config&&) = default;
-        };
-
-        // Get a cached Realm or create a new one if no cached copies exists
-        // Caching is done by path - mismatches for in_memory and read_only
-        // Config properties will raise an exception
-        // If schema/schema_version is specified, update_schema is called
-        // automatically on the realm and a migration is performed. If not
-        // specified, the schema version and schema are dynamically read from
-        // the the existing Realm.
-        static SharedRealm get_shared_realm(Config config);
-
-        // Updates a Realm to a given target schema/version creating tables and
-        // updating indexes as necessary. Uses the existing migration function
-        // on the Config, and the resulting Schema and version with updated
-        // column mappings are set on the realms config upon success.
-        void update_schema(std::unique_ptr<Schema> schema, uint64_t version);
-
-        static uint64_t get_schema_version(Config const& config);
-
-        const Config &config() const { return m_config; }
-
-        void begin_transaction();
-        void commit_transaction();
-        void cancel_transaction();
-        bool is_in_transaction() const noexcept;
-        bool is_in_read_transaction() const { return !!m_group; }
-
-        bool refresh();
-        void set_auto_refresh(bool auto_refresh) { m_auto_refresh = auto_refresh; }
-        bool auto_refresh() const { return m_auto_refresh; }
-        void notify();
-
-        void invalidate();
-        bool compact();
-        void write_copy(StringData path, BinaryData encryption_key);
-
-        std::thread::id thread_id() const { return m_thread_id; }
-        void verify_thread() const;
-        void verify_in_write() const;
-
-        bool can_deliver_notifications() const noexcept;
-
-        // Close this Realm and remove it from the cache. Continuing to use a
-        // Realm after closing it will produce undefined behavior.
-        void close();
-
-        bool is_closed() { return !m_read_only_group && !m_shared_group; }
-
-        // returns the file format version upgraded from if an upgrade took place
-        util::Optional<int> file_format_upgraded_from_version() const;
-
-        ~Realm();
-
-        void init(std::shared_ptr<_impl::RealmCoordinator> coordinator);
-        Realm(Config config);
-
-        // Expose some internal functionality to other parts of the ObjectStore
-        // without making it public to everyone
-        class Internal {
-            friend class _impl::CollectionNotifier;
-            friend class _impl::ListNotifier;
-            friend class _impl::RealmCoordinator;
-            friend class _impl::ResultsNotifier;
-
-            // ResultsNotifier and ListNotifier need access to the SharedGroup
-            // to be able to call the handover functions, which are not very wrappable
-            static SharedGroup& get_shared_group(Realm& realm) { return *realm.m_shared_group; }
-
-            // CollectionNotifier needs to be able to access the owning
-            // coordinator to wake up the worker thread when a callback is
-            // added, and coordinators need to be able to get themselves from a Realm
-            static _impl::RealmCoordinator& get_coordinator(Realm& realm) { return *realm.m_coordinator; }
-        };
-
-        static void open_with_config(const Config& config,
-                                     std::unique_ptr<Replication>& history,
-                                     std::unique_ptr<SharedGroup>& shared_group,
-                                     std::unique_ptr<Group>& read_only_group,
-                                     Realm *realm = nullptr);
-
-      private:
-        Config m_config;
-        std::thread::id m_thread_id = std::this_thread::get_id();
-        bool m_auto_refresh = true;
-
-        std::unique_ptr<Replication> m_history;
-        std::unique_ptr<SharedGroup> m_shared_group;
-        std::unique_ptr<Group> m_read_only_group;
-
-        Group *m_group = nullptr;
-
-        std::shared_ptr<_impl::RealmCoordinator> m_coordinator;
-
-        // File format versions populated when a file format upgrade takes place during realm opening
-        int upgrade_initial_version = 0, upgrade_final_version = 0;
-
-      public:
-        std::unique_ptr<BindingContext> m_binding_context;
-
-        // FIXME private
-        Group *read_group();
-    };
-
-    class RealmFileException : public std::runtime_error {
-    public:
-        enum class Kind {
-            /** Thrown for any I/O related exception scenarios when a realm is opened. */
-            AccessError,
-            /** Thrown if the user does not have permission to open or create
-             the specified file in the specified access mode when the realm is opened. */
-            PermissionDenied,
-            /** Thrown if create_Always was specified and the file did already exist when the realm is opened. */
-            Exists,
-            /** Thrown if no_create was specified and the file was not found when the realm is opened. */
-            NotFound,
-            /** Thrown if the database file is currently open in another
-             process which cannot share with the current process due to an
-             architecture mismatch. */
-            IncompatibleLockFile,
-            /** Thrown if the file needs to be upgraded to a new format, but upgrades have been explicitly disabled. */
-            FormatUpgradeRequired,
-        };
-        RealmFileException(Kind kind, std::string path, std::string message, std::string underlying) :
-            std::runtime_error(std::move(message)), m_kind(kind), m_path(std::move(path)), m_underlying(std::move(underlying)) {}
-        Kind kind() const { return m_kind; }
-        const std::string& path() const { return m_path; }
-        const std::string& underlying() const { return m_underlying; }
-
-    private:
-        Kind m_kind;
-        std::string m_path;
-        std::string m_underlying;
-    };
-
-    class MismatchedConfigException : public std::logic_error {
-    public:
-        MismatchedConfigException(StringData message, StringData path);
-    };
-
-    class InvalidTransactionException : public std::logic_error {
-    public:
-        InvalidTransactionException(std::string message) : std::logic_error(move(message)) {}
-    };
-
-    class IncorrectThreadException : public std::logic_error {
-    public:
-        IncorrectThreadException() : std::logic_error("Realm accessed from incorrect thread.") {}
-    };
-
-    class UninitializedRealmException : public std::runtime_error {
-    public:
-        UninitializedRealmException(std::string message) : std::runtime_error(move(message)) {}
-    };
-
-    class InvalidEncryptionKeyException : public std::logic_error {
-    public:
-        InvalidEncryptionKeyException() : std::logic_error("Encryption key must be 64 bytes.") {}
-    };
+namespace _impl {
+    class CollectionNotifier;
+    class ListNotifier;
+    class RealmCoordinator;
+    class ResultsNotifier;
 }
+
+// How to handle update_schema() being called on a file which has
+// already been initialized with a different schema
+enum class SchemaMode : uint8_t {
+    // If the schema version has increased, automatically apply all
+    // changes, then call the migration function.
+    //
+    // If the schema version has not changed, verify that the only
+    // changes are to add new tables and add or remvoe indexes, and then
+    // apply them if so. Does not call the migration function.
+    //
+    // This mode does not automatically remove tables which are not
+    // present in the schea; that must be manually done in the migration
+    // function, to support sharing a Realm file between processes using
+    // different class subsets.
+    //
+    // This mode allows using schemata with different subsets of tables
+    // on different threads, but the tables which are shared must be
+    // identical.
+    Automatic,
+
+    // Open the file in read-only mode. Schema version must match the
+    // version in the file, and all tables present in the file must
+    // exactly match the specified schema, except for indexes. Tables
+    // are allowed to be missing from the file.
+    ReadOnly,
+
+    // If the schema version matches and the only schema changes are new
+    // tables and indexes being added or removed, apply the changes to
+    // the existing file.
+    // Otherwise delete the file and recreate it from scratch.
+    // The migration function is not used.
+    //
+    // This mode allows using schemata with different subsets of tables
+    // on different threads, but the tables which are shared must be
+    // identical.
+    ResetFile,
+
+    // The only changes allowed are to add new tables, add columns to
+    // existing tables, and to add or remove indexes from existing
+    // columns. Extra tables not present in the schema are ignored.
+    // Indexes are only added to or removed from existing columns if the
+    // schema version is greater than the existing one (and unlike other
+    // modes, the schema version is allowed to be less than the existing
+    // one).
+    // The migration function is not used.
+    //
+    // This mode allows updating the schema with additive changes even
+    // if the Realm is already open on another thread.
+    Additive,
+
+    // Verify that the schema version has increased, call the migraiton
+    // function, and then verify that the schema now matches.
+    // The migration function is mandatory for this mode.
+    //
+    // This mode requires that all threads and processes which open a
+    // file use identical schemata.
+    //
+    // This mode is not yet implemented.
+    Manual
+};
+
+class Realm : public std::enable_shared_from_this<Realm> {
+public:
+    // A callback function to be called during a migration for Automatic and
+    // Manual schema modes. It is passed a SharedRealm at the version before
+    // the migration, the SharedRealm in the migration, and a mutable reference
+    // to the realm's Schema. Updating the schema with changes made within the
+    // migration function is only required if you wish to use the ObjectStore
+    // functions which take a Schema from within the migration function.
+    using MigrationFunction = std::function<void (SharedRealm old_realm, SharedRealm realm, Schema&)>;
+
+    struct Config {
+        std::string path;
+        // User-supplied encryption key. Must be either empty or 64 bytes.
+        std::vector<char> encryption_key;
+
+        bool in_memory = false;
+        SchemaMode schema_mode = SchemaMode::Automatic;
+
+        // Optional schema for the file.
+        // If the schema and schema version are supplied, update_schema() is
+        // called with the supplied schema, version and migration function when
+        // the Realm is actually opened and not just retreived from the cache
+        util::Optional<Schema> schema;
+        uint64_t schema_version = -1;
+        MigrationFunction migration_function;
+
+        bool read_only() const { return schema_mode == SchemaMode::ReadOnly; }
+
+        // The following are intended for internal/testing purposes and
+        // should not be publicly exposed in binding APIs
+
+        // If false, always return a new Realm instance, and don't return
+        // that Realm instance for other requests for a cached Realm. Useful
+        // for dynamic Realms and for tests that need multiple instances on
+        // one thread
+        bool cache = true;
+        // Throw an exception rather than automatically upgrading the file
+        // format. Used by the browser to warn the user that it'll modify
+        // the file.
+        bool disable_format_upgrade = false;
+        // Disable the background worker thread for producing change
+        // notifications. Useful for tests for those notifications so that
+        // everything can be done deterministically on one thread, and
+        // speeds up tests that don't need notifications.
+        bool automatic_change_notifications = true;
+    };
+
+    // Get a cached Realm or create a new one if no cached copies exists
+    // Caching is done by path - mismatches for in_memory, schema mode or
+    // encryption key will raise an exception.
+    static SharedRealm get_shared_realm(Config config);
+
+    // Updates a Realm to a given schema, using the Realm's pre-set schema mode.
+    void update_schema(Schema schema, uint64_t version=0,
+                       MigrationFunction migration_function=nullptr);
+
+    // Read the schema version from the file specified by the given config, or
+    // ObjectStore::NotVersioned if it does not exist
+    static uint64_t get_schema_version(Config const& config);
+
+    Config const& config() const { return m_config; }
+    Schema const& schema() const { return m_schema; }
+    uint64_t schema_version() const { return m_schema_version; }
+
+    void begin_transaction();
+    void commit_transaction();
+    void cancel_transaction();
+    bool is_in_transaction() const noexcept;
+    bool is_in_read_transaction() const { return !!m_group; }
+
+    bool refresh();
+    void set_auto_refresh(bool auto_refresh) { m_auto_refresh = auto_refresh; }
+    bool auto_refresh() const { return m_auto_refresh; }
+    void notify();
+
+    void invalidate();
+    bool compact();
+    void write_copy(StringData path, BinaryData encryption_key);
+
+    std::thread::id thread_id() const { return m_thread_id; }
+    void verify_thread() const;
+    void verify_in_write() const;
+
+    bool can_deliver_notifications() const noexcept;
+
+    // Close this Realm and remove it from the cache. Continuing to use a
+    // Realm after closing it will produce undefined behavior.
+    void close();
+    bool is_closed() { return !m_read_only_group && !m_shared_group; }
+
+    // returns the file format version upgraded from if an upgrade took place
+    util::Optional<int> file_format_upgraded_from_version() const;
+
+    ~Realm();
+
+    Realm(Config config, std::shared_ptr<_impl::RealmCoordinator> coordinator);
+
+    // Expose some internal functionality to other parts of the ObjectStore
+    // without making it public to everyone
+    class Internal {
+        friend class _impl::CollectionNotifier;
+        friend class _impl::ListNotifier;
+        friend class _impl::RealmCoordinator;
+        friend class _impl::ResultsNotifier;
+
+        // ResultsNotifier and ListNotifier need access to the SharedGroup
+        // to be able to call the handover functions, which are not very wrappable
+        static SharedGroup& get_shared_group(Realm& realm) { return *realm.m_shared_group; }
+
+        // CollectionNotifier needs to be able to access the owning
+        // coordinator to wake up the worker thread when a callback is
+        // added, and coordinators need to be able to get themselves from a Realm
+        static _impl::RealmCoordinator& get_coordinator(Realm& realm) { return *realm.m_coordinator; }
+    };
+
+    static void open_with_config(const Config& config,
+                                 std::unique_ptr<Replication>& history,
+                                 std::unique_ptr<SharedGroup>& shared_group,
+                                 std::unique_ptr<Group>& read_only_group,
+                                 Realm* realm);
+
+  private:
+    Config m_config;
+    std::thread::id m_thread_id = std::this_thread::get_id();
+    bool m_auto_refresh = true;
+
+    std::unique_ptr<Replication> m_history;
+    std::unique_ptr<SharedGroup> m_shared_group;
+    std::unique_ptr<Group> m_read_only_group;
+
+    Group *m_group = nullptr;
+
+    uint64_t m_schema_version;
+    Schema m_schema;
+    uint64_t m_schema_transaction_version = -1;
+
+    std::shared_ptr<_impl::RealmCoordinator> m_coordinator;
+
+    // File format versions populated when a file format upgrade takes place during realm opening
+    int upgrade_initial_version = 0, upgrade_final_version = 0;
+
+    void set_schema(Schema schema, uint64_t version);
+
+    // Ensure that m_schema nd m_schema_version match that of the current version
+    // of the file, and return true if it changed
+    bool update_schema_if_needed();
+
+  public:
+    std::unique_ptr<BindingContext> m_binding_context;
+
+    // FIXME private
+    Group& read_group();
+};
+
+class RealmFileException : public std::runtime_error {
+public:
+    enum class Kind {
+        /** Thrown for any I/O related exception scenarios when a realm is opened. */
+        AccessError,
+        /** Thrown if the user does not have permission to open or create
+         the specified file in the specified access mode when the realm is opened. */
+        PermissionDenied,
+        /** Thrown if create_Always was specified and the file did already exist when the realm is opened. */
+        Exists,
+        /** Thrown if no_create was specified and the file was not found when the realm is opened. */
+        NotFound,
+        /** Thrown if the database file is currently open in another
+         process which cannot share with the current process due to an
+         architecture mismatch. */
+        IncompatibleLockFile,
+        /** Thrown if the file needs to be upgraded to a new format, but upgrades have been explicitly disabled. */
+        FormatUpgradeRequired,
+    };
+    RealmFileException(Kind kind, std::string path, std::string message, std::string underlying)
+    : std::runtime_error(std::move(message)), m_kind(kind), m_path(std::move(path)), m_underlying(std::move(underlying)) {}
+    Kind kind() const { return m_kind; }
+    const std::string& path() const { return m_path; }
+    const std::string& underlying() const { return m_underlying; }
+
+private:
+    Kind m_kind;
+    std::string m_path;
+    std::string m_underlying;
+};
+
+class MismatchedConfigException : public std::logic_error {
+public:
+    MismatchedConfigException(StringData message, StringData path);
+};
+
+class InvalidTransactionException : public std::logic_error {
+public:
+    InvalidTransactionException(std::string message) : std::logic_error(message) {}
+};
+
+class IncorrectThreadException : public std::logic_error {
+public:
+    IncorrectThreadException() : std::logic_error("Realm accessed from incorrect thread.") {}
+};
+
+class UninitializedRealmException : public std::runtime_error {
+public:
+    UninitializedRealmException(std::string message) : std::runtime_error(message) {}
+};
+
+class InvalidEncryptionKeyException : public std::logic_error {
+public:
+    InvalidEncryptionKeyException() : std::logic_error("Encryption key must be 64 bytes.") {}
+};
+} // namespace realm
 
 #endif /* defined(REALM_REALM_HPP) */

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -247,6 +247,7 @@ public:
     int upgrade_initial_version = 0, upgrade_final_version = 0;
 
     void set_schema(Schema schema, uint64_t version);
+    void reset_file_if_needed(Schema const& schema, uint64_t version, std::vector<SchemaChange>& changes_required);
 
     // Ensure that m_schema nd m_schema_version match that of the current version
     // of the file, and return true if it changed

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -247,9 +247,9 @@ public:
     void set_schema(Schema schema, uint64_t version);
     void reset_file_if_needed(Schema const& schema, uint64_t version, std::vector<SchemaChange>& changes_required);
 
-    // Ensure that m_schema nd m_schema_version match that of the current version
-    // of the file, and return true if it changed
-    bool update_schema_if_needed();
+    // Ensure that m_schema and m_schema_version match that of the current
+    // version of the file, and return true if it changed
+    bool read_schema_from_group_if_needed();
 
   public:
     std::unique_ptr<BindingContext> m_binding_context;

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -100,8 +100,6 @@ enum class SchemaMode : uint8_t {
     //
     // This mode requires that all threads and processes which open a
     // file use identical schemata.
-    //
-    // This mode is not yet implemented.
     Manual
 };
 

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -251,6 +251,8 @@ public:
     // version of the file, and return true if it changed
     bool read_schema_from_group_if_needed();
 
+    void add_schema_change_handler();
+
   public:
     std::unique_ptr<BindingContext> m_binding_context;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,8 +10,10 @@ set(SOURCES
     index_set.cpp
     list.cpp
     main.cpp
+    migrations.cpp
     parser.cpp
     results.cpp
+    schema.cpp
     transaction_log_parsing.cpp
     util/test_file.cpp
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ set(SOURCES
     main.cpp
     migrations.cpp
     parser.cpp
+    realm.cpp
     results.cpp
     schema.cpp
     transaction_log_parsing.cpp

--- a/tests/collection_change_indices.cpp
+++ b/tests/collection_change_indices.cpp
@@ -26,7 +26,7 @@
 
 using namespace realm;
 
-TEST_CASE("[collection_change] insert()") {
+TEST_CASE("collection_change: insert()") {
     _impl::CollectionChangeBuilder c;
 
     SECTION("adds the row to the insertions set") {
@@ -60,7 +60,7 @@ TEST_CASE("[collection_change] insert()") {
     }
 }
 
-TEST_CASE("[collection_change] modify()") {
+TEST_CASE("collection_change: modify()") {
     _impl::CollectionChangeBuilder c;
 
     SECTION("marks the row as modified") {
@@ -83,7 +83,7 @@ TEST_CASE("[collection_change] modify()") {
     }
 }
 
-TEST_CASE("[collection_change] erase()") {
+TEST_CASE("collection_change: erase()") {
     _impl::CollectionChangeBuilder c;
 
     SECTION("adds the row to the deletions set") {
@@ -137,7 +137,7 @@ TEST_CASE("[collection_change] erase()") {
     }
 }
 
-TEST_CASE("[collection_change] move_over()") {
+TEST_CASE("collection_change: move_over()") {
     _impl::CollectionChangeBuilder c;
 
     SECTION("is just erase when row == last_row") {
@@ -240,7 +240,7 @@ TEST_CASE("[collection_change] move_over()") {
     }
 }
 
-TEST_CASE("[collection_change] clear()") {
+TEST_CASE("collection_change: clear()") {
     _impl::CollectionChangeBuilder c;
 
     SECTION("removes all insertions") {
@@ -281,7 +281,7 @@ TEST_CASE("[collection_change] clear()") {
     }
 }
 
-TEST_CASE("[collection_change] move()") {
+TEST_CASE("collection_change: move()") {
     _impl::CollectionChangeBuilder c;
 
     SECTION("adds the move to the list of moves") {
@@ -349,7 +349,7 @@ TEST_CASE("[collection_change] move()") {
     }
 }
 
-TEST_CASE("[collection_change] calculate() unsorted") {
+TEST_CASE("collection_change: calculate() unsorted") {
     _impl::CollectionChangeBuilder c;
 
     auto all_modified = [](size_t) { return true; };
@@ -440,7 +440,7 @@ TEST_CASE("[collection_change] calculate() unsorted") {
     }
 }
 
-TEST_CASE("[collection_change] calculate() sorted") {
+TEST_CASE("collection_change: calculate() sorted") {
     _impl::CollectionChangeBuilder c;
 
     auto all_modified = [](size_t) { return true; };
@@ -749,7 +749,7 @@ TEST_CASE("[collection_change] calculate() sorted") {
     }
 }
 
-TEST_CASE("[collection_change] merge()") {
+TEST_CASE("collection_change: merge()") {
     _impl::CollectionChangeBuilder c;
 
     SECTION("is a no-op if the new set is empty") {

--- a/tests/index_set.cpp
+++ b/tests/index_set.cpp
@@ -22,7 +22,7 @@
 
 #include "util/index_helpers.hpp"
 
-TEST_CASE("[index_set] contains()") {
+TEST_CASE("index_set: contains()") {
     SECTION("returns false if the index is before the first entry in the set") {
         realm::IndexSet set = {1, 2, 5};
         REQUIRE_FALSE(set.contains(0));
@@ -46,7 +46,7 @@ TEST_CASE("[index_set] contains()") {
     }
 }
 
-TEST_CASE("[index_set] count()") {
+TEST_CASE("index_set: count()") {
     SECTION("returns the number of indices in the set in the given range") {
         realm::IndexSet set = {1, 2, 3, 5};
         REQUIRE(set.count(0, 6) == 4);
@@ -91,7 +91,7 @@ TEST_CASE("[index_set] count()") {
     }
 }
 
-TEST_CASE("[index_set] add()") {
+TEST_CASE("index_set: add()") {
     realm::IndexSet set;
 
     SECTION("extends existing ranges when next to an edge") {
@@ -151,7 +151,7 @@ TEST_CASE("[index_set] add()") {
     }
 }
 
-TEST_CASE("[index_set] add_shifted()") {
+TEST_CASE("index_set: add_shifted()") {
     realm::IndexSet set;
 
     SECTION("on an empty set is just add()") {
@@ -198,7 +198,7 @@ TEST_CASE("[index_set] add_shifted()") {
     }
 }
 
-TEST_CASE("[index_set] add_shifted_by()") {
+TEST_CASE("index_set: add_shifted_by()") {
     realm::IndexSet set;
 
     SECTION("does nothing given an empty set to add") {
@@ -248,7 +248,7 @@ TEST_CASE("[index_set] add_shifted_by()") {
     }
 }
 
-TEST_CASE("[index_set] set()") {
+TEST_CASE("index_set: set()") {
     realm::IndexSet set;
 
     SECTION("clears the existing indices and replaces with the range [0, value)") {
@@ -258,7 +258,7 @@ TEST_CASE("[index_set] set()") {
     }
 }
 
-TEST_CASE("[index_set] insert_at()") {
+TEST_CASE("index_set: insert_at()") {
     realm::IndexSet set;
 
     SECTION("on an empty set is add()") {
@@ -322,7 +322,7 @@ TEST_CASE("[index_set] insert_at()") {
     }
 }
 
-TEST_CASE("[index_set] shift_for_insert_at()") {
+TEST_CASE("index_set: shift_for_insert_at()") {
     realm::IndexSet set;
 
     SECTION("does nothing given an empty set of insertion points") {
@@ -389,7 +389,7 @@ TEST_CASE("[index_set] shift_for_insert_at()") {
     }
 }
 
-TEST_CASE("[index_set] erase_at()") {
+TEST_CASE("index_set: erase_at()") {
     realm::IndexSet set;
 
     SECTION("is a no-op on an empty set") {
@@ -469,7 +469,7 @@ TEST_CASE("[index_set] erase_at()") {
     }
 }
 
-TEST_CASE("[index_set] erase_or_unshift()") {
+TEST_CASE("index_set: erase_or_unshift()") {
     realm::IndexSet set;
 
     SECTION("removes the given index") {
@@ -501,7 +501,7 @@ TEST_CASE("[index_set] erase_or_unshift()") {
 
 }
 
-TEST_CASE("[index_set] remove()") {
+TEST_CASE("index_set: remove()") {
     realm::IndexSet set;
 
     SECTION("is a no-op if the set is empty") {
@@ -573,7 +573,7 @@ TEST_CASE("[index_set] remove()") {
     }
 }
 
-TEST_CASE("[index_set] shift()") {
+TEST_CASE("index_set: shift()") {
     realm::IndexSet set;
 
     SECTION("is ind + count(0, ind), but adds the count-so-far to the stop index") {
@@ -586,7 +586,7 @@ TEST_CASE("[index_set] shift()") {
     }
 }
 
-TEST_CASE("[index_set] unshift()") {
+TEST_CASE("index_set: unshift()") {
     realm::IndexSet set;
 
     SECTION("is index - count(0, index)") {
@@ -599,7 +599,7 @@ TEST_CASE("[index_set] unshift()") {
     }
 }
 
-TEST_CASE("[index_set] clear()") {
+TEST_CASE("index_set: clear()") {
     realm::IndexSet set;
 
     SECTION("removes all indices from the set") {

--- a/tests/list.cpp
+++ b/tests/list.cpp
@@ -40,26 +40,26 @@ TEST_CASE("list") {
     InMemoryTestFile config;
     config.automatic_change_notifications = false;
     config.cache = false;
-    config.schema = std::make_unique<Schema>(Schema{
-        {"origin", "", {
+    auto r = Realm::get_shared_realm(config);
+    r->update_schema({
+        {"origin", {
             {"array", PropertyType::Array, "target"}
         }},
-        {"target", "", {
+        {"target", {
             {"value", PropertyType::Int}
         }},
-        {"other_origin", "", {
+        {"other_origin", {
             {"array", PropertyType::Array, "other_target"}
         }},
-        {"other_target", "", {
+        {"other_target", {
             {"value", PropertyType::Int}
         }},
     });
 
-    auto r = Realm::get_shared_realm(config);
     auto& coordinator = *_impl::RealmCoordinator::get_existing_coordinator(config.path);
 
-    auto origin = r->read_group()->get_table("class_origin");
-    auto target = r->read_group()->get_table("class_target");
+    auto origin = r->read_group().get_table("class_origin");
+    auto target = r->read_group().get_table("class_target");
 
     r->begin_transaction();
 
@@ -207,7 +207,7 @@ TEST_CASE("list") {
 
             auto get_list = [&] {
                 auto r = Realm::get_shared_realm(config);
-                auto lv = r->read_group()->get_table("class_origin")->get_linklist(0, 0);
+                auto lv = r->read_group().get_table("class_origin")->get_linklist(0, 0);
                 return List(r, lv);
             };
             auto change_list = [&] {
@@ -258,8 +258,8 @@ TEST_CASE("list") {
         }
 
         SECTION("tables-of-interest are tracked properly for multiple source versions") {
-            auto other_origin = r->read_group()->get_table("class_other_origin");
-            auto other_target = r->read_group()->get_table("class_other_target");
+            auto other_origin = r->read_group().get_table("class_other_origin");
+            auto other_target = r->read_group().get_table("class_other_target");
 
             r->begin_transaction();
             other_target->add_empty_row();
@@ -438,7 +438,7 @@ TEST_CASE("list") {
     }
 
     SECTION("sort()") {
-        auto objectschema = &*r->config().schema->find("target");
+        auto objectschema = &*r->schema().find("target");
         List list(r, lv);
         auto results = list.sort({{0}, {false}});
 
@@ -453,7 +453,7 @@ TEST_CASE("list") {
     }
 
     SECTION("filter()") {
-        auto objectschema = &*r->config().schema->find("target");
+        auto objectschema = &*r->schema().find("target");
         List list(r, lv);
         auto results = list.filter(target->where().greater(0, 5));
 
@@ -467,7 +467,7 @@ TEST_CASE("list") {
     }
 
     SECTION("snapshot()") {
-        auto objectschema = &*r->config().schema->find("target");
+        auto objectschema = &*r->schema().find("target");
         List list(r, lv);
 
         auto snapshot = list.snapshot();
@@ -499,7 +499,7 @@ TEST_CASE("list") {
 
     SECTION("get_object_schema()") {
         List list(r, lv);
-        auto objectschema = &*r->config().schema->find("target");
+        auto objectschema = &*r->schema().find("target");
         REQUIRE(&list.get_object_schema() == objectschema);
     }
 }

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -1,0 +1,664 @@
+#include "catch.hpp"
+
+#include "util/test_file.hpp"
+
+#include "object_schema.hpp"
+#include "object_store.hpp"
+#include "property.hpp"
+#include "schema.hpp"
+
+#include <realm/group.hpp>
+#include <realm/table.hpp>
+
+using namespace realm;
+
+#define VERIFY_SCHEMA(r) do { \
+    for (auto&& object_schema : (r).schema()) { \
+        auto table = ObjectStore::table_for_object_type((r).read_group(), object_schema.name); \
+        REQUIRE(table); \
+        CAPTURE(object_schema.name) \
+        for (auto&& prop : object_schema.persisted_properties) { \
+            size_t col = table->get_column_index(prop.name); \
+            CAPTURE(prop.name) \
+            REQUIRE(col != npos); \
+            REQUIRE(col == prop.table_column); \
+            REQUIRE(table->get_column_type(col) == static_cast<int>(prop.type)); \
+            REQUIRE(table->has_search_index(col) == prop.requires_index()); \
+        } \
+    } \
+} while (0)
+
+#define REQUIRE_UPDATE_SUCCEEDS(r, s, version) do { \
+    REQUIRE_NOTHROW((r).update_schema(s, version)); \
+    VERIFY_SCHEMA(r); \
+    REQUIRE((r).schema() == s); \
+} while (0)
+
+#define REQUIRE_NO_MIGRATION_NEEDED(r, schema1, schema2) do { \
+    REQUIRE_UPDATE_SUCCEEDS(r, schema1, 0); \
+    REQUIRE_UPDATE_SUCCEEDS(r, schema2, 0); \
+} while (0)
+
+#define REQUIRE_MIGRATION_NEEDED(r, schema1, schema2) do { \
+    REQUIRE_UPDATE_SUCCEEDS(r, schema1, 0); \
+    REQUIRE_THROWS((r).update_schema(schema2)); \
+    REQUIRE((r).schema() == schema1); \
+    REQUIRE_UPDATE_SUCCEEDS(r, schema2, 1); \
+} while (0)
+
+namespace {
+// Helper functions for modifying Schema objects, mostly for the sake of making
+// it clear what exactly is different about the 2+ schema objects used in
+// various tests
+Schema add_table(Schema const& schema, ObjectSchema object_schema)
+{
+    std::vector<ObjectSchema> new_schema(schema.begin(), schema.end());
+    new_schema.push_back(std::move(object_schema));
+    return new_schema;
+}
+
+Schema remove_table(Schema const& schema, StringData object_name)
+{
+    std::vector<ObjectSchema> new_schema;
+    std::remove_copy_if(schema.begin(), schema.end(), std::back_inserter(new_schema),
+                        [&](auto&& object_schema) { return object_schema.name == object_name; });
+    return new_schema;
+}
+
+Schema add_property(Schema schema, StringData object_name, Property property)
+{
+    schema.find(object_name)->persisted_properties.push_back(std::move(property));
+    return schema;
+}
+
+Schema remove_property(Schema schema, StringData object_name, StringData property_name)
+{
+    auto& properties = schema.find(object_name)->persisted_properties;
+    properties.erase(find_if(begin(properties), end(properties),
+                             [&](auto&& prop) { return prop.name == property_name; }));
+    return schema;
+}
+
+Schema set_indexed(Schema schema, StringData object_name, StringData property_name, bool value)
+{
+    schema.find(object_name)->property_for_name(property_name)->is_indexed = value;
+    return schema;
+}
+
+Schema set_optional(Schema schema, StringData object_name, StringData property_name, bool value)
+{
+    schema.find(object_name)->property_for_name(property_name)->is_nullable = value;
+    return schema;
+}
+
+Schema set_type(Schema schema, StringData object_name, StringData property_name, PropertyType value)
+{
+    schema.find(object_name)->property_for_name(property_name)->type = value;
+    return schema;
+}
+
+Schema set_target(Schema schema, StringData object_name, StringData property_name, StringData new_target)
+{
+    schema.find(object_name)->property_for_name(property_name)->object_type = new_target;
+    return schema;
+}
+
+Schema set_primary_key(Schema schema, StringData object_name, StringData new_primary_property)
+{
+    auto& object_schema = *schema.find(object_name);
+    if (auto old_primary = object_schema.primary_key_property()) {
+        old_primary->is_primary = false;
+    }
+    if (new_primary_property.size()) {
+        object_schema.property_for_name(new_primary_property)->is_primary = true;
+    }
+    object_schema.primary_key = new_primary_property;
+    return schema;
+}
+} // anonymous namespace
+
+TEST_CASE("[migration] Automatic") {
+    InMemoryTestFile config;
+    config.automatic_change_notifications = false;
+
+    SECTION("no migration required") {
+        SECTION("add object schema") {
+            auto realm = Realm::get_shared_realm(config);
+
+            Schema schema1 = {};
+            Schema schema2 = add_table(schema1, {"object", {
+                {"value", PropertyType::Int, "", "", false, false, false}
+            }});
+            Schema schema3 = add_table(schema2, {"object2", {
+                {"value", PropertyType::Int, "", "", false, false, false}
+            }});
+            REQUIRE_UPDATE_SUCCEEDS(*realm, schema1, 0);
+            REQUIRE_UPDATE_SUCCEEDS(*realm, schema2, 0);
+            REQUIRE_UPDATE_SUCCEEDS(*realm, schema3, 0);
+        }
+
+        SECTION("remove object schema") {
+            auto realm = Realm::get_shared_realm(config);
+
+            Schema schema1 = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false}
+                }},
+                {"object2", {
+                    {"value", PropertyType::Int, "", "", false, false, false}
+                }},
+            };
+            Schema schema2 = remove_table(schema1, "object2");
+            Schema schema3 = remove_table(schema2, "object");
+            REQUIRE_UPDATE_SUCCEEDS(*realm, schema3, 0);
+            REQUIRE_UPDATE_SUCCEEDS(*realm, schema2, 0);
+            REQUIRE_UPDATE_SUCCEEDS(*realm, schema1, 0);
+        }
+
+        SECTION("add index") {
+            auto realm = Realm::get_shared_realm(config);
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false}
+                }},
+            };
+            REQUIRE_NO_MIGRATION_NEEDED(*realm, schema, set_indexed(schema, "object", "value", true));
+        }
+
+        SECTION("remove index") {
+            auto realm = Realm::get_shared_realm(config);
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, true, false}
+                }},
+            };
+            REQUIRE_NO_MIGRATION_NEEDED(*realm, schema, set_indexed(schema, "object", "value", false));
+        }
+
+        SECTION("reordering properties") {
+            auto realm = Realm::get_shared_realm(config);
+
+            Schema schema1 = {
+                {"object", {
+                    {"col1", PropertyType::Int, "", "", false, false, false},
+                    {"col2", PropertyType::Int, "", "", false, false, false},
+                }},
+            };
+            Schema schema2 = {
+                {"object", {
+                    {"col2", PropertyType::Int, "", "", false, false, false},
+                    {"col1", PropertyType::Int, "", "", false, false, false},
+                }},
+            };
+            REQUIRE_NO_MIGRATION_NEEDED(*realm, schema1, schema2);
+        }
+    }
+
+    SECTION("migration required") {
+        SECTION("add property to existing object schema") {
+            auto realm = Realm::get_shared_realm(config);
+
+            Schema schema1 = {
+                {"object", {
+                    {"col1", PropertyType::Int, "", "", false, false, false},
+                }},
+            };
+            auto schema2 = add_property(schema1, "object",
+                                        {"col2", PropertyType::Int, "", "", false, false, false});
+            REQUIRE_MIGRATION_NEEDED(*realm, schema1, schema2);
+        }
+
+        SECTION("remove property from existing object schema") {
+            auto realm = Realm::get_shared_realm(config);
+            Schema schema = {
+                {"object", {
+                    {"col1", PropertyType::Int, "", "", false, false, false},
+                    {"col2", PropertyType::Int, "", "", false, false, false},
+                }},
+            };
+            REQUIRE_MIGRATION_NEEDED(*realm, schema, remove_property(schema, "object", "col2"));
+        }
+
+        SECTION("change property type") {
+            auto realm = Realm::get_shared_realm(config);
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+            };
+            REQUIRE_MIGRATION_NEEDED(*realm, schema, set_type(schema, "object", "value", PropertyType::Float));
+        }
+
+        SECTION("make property nullable") {
+            auto realm = Realm::get_shared_realm(config);
+
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+            };
+            REQUIRE_MIGRATION_NEEDED(*realm, schema, set_optional(schema, "object", "value", true));
+        }
+
+        SECTION("make property required") {
+            auto realm = Realm::get_shared_realm(config);
+
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, true},
+                }},
+            };
+            REQUIRE_MIGRATION_NEEDED(*realm, schema, set_optional(schema, "object", "value", false));
+        }
+
+        SECTION("change link target") {
+            auto realm = Realm::get_shared_realm(config);
+
+            Schema schema = {
+                {"target 1", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+                {"target 2", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+                {"origin", {
+                    {"value", PropertyType::Object, "target 1", "", false, false, true},
+                }},
+            };
+            REQUIRE_MIGRATION_NEEDED(*realm, schema, set_target(schema, "origin", "value", "target 2"));
+        }
+
+        SECTION("add pk") {
+            auto realm = Realm::get_shared_realm(config);
+
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+            };
+            REQUIRE_MIGRATION_NEEDED(*realm, schema, set_primary_key(schema, "object", "value"));
+        }
+
+        SECTION("remove pk") {
+            auto realm = Realm::get_shared_realm(config);
+
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", true, false, false},
+                }},
+            };
+            REQUIRE_MIGRATION_NEEDED(*realm, schema, set_primary_key(schema, "object", ""));
+        }
+    }
+
+    SECTION("migration block invocations") {
+        SECTION("not called for initial creation of schema") {
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+            };
+            auto realm = Realm::get_shared_realm(config);
+            realm->update_schema(schema, 5, [](SharedRealm, SharedRealm, Schema&) { REQUIRE(false); });
+        }
+
+        SECTION("not called when schema version is unchanged even if there are schema changes") {
+            Schema schema1 = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+            };
+            Schema schema2 = add_table(schema1, {"second object", {
+                {"value", PropertyType::Int, "", "", false, false, false},
+            }});
+            auto realm = Realm::get_shared_realm(config);
+            realm->update_schema(schema1, 1);
+            realm->update_schema(schema2, 1, [](SharedRealm, SharedRealm, Schema&) { REQUIRE(false); });
+        }
+
+        SECTION("called when schema version is bumped even if there are no schema changes") {
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+            };
+            auto realm = Realm::get_shared_realm(config);
+            realm->update_schema(schema);
+            bool called = false;
+            realm->update_schema(schema, 5, [&](SharedRealm, SharedRealm, Schema&) { called = true; });
+            REQUIRE(called);
+        }
+    }
+
+    SECTION("migration errors") {
+        SECTION("schema version cannot go down") {
+            auto realm = Realm::get_shared_realm(config);
+            realm->update_schema({}, 1);
+            realm->update_schema({}, 2);
+            REQUIRE_THROWS(realm->update_schema({}, 0));
+        }
+
+        SECTION("insert duplicate keys for existing PK during migration") {
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", true, false, false},
+                }},
+            };
+            auto realm = Realm::get_shared_realm(config);
+            realm->update_schema(schema, 1);
+            REQUIRE_THROWS(realm->update_schema(schema, 2, [](SharedRealm, SharedRealm realm, Schema&) {
+                auto table = ObjectStore::table_for_object_type(realm->read_group(), "object");
+                table->add_empty_row(2);
+            }));
+        }
+
+        SECTION("add pk to existing table with duplicate keys") {
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+            };
+            auto realm = Realm::get_shared_realm(config);
+            realm->update_schema(schema, 1);
+
+            auto table = ObjectStore::table_for_object_type(realm->read_group(), "object");
+            table->add_empty_row(2);
+
+            schema = set_primary_key(schema, "object", "value");
+            REQUIRE_THROWS(realm->update_schema(schema, 2, nullptr));
+        }
+
+        SECTION("throwing an exception from migration function rolls back all changes") {
+            Schema schema1 = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+            };
+            Schema schema2 = add_property(schema1, "object",
+                                          {"value2", PropertyType::Int, "", "", false, false, false});
+            auto realm = Realm::get_shared_realm(config);
+            realm->update_schema(schema1, 1);
+
+            REQUIRE_THROWS(realm->update_schema(schema2, 2, [](SharedRealm, SharedRealm realm, Schema&) {
+                auto table = ObjectStore::table_for_object_type(realm->read_group(), "object");
+                table->add_empty_row();
+                throw 5;
+            }));
+
+            auto table = ObjectStore::table_for_object_type(realm->read_group(), "object");
+            REQUIRE(table->size() == 0);
+            REQUIRE(realm->schema_version() == 1);
+            REQUIRE(realm->schema() == schema1);
+        }
+    }
+
+    SECTION("valid migrations") {
+        SECTION("changing all columns does not lose row count") {
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+            };
+            auto realm = Realm::get_shared_realm(config);
+            realm->update_schema(schema, 1);
+
+            realm->begin_transaction();
+            auto table = ObjectStore::table_for_object_type(realm->read_group(), "object");
+            table->add_empty_row(10);
+            realm->commit_transaction();
+
+            schema = set_type(schema, "object", "value", PropertyType::Float);
+            realm->update_schema(schema, 2);
+            REQUIRE(table->size() == 10);
+        }
+
+        SECTION("values for required properties are copied when converitng to nullable") {
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+            };
+            auto realm = Realm::get_shared_realm(config);
+            realm->update_schema(schema, 1);
+
+            realm->begin_transaction();
+            auto table = ObjectStore::table_for_object_type(realm->read_group(), "object");
+            table->add_empty_row(10);
+            for (size_t i = 0; i < 10; ++i)
+                table->set_int(0, i, i);
+            realm->commit_transaction();
+
+            realm->update_schema(set_optional(schema, "object", "value", true), 2);
+            for (size_t i = 0; i < 10; ++i)
+                REQUIRE(table->get_int(0, i) == i);
+        }
+
+        SECTION("values for nullable properties are discarded when converitng to required") {
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, true},
+                }},
+            };
+            auto realm = Realm::get_shared_realm(config);
+            realm->update_schema(schema, 1);
+
+            realm->begin_transaction();
+            auto table = ObjectStore::table_for_object_type(realm->read_group(), "object");
+            table->add_empty_row(10);
+            for (size_t i = 0; i < 10; ++i)
+                table->set_int(0, i, i);
+            realm->commit_transaction();
+
+            realm->update_schema(set_optional(schema, "object", "value", false), 2);
+            for (size_t i = 0; i < 10; ++i)
+                REQUIRE(table->get_int(0, i) == 0);
+        }
+
+        SECTION("deleting table removed from the schema deletes it") {
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, true},
+                }},
+            };
+            auto realm = Realm::get_shared_realm(config);
+            realm->update_schema(schema, 1);
+
+            realm->update_schema({}, 2, [](SharedRealm, SharedRealm realm, Schema&) {
+                ObjectStore::delete_data_for_object(realm->read_group(), "object");
+            });
+            REQUIRE_FALSE(ObjectStore::table_for_object_type(realm->read_group(), "object"));
+        }
+
+        SECTION("deleting table still in the schema recreates it with no rows") {
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, true},
+                }},
+            };
+            auto realm = Realm::get_shared_realm(config);
+            realm->update_schema(schema, 1);
+
+            realm->begin_transaction();
+            ObjectStore::table_for_object_type(realm->read_group(), "object")->add_empty_row();
+            realm->commit_transaction();
+
+            realm->update_schema(schema, 2, [](SharedRealm, SharedRealm realm, Schema&) {
+                ObjectStore::delete_data_for_object(realm->read_group(), "object");
+            });
+            auto table = ObjectStore::table_for_object_type(realm->read_group(), "object");
+            REQUIRE(table);
+            REQUIRE(table->size() == 0);
+        }
+
+        SECTION("deleting table which doesn't exist does nothing") {
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, true},
+                }},
+            };
+            auto realm = Realm::get_shared_realm(config);
+            realm->update_schema(schema, 1);
+
+            REQUIRE_NOTHROW(realm->update_schema({}, 2, [](SharedRealm, SharedRealm realm, Schema&) {
+                ObjectStore::delete_data_for_object(realm->read_group(), "foo");
+            }));
+        }
+    }
+
+    SECTION("schema correctness during migration") {
+        InMemoryTestFile config;
+        config.schema_mode = SchemaMode::Automatic;
+        auto realm = Realm::get_shared_realm(config);
+
+        Schema schema = {
+            {"object", {
+                {"pk", PropertyType::Int, "", "", true, false, false},
+                {"value", PropertyType::Int, "", "", false, true, false},
+                {"optional", PropertyType::Int, "", "", false, false, true},
+            }},
+            {"link origin", {
+                {"not a pk", PropertyType::Int, "", "", false, false, false},
+                {"object", PropertyType::Object, "object", "", false, false, true},
+                {"array", PropertyType::Array, "object", "", false, false, false},
+            }}
+        };
+        realm->update_schema(schema);
+
+#define VERIFY_SCHEMA_IN_MIGRATION(target_schema) do { \
+    Schema new_schema = (target_schema); \
+    realm->update_schema(new_schema, 1, [&](SharedRealm old_realm, SharedRealm new_realm, Schema&) { \
+        REQUIRE(old_realm->schema_version() == 0); \
+        REQUIRE(old_realm->schema() == schema); \
+        REQUIRE(new_realm->schema_version() == 1); \
+        REQUIRE(new_realm->schema() == new_schema); \
+        VERIFY_SCHEMA(*old_realm); \
+        VERIFY_SCHEMA(*new_realm); \
+    }); \
+} while (false)
+
+        SECTION("add new table") {
+            VERIFY_SCHEMA_IN_MIGRATION(add_table(schema, {"new table", {
+                {"value", PropertyType::Int, "", "", false, false, false},
+            }}));
+        }
+        SECTION("add property to table") {
+            VERIFY_SCHEMA_IN_MIGRATION(add_property(schema, "object", {"new", PropertyType::Int, "", "", false, false, false}));
+        }
+        SECTION("remove property from table") {
+            VERIFY_SCHEMA_IN_MIGRATION(remove_property(schema, "object", "value"));
+        }
+        SECTION("add primary key to table") {
+            VERIFY_SCHEMA_IN_MIGRATION(set_primary_key(schema, "link origin", "not a pk"));
+        }
+        SECTION("remove primary key from table") {
+            VERIFY_SCHEMA_IN_MIGRATION(set_primary_key(schema, "object", ""));
+        }
+        SECTION("change primary key") {
+            VERIFY_SCHEMA_IN_MIGRATION(set_primary_key(schema, "object", "value"));
+        }
+        SECTION("change property type") {
+            VERIFY_SCHEMA_IN_MIGRATION(set_type(schema, "object", "value", PropertyType::Date));
+        }
+        SECTION("change link target") {
+            VERIFY_SCHEMA_IN_MIGRATION(set_target(schema, "link origin", "object", "link origin"));
+        }
+        SECTION("change linklist target") {
+            VERIFY_SCHEMA_IN_MIGRATION(set_target(schema, "link origin", "array", "link origin"));
+        }
+        SECTION("make property optional") {
+            VERIFY_SCHEMA_IN_MIGRATION(set_optional(schema, "object", "value", true));
+        }
+        SECTION("make property required") {
+            VERIFY_SCHEMA_IN_MIGRATION(set_optional(schema, "object", "optional", false));
+        }
+        SECTION("add index") {
+            VERIFY_SCHEMA_IN_MIGRATION(set_indexed(schema, "object", "optional", true));
+        }
+        SECTION("remove index") {
+            VERIFY_SCHEMA_IN_MIGRATION(set_indexed(schema, "object", "value", false));
+        }
+        SECTION("reorder properties") {
+            auto schema2 = schema;
+            auto& properties = schema2.find("object")->persisted_properties;
+            std::swap(properties[0], properties[1]);
+            VERIFY_SCHEMA_IN_MIGRATION(schema2);
+        }
+    }
+}
+
+TEST_CASE("[migration] ReadOnly") {
+    TestFile config;
+
+    auto realm_with_schema = [&](Schema schema) {
+        {
+            auto realm = Realm::get_shared_realm(config);
+            realm->update_schema(std::move(schema));
+        }
+        config.schema_mode = SchemaMode::ReadOnly;
+        return Realm::get_shared_realm(config);
+    };
+
+    SECTION("allowed schema mismatches") {
+        SECTION("index") {
+            auto realm = realm_with_schema({
+                {"object", {
+                    {"indexed", PropertyType::Int, "", "", false, true, false},
+                    {"unindexed", PropertyType::Int, "", "", false, false, false},
+                }},
+            });
+            Schema schema = {
+                {"object", {
+                    {"indexed", PropertyType::Int, "", "", false, false, false},
+                    {"unindexed", PropertyType::Int, "", "", false, true, false},
+                }},
+            };
+            REQUIRE_NOTHROW(realm->update_schema(schema));
+            REQUIRE(realm->schema() == schema);
+        }
+
+        SECTION("missing tables") {
+            auto realm = realm_with_schema({
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+            });
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+                {"second object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+            };
+            REQUIRE_NOTHROW(realm->update_schema(schema));
+            REQUIRE(realm->schema() == schema);
+        }
+    }
+
+    SECTION("disallowed mismatches") {
+        SECTION("add column") {
+            auto realm = realm_with_schema({
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+            });
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                    {"value 2", PropertyType::Int, "", "", false, false, false},
+                }},
+            };
+            REQUIRE_THROWS(realm->update_schema(schema));
+        }
+
+        SECTION("bump schema version") {
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+            };
+            auto realm = realm_with_schema(schema);
+            REQUIRE_THROWS(realm->update_schema(schema, 1));
+        }
+    }
+}

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -953,8 +953,13 @@ TEST_CASE("migration: Additive") {
         REQUIRE(!table->has_search_index(1));
     }
 
-    SECTION("cannot remove properties from existing tables") {
-        REQUIRE_THROWS(realm->update_schema(remove_property(schema, "object", "value")));
+    SECTION("can remove properties from existing tables, but column is not removed") {
+        auto table = ObjectStore::table_for_object_type(realm->read_group(), "object");
+        REQUIRE_NOTHROW(realm->update_schema(remove_property(schema, "object", "value")));
+        REQUIRE(ObjectStore::table_for_object_type(realm->read_group(), "object")->get_column_count() == 2);
+        auto const& properties = realm->schema().find("object")->persisted_properties;
+        REQUIRE(properties.size() == 1);
+        REQUIRE(properties[0].table_column == 1);
     }
 
     SECTION("cannot change existing property types") {

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -1,3 +1,21 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
 #include "catch.hpp"
 
 #include "util/test_file.hpp"

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -803,6 +803,12 @@ TEST_CASE("migration: ReadOnly") {
             };
             REQUIRE_NOTHROW(realm->update_schema(schema));
             REQUIRE(realm->schema() == schema);
+
+            for (auto& object_schema : realm->schema()) {
+                for (size_t i = 0; i < object_schema.persisted_properties.size(); ++i) {
+                    REQUIRE(i == object_schema.persisted_properties[i].table_column);
+                }
+            }
         }
 
         SECTION("missing tables") {
@@ -821,6 +827,14 @@ TEST_CASE("migration: ReadOnly") {
             };
             REQUIRE_NOTHROW(realm->update_schema(schema));
             REQUIRE(realm->schema() == schema);
+
+            auto object_schema = realm->schema().find("object");
+            REQUIRE(object_schema->persisted_properties.size() == 1);
+            REQUIRE(object_schema->persisted_properties[0].table_column == 0);
+
+            object_schema = realm->schema().find("second object");
+            REQUIRE(object_schema->persisted_properties.size() == 1);
+            REQUIRE(object_schema->persisted_properties[0].table_column == size_t(-1));
         }
     }
 

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -120,7 +120,7 @@ Schema set_primary_key(Schema schema, StringData object_name, StringData new_pri
 }
 } // anonymous namespace
 
-TEST_CASE("[migration] Automatic") {
+TEST_CASE("migration: Automatic") {
     InMemoryTestFile config;
     config.automatic_change_notifications = false;
 
@@ -774,7 +774,7 @@ TEST_CASE("[migration] Automatic") {
     }
 }
 
-TEST_CASE("[migration] ReadOnly") {
+TEST_CASE("migration: ReadOnly") {
     TestFile config;
 
     auto realm_with_schema = [&](Schema schema) {
@@ -851,7 +851,7 @@ TEST_CASE("[migration] ReadOnly") {
     }
 }
 
-TEST_CASE("[migration] ResetFile") {
+TEST_CASE("migration: ResetFile") {
     TestFile config;
     config.schema_mode = SchemaMode::ResetFile;
 
@@ -900,7 +900,7 @@ TEST_CASE("[migration] ResetFile") {
     }
 }
 
-TEST_CASE("[migration] Additive") {
+TEST_CASE("migration: Additive") {
     InMemoryTestFile config;
     config.schema_mode = SchemaMode::Additive;
     auto realm = Realm::get_shared_realm(config);
@@ -994,7 +994,7 @@ TEST_CASE("[migration] Additive") {
     }
 }
 
-TEST_CASE("[migration] Manual") {
+TEST_CASE("migration: Manual") {
     TestFile config;
     config.schema_mode = SchemaMode::Manual;
     auto realm = Realm::get_shared_realm(config);

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -1,0 +1,153 @@
+#include "catch.hpp"
+#include "util/test_file.hpp"
+
+#include "object_schema.hpp"
+#include "object_store.hpp"
+#include "property.hpp"
+#include "schema.hpp"
+
+#include <realm/group.hpp>
+#include <realm/util/file.hpp>
+
+using namespace realm;
+
+TEST_CASE("SharedRealm: get_shared_realm()") {
+    TestFile config;
+    config.schema_version = 1;
+    config.schema = Schema{
+        {"object", {
+            {"value", PropertyType::Int, "", "", false, false, false}
+        }},
+    };
+
+    SECTION("should return the same instance when caching is enabled") {
+        auto realm1 = Realm::get_shared_realm(config);
+        auto realm2 = Realm::get_shared_realm(config);
+        REQUIRE(realm1.get() == realm2.get());
+    }
+
+    SECTION("should return different instances when caching is disabled") {
+        config.cache = false;
+        auto realm1 = Realm::get_shared_realm(config);
+        auto realm2 = Realm::get_shared_realm(config);
+        REQUIRE(realm1.get() != realm2.get());
+    }
+
+    SECTION("should reject mismatched config") {
+        config.cache = false;
+
+        SECTION("schema version") {
+            auto realm = Realm::get_shared_realm(config);
+            config.schema_version = 2;
+            REQUIRE_THROWS(Realm::get_shared_realm(config));
+            config.schema_version = ObjectStore::NotVersioned;
+            REQUIRE_NOTHROW(Realm::get_shared_realm(config));
+        }
+
+        SECTION("schema mode") {
+            auto realm = Realm::get_shared_realm(config);
+            config.schema_mode = SchemaMode::Manual;
+            REQUIRE_THROWS(Realm::get_shared_realm(config));
+        }
+
+        SECTION("durability") {
+            auto realm = Realm::get_shared_realm(config);
+            config.in_memory = true;
+            REQUIRE_THROWS(Realm::get_shared_realm(config));
+        }
+
+        SECTION("schema") {
+            auto realm = Realm::get_shared_realm(config);
+            config.schema = Schema{
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                    {"value2", PropertyType::Int, "", "", false, false, false}
+                }},
+            };
+            REQUIRE_THROWS(Realm::get_shared_realm(config));
+        }
+    }
+
+    SECTION("should apply the schema if one is supplied") {
+        Realm::get_shared_realm(config);
+
+        {
+            Group g(config.path);
+            auto table = ObjectStore::table_for_object_type(g, "object");
+            REQUIRE(table);
+            REQUIRE(table->get_column_count() == 1);
+            REQUIRE(table->get_column_name(0) == "value");
+        }
+
+        config.schema_version = 2;
+        config.schema = Schema{
+            {"object", {
+                {"value", PropertyType::Int, "", "", false, false, false},
+                {"value2", PropertyType::Int, "", "", false, false, false}
+            }},
+        };
+        bool migration_called = false;
+        config.migration_function = [&](SharedRealm old_realm, SharedRealm new_realm, Schema&) {
+            migration_called = true;
+            REQUIRE(ObjectStore::table_for_object_type(old_realm->read_group(), "object")->get_column_count() == 1);
+            REQUIRE(ObjectStore::table_for_object_type(new_realm->read_group(), "object")->get_column_count() == 2);
+        };
+        Realm::get_shared_realm(config);
+        REQUIRE(migration_called);
+    }
+
+    SECTION("should properly roll back from migration errors") {
+        Realm::get_shared_realm(config);
+
+        config.schema_version = 2;
+        config.schema = Schema{
+            {"object", {
+                {"value", PropertyType::Int, "", "", false, false, false},
+                {"value2", PropertyType::Int, "", "", false, false, false}
+            }},
+        };
+        bool migration_called = false;
+        config.migration_function = [&](SharedRealm old_realm, SharedRealm new_realm, Schema&) {
+            REQUIRE(ObjectStore::table_for_object_type(old_realm->read_group(), "object")->get_column_count() == 1);
+            REQUIRE(ObjectStore::table_for_object_type(new_realm->read_group(), "object")->get_column_count() == 2);
+            if (!migration_called) {
+                migration_called = true;
+                throw "error";
+            }
+        };
+        REQUIRE_THROWS_WITH(Realm::get_shared_realm(config), "error");
+        REQUIRE(migration_called);
+        REQUIRE_NOTHROW(Realm::get_shared_realm(config));
+    }
+
+    SECTION("should read the schema from the file if none is supplied") {
+        Realm::get_shared_realm(config);
+
+        config.schema = util::none;
+        auto realm = Realm::get_shared_realm(config);
+        REQUIRE(realm->schema().size() == 1);
+        auto it = realm->schema().find("object");
+        REQUIRE(it != realm->schema().end());
+        REQUIRE(it->persisted_properties.size() == 1);
+        REQUIRE(it->persisted_properties[0].name == "value");
+        REQUIRE(it->persisted_properties[0].table_column == 0);
+    }
+
+    SECTION("should populate the table columns in the schema when opening as read-only") {
+        Realm::get_shared_realm(config);
+
+        config.schema_mode = SchemaMode::ReadOnly;
+        auto realm = Realm::get_shared_realm(config);
+        auto it = realm->schema().find("object");
+        REQUIRE(it != realm->schema().end());
+        REQUIRE(it->persisted_properties.size() == 1);
+        REQUIRE(it->persisted_properties[0].name == "value");
+        REQUIRE(it->persisted_properties[0].table_column == 0);
+    }
+
+    SECTION("should throw when creating the notification pipe fails") {
+        util::try_make_dir(config.path + ".note");
+        REQUIRE_THROWS(Realm::get_shared_realm(config));
+        util::remove_dir(config.path + ".note");
+    }
+}

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -1,3 +1,21 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
 #include "catch.hpp"
 #include "util/test_file.hpp"
 

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -40,25 +40,26 @@ TEST_CASE("[results] notifications") {
     InMemoryTestFile config;
     config.cache = false;
     config.automatic_change_notifications = false;
-    config.schema = std::make_unique<Schema>(Schema{
-        {"object", "", {
+
+    auto r = Realm::get_shared_realm(config);
+    r->update_schema({
+        {"object", {
             {"value", PropertyType::Int},
             {"link", PropertyType::Object, "linked to object", "", false, false, true}
         }},
-        {"other object", "", {
+        {"other object", {
             {"value", PropertyType::Int}
         }},
-        {"linking object", "", {
+        {"linking object", {
             {"link", PropertyType::Object, "object", "", false, false, true}
         }},
-        {"linked to object", "", {
+        {"linked to object", {
             {"value", PropertyType::Int}
         }}
     });
 
-    auto r = Realm::get_shared_realm(config);
     auto coordinator = _impl::RealmCoordinator::get_existing_coordinator(config.path);
-    auto table = r->read_group()->get_table("class_object");
+    auto table = r->read_group().get_table("class_object");
 
     r->begin_transaction();
     table->add_empty_row(10);
@@ -165,21 +166,21 @@ TEST_CASE("[results] notifications") {
 
         SECTION("modifications to unrelated tables do not send notifications") {
             write([&] {
-                r->read_group()->get_table("class_other object")->add_empty_row();
+                r->read_group().get_table("class_other object")->add_empty_row();
             });
             REQUIRE(notification_calls == 1);
         }
 
         SECTION("irrelevant modifications to linked tables do not send notifications") {
             write([&] {
-                r->read_group()->get_table("class_linked to object")->add_empty_row();
+                r->read_group().get_table("class_linked to object")->add_empty_row();
             });
             REQUIRE(notification_calls == 1);
         }
 
         SECTION("irrelevant modifications to linking tables do not send notifications") {
             write([&] {
-                r->read_group()->get_table("class_linking object")->add_empty_row();
+                r->read_group().get_table("class_linking object")->add_empty_row();
             });
             REQUIRE(notification_calls == 1);
         }
@@ -443,15 +444,16 @@ TEST_CASE("[results] async error handling") {
     InMemoryTestFile config;
     config.cache = false;
     config.automatic_change_notifications = false;
-    config.schema = std::make_unique<Schema>(Schema{
-        {"object", "", {
+
+    auto r = Realm::get_shared_realm(config);
+    r->update_schema({
+        {"object", {
             {"value", PropertyType::Int},
         }},
     });
 
-    auto r = Realm::get_shared_realm(config);
     auto coordinator = _impl::RealmCoordinator::get_existing_coordinator(config.path);
-    Results results(r, *r->read_group()->get_table("class_object"));
+    Results results(r, *r->read_group().get_table("class_object"));
 
     class OpenFileLimiter {
     public:
@@ -557,14 +559,15 @@ TEST_CASE("[results] notifications after move") {
     InMemoryTestFile config;
     config.cache = false;
     config.automatic_change_notifications = false;
-    config.schema = std::make_unique<Schema>(Schema{
-        {"object", "", {
+
+    auto r = Realm::get_shared_realm(config);
+    r->update_schema({
+        {"object", {
             {"value", PropertyType::Int},
         }},
     });
 
-    auto r = Realm::get_shared_realm(config);
-    auto table = r->read_group()->get_table("class_object");
+    auto table = r->read_group().get_table("class_object");
     auto results = std::make_unique<Results>(r, *table);
 
     int notification_calls = 0;
@@ -606,14 +609,14 @@ TEST_CASE("[results] notifications after move") {
 
 TEST_CASE("[results] error messages") {
     InMemoryTestFile config;
-    config.schema = std::make_unique<Schema>(Schema{
-        {"object", "", {
+    config.schema = Schema{
+        {"object", {
             {"value", PropertyType::String},
         }},
-    });
+    };
 
     auto r = Realm::get_shared_realm(config);
-    auto table = r->read_group()->get_table("class_object");
+    auto table = r->read_group().get_table("class_object");
     Results results(r, *table);
 
     r->begin_transaction();
@@ -633,15 +636,15 @@ TEST_CASE("results: snapshots") {
     InMemoryTestFile config;
     config.cache = false;
     config.automatic_change_notifications = false;
-    config.schema = std::make_unique<Schema>(Schema{
-        {"object", "", {
+    config.schema = Schema{
+        {"object", {
             {"value", PropertyType::Int},
             {"array", PropertyType::Array, "linked to object"}
         }},
-        {"linked to object", "", {
+        {"linked to object", {
             {"value", PropertyType::Int}
         }}
-    });
+    };
 
     auto r = Realm::get_shared_realm(config);
 
@@ -659,7 +662,7 @@ TEST_CASE("results: snapshots") {
     }
 
     SECTION("snapshot of Results based on Table") {
-        auto table = r->read_group()->get_table("class_object");
+        auto table = r->read_group().get_table("class_object");
         Results results(r, *table);
 
         {
@@ -698,8 +701,8 @@ TEST_CASE("results: snapshots") {
     }
 
     SECTION("snapshot of Results based on LinkView") {
-        auto object = r->read_group()->get_table("class_object");
-        auto linked_to = r->read_group()->get_table("class_linked to object");
+        auto object = r->read_group().get_table("class_object");
+        auto linked_to = r->read_group().get_table("class_linked to object");
 
         write([=]{
             object->add_empty_row();
@@ -750,7 +753,7 @@ TEST_CASE("results: snapshots") {
     }
 
     SECTION("snapshot of Results based on Query") {
-        auto table = r->read_group()->get_table("class_object");
+        auto table = r->read_group().get_table("class_object");
         Query q = table->column<Int>(0) > 0;
         Results results(r, std::move(q));
 
@@ -796,7 +799,7 @@ TEST_CASE("results: snapshots") {
     }
 
     SECTION("snapshot of Results based on TableView from query") {
-        auto table = r->read_group()->get_table("class_object");
+        auto table = r->read_group().get_table("class_object");
         Query q = table->column<Int>(0) > 0;
         Results results(r, q.find_all());
 
@@ -842,8 +845,8 @@ TEST_CASE("results: snapshots") {
     }
 
     SECTION("snapshot of Results based on TableView from backlinks") {
-        auto object = r->read_group()->get_table("class_object");
-        auto linked_to = r->read_group()->get_table("class_linked to object");
+        auto object = r->read_group().get_table("class_object");
+        auto linked_to = r->read_group().get_table("class_linked to object");
 
         write([=]{
             linked_to->add_empty_row();
@@ -898,7 +901,7 @@ TEST_CASE("results: snapshots") {
     }
 
     SECTION("snapshot of Results with notification callback registered") {
-        auto table = r->read_group()->get_table("class_object");
+        auto table = r->read_group().get_table("class_object");
         Query q = table->column<Int>(0) > 0;
         Results results(r, q.find_all());
 
@@ -925,7 +928,7 @@ TEST_CASE("results: snapshots") {
     }
 
     SECTION("adding notification callback to snapshot throws") {
-        auto table = r->read_group()->get_table("class_object");
+        auto table = r->read_group().get_table("class_object");
         Query q = table->column<Int>(0) > 0;
         Results results(r, q.find_all());
         auto snapshot = results.snapshot();

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -36,7 +36,7 @@
 
 using namespace realm;
 
-TEST_CASE("[results] notifications") {
+TEST_CASE("results: notifications") {
     InMemoryTestFile config;
     config.cache = false;
     config.automatic_change_notifications = false;
@@ -440,7 +440,7 @@ TEST_CASE("[results] notifications") {
     }
 }
 
-TEST_CASE("[results] async error handling") {
+TEST_CASE("results: async error handling") {
     InMemoryTestFile config;
     config.cache = false;
     config.automatic_change_notifications = false;
@@ -555,7 +555,7 @@ TEST_CASE("[results] async error handling") {
     }
 }
 
-TEST_CASE("[results] notifications after move") {
+TEST_CASE("results: notifications after move") {
     InMemoryTestFile config;
     config.cache = false;
     config.automatic_change_notifications = false;
@@ -607,7 +607,7 @@ TEST_CASE("[results] notifications after move") {
     }
 }
 
-TEST_CASE("[results] error messages") {
+TEST_CASE("results: error messages") {
     InMemoryTestFile config;
     config.schema = Schema{
         {"object", {

--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -1,3 +1,21 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
 #include "catch.hpp"
 
 #include "object_schema.hpp"

--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -1,0 +1,455 @@
+#include "catch.hpp"
+
+#include "object_schema.hpp"
+#include "property.hpp"
+#include "schema.hpp"
+
+#include <realm/group.hpp>
+#include <realm/table.hpp>
+
+using namespace realm;
+
+struct SchemaChangePrinter {
+    std::ostream& out;
+
+    template<typename Value>
+    void print(Value value) const
+    {
+        out << value;
+    }
+
+    template<typename Value, typename... Rest>
+    void print(Value value, Rest... rest) const
+    {
+        out << value << ", ";
+        print(rest...);
+    }
+
+#define REALM_SC_PRINT(type, ...) \
+    void operator()(schema_change::type v) const \
+    { \
+        out << #type << "{"; \
+        print(__VA_ARGS__); \
+        out << "}"; \
+    }
+
+    REALM_SC_PRINT(AddIndex, v.object, v.property)
+    REALM_SC_PRINT(AddProperty, v.object, v.property)
+    REALM_SC_PRINT(AddTable, v.object)
+    REALM_SC_PRINT(ChangePrimaryKey, v.object, v.property)
+    REALM_SC_PRINT(ChangePropertyType, v.object, v.old_property, v.new_property)
+    REALM_SC_PRINT(MakePropertyNullable, v.object, v.property)
+    REALM_SC_PRINT(MakePropertyRequired, v.object, v.property)
+    REALM_SC_PRINT(RemoveIndex, v.object, v.property)
+    REALM_SC_PRINT(RemoveProperty, v.object, v.property)
+
+#undef REALM_SC_PRINT
+};
+
+namespace Catch {
+std::string toString(SchemaChange const& sc)
+{
+    std::stringstream ss;
+    sc.visit(SchemaChangePrinter{ss});
+    return ss.str();
+}
+}
+
+TEST_CASE("ObjectSchema") {
+    SECTION("from a Group") {
+        Group g;
+        TableRef pk = g.add_table("pk");
+        pk->add_column(type_String, "pk_table");
+        pk->add_column(type_String, "pk_property");
+        pk->add_empty_row();
+        pk->set_string(0, 0, "table");
+        pk->set_string(1, 0, "pk");
+
+        TableRef table = g.add_table("class_table");
+        TableRef target = g.add_table("class_target");
+
+        table->add_column(type_Int, "pk");
+
+        table->add_column(type_Int, "int");
+        table->add_column(type_Bool, "bool");
+        table->add_column(type_Float, "float");
+        table->add_column(type_Double, "double");
+        table->add_column(type_String, "string");
+        table->add_column(type_Binary, "data");
+        table->add_column(type_Timestamp, "date");
+
+        table->add_column_link(type_Link, "object", *target);
+        table->add_column_link(type_LinkList, "array", *target);
+
+        table->add_column(type_Int, "int?", true);
+        table->add_column(type_Bool, "bool?", true);
+        table->add_column(type_Float, "float?", true);
+        table->add_column(type_Double, "double?", true);
+        table->add_column(type_String, "string?", true);
+        table->add_column(type_Binary, "data?", true);
+        table->add_column(type_Timestamp, "date?", true);
+
+        size_t indexed_start = table->get_column_count();
+        table->add_column(type_Int, "indexed int");
+        table->add_column(type_Bool, "indexed bool");
+        table->add_column(type_String, "indexed string");
+        table->add_column(type_Timestamp, "indexed date");
+
+        table->add_column(type_Int, "indexed int?", true);
+        table->add_column(type_Bool, "indexed bool?", true);
+        table->add_column(type_String, "indexed string?", true);
+        table->add_column(type_Timestamp, "indexed date?", true);
+
+        for (size_t i = indexed_start; i < table->get_column_count(); ++i)
+            table->add_search_index(i);
+
+        ObjectSchema os(g, "table");
+
+#define REQUIRE_PROPERTY(name, type, ...) do { \
+    auto prop = os.property_for_name(name); \
+    REQUIRE(prop); \
+    REQUIRE(*prop == Property(name, PropertyType::type, __VA_ARGS__)); \
+    REQUIRE(prop->table_column == expected_col++); \
+} while (0)
+
+        size_t expected_col = 0;
+
+        REQUIRE(os.property_for_name("nonexistent property") == nullptr);
+
+        // bools are (primary, indexed, nullable)
+        REQUIRE_PROPERTY("pk", Int, "", "",true, false, false);
+
+        REQUIRE_PROPERTY("int", Int, "", "", false, false, false);
+        REQUIRE_PROPERTY("bool", Bool, "", "", false, false, false);
+        REQUIRE_PROPERTY("float", Float, "", "", false, false, false);
+        REQUIRE_PROPERTY("double", Double, "", "", false, false, false);
+        REQUIRE_PROPERTY("string", String, "", "", false, false, false);
+        REQUIRE_PROPERTY("data", Data, "", "", false, false, false);
+        REQUIRE_PROPERTY("date", Date, "", "", false, false, false);
+
+        REQUIRE_PROPERTY("object", Object, "target", "", false, false, true);
+        REQUIRE_PROPERTY("array", Array, "target", "", false, false, false);
+
+        REQUIRE_PROPERTY("int?", Int, "", "", false, false, true);
+        REQUIRE_PROPERTY("bool?", Bool, "", "", false, false, true);
+        REQUIRE_PROPERTY("float?", Float, "", "", false, false, true);
+        REQUIRE_PROPERTY("double?", Double, "", "", false, false, true);
+        REQUIRE_PROPERTY("string?", String, "", "", false, false, true);
+        REQUIRE_PROPERTY("data?", Data, "", "", false, false, true);
+        REQUIRE_PROPERTY("date?", Date, "", "", false, false, true);
+
+        REQUIRE_PROPERTY("indexed int", Int, "", "", false, true, false);
+        REQUIRE_PROPERTY("indexed bool", Bool, "", "", false, true, false);
+        REQUIRE_PROPERTY("indexed string", String, "", "", false, true, false);
+        REQUIRE_PROPERTY("indexed date", Date, "", "", false, true, false);
+
+        REQUIRE_PROPERTY("indexed int?", Int, "", "", false, true, true);
+        REQUIRE_PROPERTY("indexed bool?", Bool, "", "", false, true, true);
+        REQUIRE_PROPERTY("indexed string?", String, "", "", false, true, true);
+        REQUIRE_PROPERTY("indexed date?", Date, "", "", false, true, true);
+
+        pk->set_string(1, 0, "nonexistent property");
+        REQUIRE(ObjectSchema(g, "table").primary_key_property() == nullptr);
+    }
+}
+
+TEST_CASE("Schema") {
+    SECTION("validate()") {
+        SECTION("rejects link properties with no target object") {
+            Schema schema = {
+                {"object", {
+                    {"link", PropertyType::Object, "", "", false, false, true}
+                }},
+            };
+            REQUIRE_THROWS(schema.validate());
+        }
+
+        SECTION("rejects array properties with no target object") {
+            Schema schema = {
+                {"object", {
+                    {"array", PropertyType::Array, "", "", false, false, true}
+                }},
+            };
+            REQUIRE_THROWS(schema.validate());
+        }
+
+        SECTION("rejects link properties with a target not in the schema") {
+            Schema schema = {
+                {"object", {
+                    {"link", PropertyType::Object, "invalid target", "", false, false, true}
+                }}
+            };
+            REQUIRE_THROWS(schema.validate());
+        }
+
+        SECTION("rejects array properties with a target not in the schema") {
+            Schema schema = {
+                {"object", {
+                    {"array", PropertyType::Array, "invalid target", "", false, false, true}
+                }}
+            };
+            REQUIRE_THROWS(schema.validate());
+        }
+
+        SECTION("rejects target object types for non-link properties") {
+            Schema schema = {
+                {"object", {
+                    {"int", PropertyType::Int, "", "", false, false, false},
+                    {"bool", PropertyType::Bool, "", "", false, false, false},
+                    {"float", PropertyType::Float, "", "", false, false, false},
+                    {"double", PropertyType::Double, "", "", false, false, false},
+                    {"string", PropertyType::String, "", "", false, false, false},
+                    {"date", PropertyType::Date, "", "", false, false, false},
+                }}
+            };
+            for (auto& prop : schema.begin()->persisted_properties) {
+                REQUIRE_NOTHROW(schema.validate());
+                prop.object_type = "object";
+                REQUIRE_THROWS(schema.validate());
+                prop.object_type = "";
+            }
+        }
+
+        SECTION("rejects non-nullable link properties") {
+            Schema schema = {
+                {"object", {
+                    {"link", PropertyType::Object, "target", "", false, false, false}
+                }},
+                {"target", {
+                    {"value", PropertyType::Int}
+                }}
+            };
+            REQUIRE_THROWS(schema.validate());
+        }
+
+        SECTION("rejects nullable array properties") {
+            Schema schema = {
+                {"object", {
+                    {"array", PropertyType::Array, "target", "", false, false, true}
+                }},
+                {"target", {
+                    {"value", PropertyType::Int}
+                }}
+            };
+            REQUIRE_THROWS(schema.validate());
+        }
+
+        SECTION("rejects duplicate primary keys") {
+            Schema schema = {
+                {"object", {
+                    {"pk1", PropertyType::Int, "", "", true, false, false},
+                    {"pk2", PropertyType::Int, "", "", true, false, false},
+                }}
+            };
+            REQUIRE_THROWS(schema.validate());
+        }
+
+        SECTION("rejects indexes for types that cannot be indexed") {
+            Schema schema = {
+                {"object", {
+                    {"float", PropertyType::Float, "", "", false, false, false},
+                    {"double", PropertyType::Double, "", "", false, false, false},
+                    {"data", PropertyType::Data, "", "", false, false, false},
+                    {"object", PropertyType::Object, "object", "", false, false, true},
+                    {"array", PropertyType::Array, "object", "", false, false, false},
+                }}
+            };
+            for (auto& prop : schema.begin()->persisted_properties) {
+                REQUIRE_NOTHROW(schema.validate());
+                prop.is_indexed = true;
+                REQUIRE_THROWS(schema.validate());
+                prop.is_indexed = false;
+            }
+        }
+
+        SECTION("allows indexing types that can be indexed") {
+            Schema schema = {
+                {"object", {
+                    {"int", PropertyType::Int, "", "", false, true, false},
+                    {"bool", PropertyType::Bool, "", "", false, true, false},
+                    {"string", PropertyType::String, "", "", false, true, false},
+                    {"date", PropertyType::Date, "", "", false, true, false},
+                }}
+            };
+            REQUIRE_NOTHROW(schema.validate());
+        }
+    }
+
+    SECTION("compare()") {
+        using namespace schema_change;
+        using vec = std::vector<SchemaChange>;
+        SECTION("add table") {
+            Schema schema1 = {
+                {"object 1", {
+                    {"int", PropertyType::Int, "", "", false, false, false},
+                }}
+            };
+            Schema schema2 = {
+                {"object 1", {
+                    {"int", PropertyType::Int, "", "", false, false, false},
+                }},
+                {"object 2", {
+                    {"int", PropertyType::Int, "", "", false, false, false},
+                }}
+            };
+            REQUIRE(schema1.compare(schema2) == vec{AddTable{&*schema2.find("object 2")}});
+        }
+
+        SECTION("add property") {
+            Schema schema1 = {
+                {"object", {
+                    {"int 1", PropertyType::Int, "", "", false, false, false},
+                }}
+            };
+            Schema schema2 = {
+                {"object", {
+                    {"int 1", PropertyType::Int, "", "", false, false, false},
+                    {"int 2", PropertyType::Int, "", "", false, false, false},
+                }}
+            };
+            REQUIRE(schema1.compare(schema2) == vec{(AddProperty{&*schema1.find("object"), &schema2.find("object")->persisted_properties[1]})});
+        }
+
+        SECTION("remove property") {
+            Schema schema1 = {
+                {"object", {
+                    {"int 1", PropertyType::Int, "", "", false, false, false},
+                    {"int 2", PropertyType::Int, "", "", false, false, false},
+                }}
+            };
+            Schema schema2 = {
+                {"object", {
+                    {"int 1", PropertyType::Int, "", "", false, false, false},
+                }}
+            };
+            REQUIRE(schema1.compare(schema2) == vec{(RemoveProperty{&*schema1.find("object"), &schema1.find("object")->persisted_properties[1]})});
+        }
+
+        SECTION("change property type") {
+            Schema schema1 = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }}
+            };
+            Schema schema2 = {
+                {"object", {
+                    {"value", PropertyType::Double, "", "", false, false, false},
+                }}
+            };
+            REQUIRE(schema1.compare(schema2) == vec{(ChangePropertyType{
+                &*schema1.find("object"),
+                &schema1.find("object")->persisted_properties[0],
+                &schema2.find("object")->persisted_properties[0]})});
+        };
+
+        SECTION("change link target") {
+            Schema schema1 = {
+                {"object", {
+                    {"value", PropertyType::Object, "target 1", "", false, false, false},
+                }},
+                {"target 1", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+                {"target 2", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+            };
+            Schema schema2 = {
+                {"object", {
+                    {"value", PropertyType::Object, "target 2", "", false, false, false},
+                }},
+                {"target 1", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+                {"target 2", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }},
+            };
+            REQUIRE(schema1.compare(schema2) == vec{(ChangePropertyType{
+                &*schema1.find("object"),
+                &schema1.find("object")->persisted_properties[0],
+                &schema2.find("object")->persisted_properties[0]})});
+        }
+
+        SECTION("add index") {
+            Schema schema1 = {
+                {"object", {
+                    {"int", PropertyType::Int, "", "", false, false, false},
+                }}
+            };
+            Schema schema2 = {
+                {"object", {
+                    {"int", PropertyType::Int, "", "", false, true, false},
+                }}
+            };
+            auto object_schema = &*schema1.find("object");
+            REQUIRE(schema1.compare(schema2) == vec{(AddIndex{object_schema, &object_schema->persisted_properties[0]})});
+        }
+
+        SECTION("remove index") {
+            Schema schema1 = {
+                {"object", {
+                    {"int", PropertyType::Int, "", "", false, true, false},
+                }}
+            };
+            Schema schema2 = {
+                {"object", {
+                    {"int", PropertyType::Int, "", "", false, false, false},
+                }}
+            };
+            auto object_schema = &*schema1.find("object");
+            REQUIRE(schema1.compare(schema2) == vec{(RemoveIndex{object_schema, &object_schema->persisted_properties[0]})});
+        }
+
+        SECTION("add index and make nullable") {
+            Schema schema1 = {
+                {"object", {
+                    {"int", PropertyType::Int, "", "", false, false, false},
+                }}
+            };
+            Schema schema2 = {
+                {"object", {
+                    {"int", PropertyType::Int, "", "", false, true, true},
+                }}
+            };
+            auto object_schema = &*schema1.find("object");
+            REQUIRE(schema1.compare(schema2) == (vec{
+                MakePropertyNullable{object_schema, &object_schema->persisted_properties[0]},
+                AddIndex{object_schema, &object_schema->persisted_properties[0]}}));
+        }
+
+        SECTION("add index and change type") {
+            Schema schema1 = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }}
+            };
+            Schema schema2 = {
+                {"object", {
+                    {"value", PropertyType::Double, "", "", false, true, false},
+                }}
+            };
+            REQUIRE(schema1.compare(schema2) == vec{(ChangePropertyType{
+                &*schema1.find("object"),
+                &schema1.find("object")->persisted_properties[0],
+                &schema2.find("object")->persisted_properties[0]})});
+        }
+
+        SECTION("make nullable and change type") {
+            Schema schema1 = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                }}
+            };
+            Schema schema2 = {
+                {"object", {
+                    {"value", PropertyType::Double, "", "", false, false, true},
+                }}
+            };
+            REQUIRE(schema1.compare(schema2) == vec{(ChangePropertyType{
+                &*schema1.find("object"),
+                &schema1.find("object")->persisted_properties[0],
+                &schema2.find("object")->persisted_properties[0]})});
+        }
+    }
+}

--- a/tests/transaction_log_parsing.cpp
+++ b/tests/transaction_log_parsing.cpp
@@ -129,13 +129,13 @@ TEST_CASE("Transaction log parsing") {
     config.automatic_change_notifications = false;
 
     SECTION("schema change validation") {
-        config.schema = std::make_unique<Schema>(Schema{
-            {"table", "", {
+        auto r = Realm::get_shared_realm(config);
+        r->update_schema({
+            {"table", {
                 {"unindexed", PropertyType::Int},
                 {"indexed", PropertyType::Int, "", "", false, true}
             }},
         });
-        auto r = Realm::get_shared_realm(config);
         r->read_group();
 
         auto history = make_client_history(config.path);
@@ -196,14 +196,14 @@ TEST_CASE("Transaction log parsing") {
     }
 
     SECTION("table change information") {
-        config.schema = std::make_unique<Schema>(Schema{
-            {"table", "", {
+        auto r = Realm::get_shared_realm(config);
+        r->update_schema({
+            {"table", {
                 {"value", PropertyType::Int}
             }},
         });
 
-        auto r = Realm::get_shared_realm(config);
-        auto& table = *r->read_group()->get_table("class_table");
+        auto& table = *r->read_group().get_table("class_table");
 
         r->begin_transaction();
         table.add_empty_row(10);
@@ -285,19 +285,18 @@ TEST_CASE("Transaction log parsing") {
     }
 
     SECTION("LinkView change information") {
-        config.schema = std::make_unique<Schema>(Schema{
-            {"origin", "", {
+        auto r = Realm::get_shared_realm(config);
+        r->update_schema({
+            {"origin", {
                 {"array", PropertyType::Array, "target"}
             }},
-            {"target", "", {
+            {"target", {
                 {"value", PropertyType::Int}
             }},
         });
 
-        auto r = Realm::get_shared_realm(config);
-
-        auto origin = r->read_group()->get_table("class_origin");
-        auto target = r->read_group()->get_table("class_target");
+        auto origin = r->read_group().get_table("class_origin");
+        auto target = r->read_group().get_table("class_target");
 
         r->begin_transaction();
 
@@ -821,17 +820,15 @@ TEST_CASE("Transaction log parsing") {
 TEST_CASE("DeepChangeChecker") {
     InMemoryTestFile config;
     config.automatic_change_notifications = false;
-
-    config.schema = std::make_unique<Schema>(Schema{
-        {"table", "", {
+    auto r = Realm::get_shared_realm(config);
+    r->update_schema({
+        {"table", {
             {"int", PropertyType::Int},
             {"link", PropertyType::Object, "table", "", false, false, true},
             {"array", PropertyType::Array, "table"}
         }},
     });
-
-    auto r = Realm::get_shared_realm(config);
-    auto table = r->read_group()->get_table("class_table");
+    auto table = r->read_group().get_table("class_table");
 
     r->begin_transaction();
     table->add_empty_row(10);


### PR DESCRIPTION
Add the concept of "schema modes" which control how updates to the schema are handled. Currently there are five:

  1. Automatic: the Cocoa binding's default mode. Adding new tables and adding or removing indexes is always allowed. Adding, removing, or modifying a property, or changing the primary key requires incrementing the schema version. The migration function is called whenever the schema version is increased.
  2. Read-only: open the file in read-only mode, allow missing or extra tables, allow index mismatches, and error on all other differences.
  3. Reset file: allow adding new tables or adding/removing indexes. All other changes (including bumping the schema version) result in the file being deleted and recreated. Does not work with multi-process.
  4. Additive-only: Allowing adding new tables and new columns to tables. Do not allow modifying existing columns, or changing the primary key of existing tables. Indexes are updated only if the schema version is increased.
  5. Manual: the Java binding's default mode. Any schema changes require a schema version bump. Changes are not automatically applied; instead the migration function is called which is responsible for ensuring that the file's schema matches the declared one.

Supporting these various modes requires detangling the process of comparing a Schema object to a Group's schema from the code that does the updating. Redesign schema updating to use roughly the following high-level flow:

  1. Read the Schema from the Group.
  2. Diff that schema with the schema passed in by the user and build up a list of changes needed to make them match.
  3. Verify that all changes are legal for the current schema mode.
  4. Apply the changes.

Obviously some of these steps are skipped for some of the modes.

There are a few breaking changes to the API in this:

  1. The schema property on Realm::Config is now an `Optional<Schema>` rather than `unique_ptr<Schema>`.
  2. The schema and schema version is read from the Realm via the new member functions for that rather than reading them from the Realm's config object.
  3. Opening Realms in read-only mode is now a schema mode rather than a separate flag.
  4. Realm::read_group() now returns a reference, and the ObjectStore functions all take references when nullptr is not a legal argument.

This also adds `ObjectStore::rename_property()` for renaming a property from within a migration function.

The main remaining WIP thing is a lot more testing; this passes realm-cocoa's tests but that doesn't mean a lot as Cocoa has its own parallel schema functionality that may be masking bugs and there's some functionality here not used by Cocoa.