### PR TITLE
Ensure manipulation of `Realm` must go through a `SharedRealm`

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -98,7 +98,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
         }
     }
 
-    auto realm = std::make_shared<Realm>(std::move(config));
+    auto realm = Realm::make_shared_realm(std::move(config));
     if (!config.read_only() && !m_notifier && config.automatic_change_notifications) {
         try {
             m_notifier = std::make_unique<ExternalCommitHelper>(*this);


### PR DESCRIPTION
Addresses https://github.com/realm/realm-object-store/issues/117 //cc @bdash @tgoyne 