### PR TITLE
[Apple] Only notify a Realm if it isn't closed yet

### DIFF
--- a/src/impl/apple/weak_realm_notifier.cpp
+++ b/src/impl/apple/weak_realm_notifier.cpp
@@ -37,7 +37,9 @@ WeakRealmNotifier::WeakRealmNotifier(const std::shared_ptr<Realm>& realm, bool c
     ctx.info = new RefCountedWeakPointer{realm, {0}};
     ctx.perform = [](void* info) {
         if (auto realm = static_cast<RefCountedWeakPointer*>(info)->realm.lock()) {
-            realm->notify();
+            if (!realm->is_closed()) {
+                realm->notify();
+            }
         }
     };
     ctx.retain = [](const void* info) {


### PR DESCRIPTION
As discovered in https://github.com/realm/realm-dotnet/issues/653, when lots and lots of realms are opened and closed rapidly in a parallel scenario a WeakRealmNotifier notification can arrive after the realm is closed but before it's freed which results in a crash when we call `Realm::notify()`.

This check is already performed in the Android WeakRealmNotifier.
