### PR TITLE
Switch to building the object store as a static library only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,8 +11,7 @@ CMakeScripts/
 realm-object-store.xcodeproj/
 
 # Build products
-src/librealm-object-store.dylib
-src/librealm-object-store-static.a
+src/librealm-object-store.a
 tests/tests
 *.build/
 Debug/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,19 +73,8 @@ set(INCLUDE_DIRS
     ${UV_INCLUDE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR})
 
-# An object library to group together the compilation of the source files.
-add_library(realm-object-store-objects OBJECT ${SOURCES} ${HEADERS})
-add_dependencies(realm-object-store-objects realm)
-target_compile_definitions(realm-object-store-objects PRIVATE ${PLATFORM_DEFINES})
-set_target_properties(realm-object-store-objects PROPERTIES POSITION_INDEPENDENT_CODE 1)
-target_include_directories(realm-object-store-objects PUBLIC ${INCLUDE_DIRS})
-
-# A static library, aggregating the prebuilt object files.
-add_library(realm-object-store-static STATIC $<TARGET_OBJECTS:realm-object-store-objects>)
-target_include_directories(realm-object-store-static PUBLIC ${INCLUDE_DIRS})
-target_link_libraries(realm-object-store-static PUBLIC realm ${PLATFORM_LIBRARIES})
-
-# A dynamic library, linking together the prebuilt object files.
-add_library(realm-object-store SHARED $<TARGET_OBJECTS:realm-object-store-objects> placeholder.cpp)
+add_library(realm-object-store STATIC ${SOURCES} ${HEADERS})
+set_target_properties(realm-object-store PROPERTIES POSITION_INDEPENDENT_CODE 1)
+target_compile_definitions(realm-object-store PRIVATE ${PLATFORM_DEFINES})
 target_include_directories(realm-object-store PUBLIC ${INCLUDE_DIRS})
-target_link_libraries(realm-object-store PRIVATE realm ${PLATFORM_LIBRARIES})
+target_link_libraries(realm-object-store PUBLIC realm ${PLATFORM_LIBRARIES})

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,7 +25,7 @@ set(SOURCES
 
 add_executable(tests ${SOURCES} ${HEADERS})
 target_compile_definitions(tests PRIVATE ${PLATFORM_DEFINES})
-target_link_libraries(tests realm-object-store realm ${PLATFORM_LIBRARIES})
+target_link_libraries(tests realm-object-store ${PLATFORM_LIBRARIES})
 
 create_coverage_target(generate-coverage tests)
 


### PR DESCRIPTION
The presence of the dynamic library predates the object store having its own test suite, and was used to catch link errors due to bugs in object store or missing symbols in core. It is no longer needed for this purpose now that object store has a proper test suite.

Removing the dynamic library also works around some linker problems that reveal themselves when using a version of core built with Xcode 8. See https://github.com/realm/realm-object-store/pull/136#issuecomment-242897308 for the gory details.

/cc @tgoyne 