### PR TITLE
Handle Lists moving due to unique key reuse

### DIFF
--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -657,6 +657,15 @@ public:
         return true;
     }
 
+    bool change_link_targets(size_t from, size_t to)
+    {
+        for (auto& list : m_info.lists) {
+            if (list.table_ndx == current_table() && list.row_ndx == from)
+                list.row_ndx = to;
+        }
+        return true;
+    }
+
     bool clear_table()
     {
         auto tbl_ndx = current_table();

--- a/tests/list.cpp
+++ b/tests/list.cpp
@@ -42,6 +42,7 @@ TEST_CASE("list") {
     auto r = Realm::get_shared_realm(config);
     r->update_schema({
         {"origin", {
+            {"pk", PropertyType::Int, "", "", true},
             {"array", PropertyType::Array, "target"}
         }},
         {"target", {
@@ -67,10 +68,12 @@ TEST_CASE("list") {
         target->set_int(0, i, i);
 
     origin->add_empty_row(2);
-    LinkViewRef lv = origin->get_linklist(0, 0);
+    origin->set_int_unique(0, 0, 1);
+    origin->set_int_unique(0, 1, 2);
+    LinkViewRef lv = origin->get_linklist(1, 0);
     for (int i = 0; i < 10; ++i)
         lv->add(i);
-    LinkViewRef lv2 = origin->get_linklist(0, 1);
+    LinkViewRef lv2 = origin->get_linklist(1, 1);
     for (int i = 0; i < 10; ++i)
         lv2->add(i);
 
@@ -206,7 +209,7 @@ TEST_CASE("list") {
 
             auto get_list = [&] {
                 auto r = Realm::get_shared_realm(config);
-                auto lv = r->read_group().get_table("class_origin")->get_linklist(0, 0);
+                auto lv = r->read_group().get_table("class_origin")->get_linklist(1, 0);
                 return List(r, lv);
             };
             auto change_list = [&] {
@@ -316,20 +319,37 @@ TEST_CASE("list") {
 
         SECTION("moving the list's containing row does not break notifications") {
             auto token = require_change();
+
+            // insert rows before it
             write([&] {
                 origin->insert_empty_row(0, 2);
                 lv->add(1);
             });
             REQUIRE_INDICES(change.insertions, 10);
+            REQUIRE(lst.size() == 11);
+            REQUIRE(lst.get(10).get_index() == 1);
 
+            // delete the row after it, then the row before it so that it
+            // is moved by the deletion
             write([&] {
-                // delete the row after it, then the row before it so that it
-                // is moved by the deletion
                 origin->move_last_over(3);
                 origin->move_last_over(0);
                 lv->add(2);
             });
             REQUIRE_INDICES(change.insertions, 11);
+            REQUIRE(lst.size() == 12);
+            REQUIRE(lst.get(11).get_index() == 2);
+
+            // add a new row with the same primary key
+            write([&] {
+                size_t row = origin->add_empty_row(2);
+                origin->set_int_unique(0, 2, 1);
+                origin->get_linklist(1, 2)->add(3);
+            });
+            REQUIRE(origin->size() == 3);
+            REQUIRE_INDICES(change.insertions, 12);
+            REQUIRE(lst.size() == 13);
+            REQUIRE(lst.get(12).get_index() == 3);
         }
     }
 

--- a/tests/list.cpp
+++ b/tests/list.cpp
@@ -32,6 +32,7 @@
 
 #include <realm/group_shared.hpp>
 #include <realm/link_view.hpp>
+#include <realm/version.hpp>
 
 using namespace realm;
 
@@ -340,6 +341,7 @@ TEST_CASE("list") {
             REQUIRE(lst.size() == 12);
             REQUIRE(lst.get(11).get_index() == 2);
 
+#if REALM_VER_MAJOR >= 2
             // add a new row with the same primary key
             write([&] {
                 size_t row = origin->add_empty_row(2);
@@ -350,6 +352,7 @@ TEST_CASE("list") {
             REQUIRE_INDICES(change.insertions, 12);
             REQUIRE(lst.size() == 13);
             REQUIRE(lst.get(12).get_index() == 3);
+#endif
         }
     }
 


### PR DESCRIPTION
Requires https://github.com/realm/realm-core/pull/2093 to actually work in a useful way.

All other notification types also have issues related to objects being subsumed which need to be addressed separately.