### PR TITLE
Fix running the tests on OS X with locally-built core

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,7 +21,7 @@ set(SOURCES
 )
 
 add_executable(tests ${SOURCES} ${HEADERS})
-target_link_libraries(tests realm-object-store realm ${PLATFORM_LIBRARIES})
+target_link_libraries(tests realm-object-store ${PLATFORM_LIBRARIES})
 
 create_coverage_target(generate-coverage tests)
 


### PR DESCRIPTION
Don't link the core static library directly into the tests binary. This results in two copies of core being present (one in tests, one in librealm-object-store.dylib), causing havoc.

This was broken by #134. I don't have a working Android setup at the moment so I cannot tell what impact this fix has on the work done in #134.

/cc @tgoyne