### PR TITLE
Choose the commit helper by compiling source

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,17 +44,17 @@ set(HEADERS
 if(APPLE)
     list(APPEND SOURCES
         impl/apple/weak_realm_notifier.cpp
-        impl/apple/external_commit_helper.cpp)
+        impl/apple/apple_external_commit_helper.cpp)
     list(APPEND HEADERS
         impl/apple/weak_realm_notifier.hpp
-        impl/apple/external_commit_helper.hpp)
+        impl/apple/apple_external_commit_helper.hpp)
     find_library(CF_LIBRARY CoreFoundation)
 else()
     list(APPEND SOURCES
-        impl/generic/external_commit_helper.cpp)
+        impl/generic/generic_external_commit_helper.cpp)
     list(APPEND HEADERS
         impl/generic/weak_realm_notifier.hpp
-        impl/generic/external_commit_helper.hpp)
+        impl/generic/generic_external_commit_helper.hpp)
 endif()
 
 set(INCLUDE_DIRS ${REALM_CORE_INCLUDE_DIR} ${PEGTL_INCLUDE_DIR} ${CMAKE_CURRENT_SOURCE_DIR})

--- a/src/impl/android/android_external_commit_helper.cpp
+++ b/src/impl/android/android_external_commit_helper.cpp
@@ -66,7 +66,7 @@ void notify_fd(int fd)
 }
 } // anonymous namespace
 
-void ExternalCommitHelper::FdHolder::close()
+void AndroidExternalCommitHelper::FdHolder::close()
 {
     if (m_fd != -1) {
         ::close(m_fd);
@@ -74,7 +74,7 @@ void ExternalCommitHelper::FdHolder::close()
     m_fd = -1;
 }
 
-ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent)
+AndroidExternalCommitHelper::AndroidExternalCommitHelper(RealmCoordinator& parent)
 : m_parent(parent)
 {
     m_epfd = epoll_create(1);
@@ -146,13 +146,13 @@ ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent)
     });
 }
 
-ExternalCommitHelper::~ExternalCommitHelper()
+AndroidExternalCommitHelper::~AndroidExternalCommitHelper()
 {
     notify_fd(m_shutdown_write_fd);
     m_thread.join(); // Wait for the thread to exit
 }
 
-void ExternalCommitHelper::listen()
+void AndroidExternalCommitHelper::listen()
 {
     pthread_setname_np(pthread_self(), "Realm notification listener");
 
@@ -195,7 +195,17 @@ void ExternalCommitHelper::listen()
 }
 
 
-void ExternalCommitHelper::notify_others()
+void AndroidExternalCommitHelper::notify_others()
 {
     notify_fd(m_notify_fd);
+}
+
+namespace realm {
+namespace _impl{
+
+ExternalCommitHelperImpl* get_external_commit_helper(RealmCoordinator& parent) {
+    return new AndroidExternalCommitHelper(parent);
+}
+
+}
 }

--- a/src/impl/apple/apple_external_commit_helper.cpp
+++ b/src/impl/apple/apple_external_commit_helper.cpp
@@ -55,7 +55,7 @@ void notify_fd(int fd, int read_fd)
 }
 } // anonymous namespace
 
-void ExternalCommitHelper::FdHolder::close()
+void AppleExternalCommitHelper::FdHolder::close()
 {
     if (m_fd != -1) {
         ::close(m_fd);
@@ -86,7 +86,7 @@ void ExternalCommitHelper::FdHolder::close()
 // signal the runloop source and wake up the target runloop, and when data is
 // written to the anonymous pipe the background thread removes the runloop
 // source from the runloop and and shuts down.
-ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent)
+AppleExternalCommitHelper::AppleExternalCommitHelper(RealmCoordinator& parent)
 : m_parent(parent)
 {
     m_kq = kqueue();
@@ -171,13 +171,13 @@ ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent)
     });
 }
 
-ExternalCommitHelper::~ExternalCommitHelper()
+AppleExternalCommitHelper::~AppleExternalCommitHelper()
 {
     notify_fd(m_shutdown_write_fd, m_shutdown_read_fd);
     m_thread.wait(); // Wait for the thread to exit
 }
 
-void ExternalCommitHelper::listen()
+void AppleExternalCommitHelper::listen()
 {
     pthread_setname_np("RLMRealm notification listener");
 
@@ -215,7 +215,7 @@ void ExternalCommitHelper::listen()
     }
 }
 
