### PR TITLE
Set up notifier immediately after creating results table view

### DIFF
--- a/src/results.cpp
+++ b/src/results.cpp
@@ -267,7 +267,7 @@ void Results::update_tableview(bool wants_notifications)
                 m_table_view.sort(m_sort);
             }
             m_mode = Mode::TableView;
-            break;
+            REALM_FALLTHROUGH;
         case Mode::TableView:
             if (wants_notifications && !m_notifier && !m_realm->is_in_transaction() && m_realm->can_deliver_notifications()) {
                 m_notifier = std::make_shared<_impl::ResultsNotifier>(*this);


### PR DESCRIPTION
We previously did not set up the notifier until `update_tableview` was called while `m_mode` was `Mode::TableView`. This led to us not creating the notifier until the second access (since `m_mode` is query on the first access when the table view is created). This PR corrects this buggy behavior to what was intended.

Note that this fall through leads to `sync_if_needed` being unnecessarily called, but it's supposedly cheap. We could duplicate the notifier setup code in the query case if we're worried about this.

//cc @bdash @tgoyne 