### PR TITLE
Fix include path for handover.hpp

### DIFF
--- a/src/impl/handover.cpp
+++ b/src/impl/handover.cpp
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#include "handover.hpp"
+#include "impl/handover.hpp"
 
 using namespace realm;
 using namespace realm::_impl;


### PR DESCRIPTION
All include paths need to be relative to `src` for non-Xcode/CMake builds to work.