### PR TITLE
Eliminate some string copies for Schema::find()

### DIFF
--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -52,25 +52,25 @@ Schema::Schema(base types) : base(std::move(types))
     std::sort(begin(), end(), compare_by_name);
 }
 
-Schema::iterator Schema::find(std::string const& name)
+Schema::iterator Schema::find(StringData name)
 {
-    ObjectSchema cmp;
-    cmp.name = name;
-    return find(cmp);
+    auto it = std::lower_bound(begin(), end(), name, [](ObjectSchema const& lft, StringData rgt) {
+        return lft.name < rgt;
+    });
+    if (it != end() && it->name != name) {
+        it = end();
+    }
+    return it;
 }
 
-Schema::const_iterator Schema::find(std::string const& name) const
+Schema::const_iterator Schema::find(StringData name) const
 {
     return const_cast<Schema *>(this)->find(name);
 }
 
 Schema::iterator Schema::find(ObjectSchema const& object) noexcept
 {
-    auto it = std::lower_bound(begin(), end(), object, compare_by_name);
-    if (it != end() && it->name != object.name) {
-        it = end();
-    }
-    return it;
+    return find(object.name);
 }
 
 Schema::const_iterator Schema::find(ObjectSchema const& object) const noexcept

--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -34,10 +34,6 @@ bool operator==(Schema const& a, Schema const& b)
 }
 }
 
-static bool compare_by_name(ObjectSchema const& lft, ObjectSchema const& rgt) {
-    return lft.name < rgt.name;
-}
-
 Schema::Schema() = default;
 Schema::~Schema() = default;
 Schema::Schema(Schema const&) = default;
@@ -49,7 +45,9 @@ Schema::Schema(std::initializer_list<ObjectSchema> types) : Schema(base(types)) 
 
 Schema::Schema(base types) : base(std::move(types))
 {
-    std::sort(begin(), end(), compare_by_name);
+    std::sort(begin(), end(), [](ObjectSchema const& lft, ObjectSchema const& rgt) {
+        return lft.name < rgt.name;
+    });
 }
 
 Schema::iterator Schema::find(StringData name)

--- a/src/schema.hpp
+++ b/src/schema.hpp
@@ -23,8 +23,9 @@
 #include <vector>
 
 namespace realm {
-class SchemaChange;
 class ObjectSchema;
+class SchemaChange;
+class StringData;
 struct Property;
 
 class Schema : private std::vector<ObjectSchema> {
@@ -43,8 +44,8 @@ public:
     Schema& operator=(Schema&&);
 
     // find an ObjectSchema by name
-    iterator find(std::string const& name);
-    const_iterator find(std::string const& name) const;
+    iterator find(StringData name);
+    const_iterator find(StringData name) const;
 
     // find an ObjectSchema with the same name as the passed in one
     iterator find(ObjectSchema const& object) noexcept;


### PR DESCRIPTION
This gives a surprisingly large speedup for Realm instance init.