### PR TITLE
Fix incorrect row index updating for List notifications

### DIFF
--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -626,6 +626,10 @@ public:
         REALM_ASSERT(!unordered);
         if (auto change = get_change())
             change->insert(row_ndx, num_rows_to_insert, need_move_info());
+        for (auto& list : m_info.lists) {
+            if (list.row_ndx >= row_ndx)
+                list.row_ndx += num_rows_to_insert;
+        }
 
         return true;
     }
@@ -642,7 +646,7 @@ public:
                     m_info.lists.pop_back();
                     continue;
                 }
-                if (it->row_ndx == last_row - 1)
+                if (it->row_ndx == last_row)
                     it->row_ndx = row_ndx;
             }
             ++it;

--- a/tests/list.cpp
+++ b/tests/list.cpp
@@ -314,6 +314,24 @@ TEST_CASE("list") {
             REQUIRE_INDICES(change.modifications, 5);
             REQUIRE_MOVES(change, {1, 2});
         }
+
+        SECTION("moving the list's containing row does not break notifications") {
+            auto token = require_change();
+            write([&] {
+                origin->insert_empty_row(0, 2);
+                lv->add(1);
+            });
+            REQUIRE_INDICES(change.insertions, 10);
+
+            write([&] {
+                // delete the row after it, then the row before it so that it
+                // is moved by the deletion
+                origin->move_last_over(3);
+                origin->move_last_over(0);
+                lv->add(2);
+            });
+            REQUIRE_INDICES(change.insertions, 11);
+        }
     }
 
     SECTION("sorted add_notification_block()") {


### PR DESCRIPTION
Non-end row insertions and move_last_over() can move the row containing a List being observed, which was not being handled correctly.