-void ExternalCommitHelper::notify_others()
+void AppleExternalCommitHelper::notify_others()
 {
     if (m_notify_fd_write != -1) {
         notify_fd(m_notify_fd_write, m_notify_fd);
@@ -223,4 +223,14 @@ void ExternalCommitHelper::notify_others()
     else {
         notify_fd(m_notify_fd, m_notify_fd);
     }
+}
+
+namespace realm {
+namespace _impl{
+
+ExternalCommitHelperImpl* get_external_commit_helper(RealmCoordinator& parent) {
+    return new AppleExternalCommitHelper(parent);
+}
+
+}
 }

--- a/src/impl/apple/apple_external_commit_helper.hpp
+++ b/src/impl/apple/apple_external_commit_helper.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2016 Realm Inc.
+// Copyright 2015 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,17 +16,23 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#include <thread>
+#ifndef APPLE_EXTERNAL_COMMIT_HELPER
+#define APPLE_EXTERNAL_COMMIT_HELPER
+
+#include <future>
+
+#include "impl/external_commit_helper.hpp"
 
 namespace realm {
+class Realm;
 
 namespace _impl {
 class RealmCoordinator;
 
-class ExternalCommitHelper {
+class AppleExternalCommitHelper : public ExternalCommitHelperImpl {
 public:
-    ExternalCommitHelper(RealmCoordinator& parent);
-    ~ExternalCommitHelper();
+    AppleExternalCommitHelper(RealmCoordinator& parent);
+    ~AppleExternalCommitHelper();
 
     void notify_others();
 
@@ -39,9 +45,9 @@ private:
         ~FdHolder() { close(); }
         operator int() const { return m_fd; }
 
-        FdHolder& operator=(int new_fd) {
+        FdHolder& operator=(int newFd) {
             close();
-            m_fd = new_fd;
+            m_fd = newFd;
             return *this;
         }
 
@@ -58,19 +64,24 @@ private:
     RealmCoordinator& m_parent;
 
     // The listener thread
-    std::thread m_thread;
+    std::future<void> m_thread;
 
-    // Read-write file descriptor for the named pipe which is waited on for
-    // changes and written to when a commit is made
+    // Pipe which is waited on for changes and written to when there is a new
+    // commit to notify others of. When using a named pipe m_notify_fd is
+    // read-write and m_notify_fd_write is unused; when using an anonymous pipe
+    // (on tvOS) m_notify_fd is read-only and m_notify_fd_write is write-only.
     FdHolder m_notify_fd;
-    // File descriptor for epoll
-    FdHolder m_epfd;
+    FdHolder m_notify_fd_write;
+
+    // File descriptor for the kqueue
+    FdHolder m_kq;
+
     // The two ends of an anonymous pipe used to notify the kqueue() thread that
     // it should be shut down.
     FdHolder m_shutdown_read_fd;
     FdHolder m_shutdown_write_fd;
 };
-
 } // namespace _impl
 } // namespace realm
 
+#endif // APPLE_EXTERNAL_COMMIT_HELPER

--- a/src/impl/external_commit_helper.hpp
+++ b/src/impl/external_commit_helper.hpp
@@ -15,18 +15,46 @@
 // limitations under the License.
 //
 ////////////////////////////////////////////////////////////////////////////
+#ifndef EXTERNAL_COMMIT_HELPER
+#define EXTERNAL_COMMIT_HELPER
 
-#ifndef REALM_EXTERNAL_COMMIT_HELPER_HPP
-#define REALM_EXTERNAL_COMMIT_HELPER_HPP
+#include <realm/group_shared.hpp>
 
-#include <realm/util/features.h>
+#include <future>
 
-#if REALM_PLATFORM_APPLE
-#include "impl/apple/external_commit_helper.hpp"
-#elif REALM_ANDROID
-#include "impl/android/external_commit_helper.hpp"
-#else
-#include "impl/generic/external_commit_helper.hpp"
-#endif
+namespace realm {
+class Replication;
 
-#endif // REALM_EXTERNAL_COMMIT_HELPER_HPP
+namespace _impl {
+
+class RealmCoordinator;
+class ExternalCommitHelperImpl {
+public:
+    ExternalCommitHelperImpl(RealmCoordinator& parent):m_parent(parent) {};
+    virtual ~ExternalCommitHelperImpl() {};
+
+    virtual void notify_others() = 0;
+
+protected:
+    RealmCoordinator& m_parent;
+};
+
+// Implement this function to return the implementation instance.
+extern ExternalCommitHelperImpl* get_external_commit_helper(RealmCoordinator& parent);
+
+class ExternalCommitHelper {
+public:
+    ExternalCommitHelper(_impl::RealmCoordinator& parent) : impl(get_external_commit_helper(parent)) {}
+    ~ExternalCommitHelper() {};
+
+    void notify_others() { impl-> notify_others(); }
+
+private:
+    const std::unique_ptr<ExternalCommitHelperImpl> impl;
+};
+
+} // namespace _impl
+} // namespace realm
+
+#endif // EXTERNAL_COMMIT_HELPER
+

--- a/src/impl/generic/generic_external_commit_helper.hpp
+++ b/src/impl/generic/generic_external_commit_helper.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2015 Realm Inc.
+// Copyright 2016 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -16,9 +16,14 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+#ifndef GENERIC_EXTERNAL_COMMIT_HELPER
+#define GENERIC_EXTERNAL_COMMIT_HELPER
+
 #include <realm/group_shared.hpp>
 
 #include <future>
+
+#include "impl/external_commit_helper.hpp"
 
 namespace realm {
 class Replication;
@@ -26,16 +31,15 @@ class Replication;
 namespace _impl {
 class RealmCoordinator;
 
-class ExternalCommitHelper {
+class GenericExternalCommitHelper : public ExternalCommitHelperImpl {
 public:
-    ExternalCommitHelper(RealmCoordinator& parent);
-    ~ExternalCommitHelper();
+    GenericExternalCommitHelper(RealmCoordinator& parent);
+    ~GenericExternalCommitHelper();
 
     // A no-op in this version, but needed for the Apple version
-    void notify_others() { }
+    void notify_others() override { }
 
 private:
-    RealmCoordinator& m_parent;
 
     // A shared group used to listen for changes
     std::unique_ptr<Replication> m_history;
@@ -47,4 +51,6 @@ private:
 
 } // namespace _impl
 } // namespace realm
+
+#endif // GENERIC_EXTERNAL_COMMIT_HELPER
 


### PR DESCRIPTION
Use macro to choose the implementation is not flexible enough and easy
to make mistakes.
Just use global function to return the implementation instance during
run time.

Especially for realm-java, it probably will use an empty commit helper
at the beginning which makes the marcos even more complex.