### PR TITLE
Add RealmFriend for java-binding and fix other build issues

### DIFF
--- a/src/impl/android/weak_realm_notifier.cpp
+++ b/src/impl/android/weak_realm_notifier.cpp
@@ -100,7 +100,7 @@ void WeakRealmNotifier::notify()
         // to do so we allocate a weak pointer on the heap and send its address over a pipe.
         // the other end of the pipe is read by the realm thread. when it's done with the pointer, it deletes it.
         auto realm_ptr = new std::weak_ptr<Realm>(realm());
-        if (write(m_message_pipe.write, &realm_ptr, sizeof(realm_ptr)) != sizeof(realm_ptr)) {
+        if (::write(m_message_pipe.write, &realm_ptr, sizeof(realm_ptr)) != sizeof(realm_ptr)) {
             delete realm_ptr;
             LOGE("Buffer overrun when writing to WeakRealmNotifier's ALooper message pipe.");
         }

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -446,7 +446,9 @@ bool Realm::compact()
 
 void Realm::write_copy(StringData path, BinaryData key)
 {
-    REALM_ASSERT(!key.data() || key.size() == 64);
+    if ((key.data() && key.size() != 64)) {
+        throw InvalidEncryptionKeyException();
+    }
     verify_thread();
     try {
         read_group().write(path, key.data());

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -26,6 +26,8 @@
 #include <memory>
 #include <thread>
 
+#include <realm/group_shared.hpp>
+
 namespace realm {
 class BinaryData;
 class BindingContext;
@@ -42,6 +44,7 @@ namespace _impl {
     class ListNotifier;
     class RealmCoordinator;
     class ResultsNotifier;
+    class RealmFriend;
 }
 
 // How to handle update_schema() being called on a file which has
@@ -271,6 +274,8 @@ public:
 
     // FIXME private
     Group& read_group();
+
+    friend class _impl::RealmFriend;
 };
 
 class RealmFileException : public std::runtime_error {
@@ -328,6 +333,24 @@ class InvalidEncryptionKeyException : public std::logic_error {
 public:
     InvalidEncryptionKeyException() : std::logic_error("Encryption key must be 64 bytes.") {}
 };
+
+// FIXME Those are exposed for Java async queries, mainly because of handover related methods.
+class _impl::RealmFriend {
+public:
+    static SharedGroup& get_shared_group(Realm& realm) { return *realm.m_shared_group; }
+    static Group& read_group_to(Realm& realm, SharedGroup::VersionID& version) {
+        if (!realm.m_group) {
+            realm.m_group = &const_cast<Group&>(realm.m_shared_group->begin_read(version));
+            realm.add_schema_change_handler();
+        }
+        else if (version != realm.m_shared_group->get_version_of_current_transaction()) {
+            realm.m_shared_group->end_read();
+            realm.m_group = &const_cast<Group&>(realm.m_shared_group->begin_read(version));
+        }
+        return *realm.m_group;
+    }
+};
+
 } // namespace realm
 
 #endif /* defined(REALM_REALM_HPP) */


### PR DESCRIPTION
Ideally Java should use the async query logic from OS, but since the
behaviours are not exact the same right now, Java will keep the current
async implementation for a bit while.

Expose SharedGroup and Group pointer by RealmFriend to make java's async
query work.