### PR TITLE
Fix warning about toString being unused when building tests

### DIFF
--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -65,13 +65,16 @@ struct SchemaChangePrinter {
 };
 
 namespace Catch {
-std::string toString(SchemaChange const& sc)
-{
-    std::stringstream ss;
-    sc.visit(SchemaChangePrinter{ss});
-    return ss.str();
-}
-}
+template<>
+struct StringMaker<SchemaChange> {
+    static std::string convert(SchemaChange const& sc)
+    {
+        std::stringstream ss;
+        sc.visit(SchemaChangePrinter{ss});
+        return ss.str();
+    }
+};
+} // namespace Catch
 
 TEST_CASE("ObjectSchema") {
     SECTION("from a Group") {


### PR DESCRIPTION
The overload of `toString` we were providing wasn't being picked up by Catch, and so was never being called. Switch to their suggested alternative approach of providing a specialization of `StringMaker`. This specialization is correctly picked up by Catch.

/cc @tgoyne 