### PR TITLE
Specify width of PropertyType to 1 byte

### DIFF
--- a/src/property.hpp
+++ b/src/property.hpp
@@ -22,7 +22,7 @@
 #include <string>
 
 namespace realm {
-    enum class PropertyType {
+    enum class PropertyType : unsigned char {
         Int    = 0,
         Bool   = 1,
         Float  = 9,


### PR DESCRIPTION
We need this to be explicit to marshal it in .NET
