### PR TITLE
Implement remaining transaction log instructions for collection notifications

### DIFF
--- a/src/binding_context.hpp
+++ b/src/binding_context.hpp
@@ -99,7 +99,7 @@ public:
 
     // Called immediately after the read transaction version is advanced. Unlike
     // will_change(), this is called even if detailed change information was not
-    // requested or if the Realm is not actually in a read transactuib, although
+    // requested or if the Realm is not actually in a read transaction, although
     // both vectors will be empty in that case.
     virtual void did_change(std::vector<ObserverState> const& observers,
                             std::vector<void*> const& invalidated);

--- a/src/impl/collection_change_builder.cpp
+++ b/src/impl/collection_change_builder.cpp
@@ -363,9 +363,10 @@ void CollectionChangeBuilder::swap(size_t ndx_1, size_t ndx_2, bool track_moves)
     auto move_2 = m_move_mapping.find(ndx_2);
     bool have_move_1 = move_1 != end(m_move_mapping) && move_1->first == ndx_1;
     bool have_move_2 = move_2 != end(m_move_mapping) && move_2->first == ndx_2;
-    if (have_move_1 && have_move_2)
+    if (have_move_1 && have_move_2) {
         // both are already moves, so just swap the destinations
         std::swap(move_1->second, move_2->second);
+    }
     else if (have_move_1) {
         update_move(move_1, ndx_2, ndx_1);
     }
@@ -399,7 +400,7 @@ void CollectionChangeBuilder::subsume(size_t old_ndx, size_t new_ndx, bool track
     REALM_ASSERT_DEBUG(insertions.contains(new_ndx));
     REALM_ASSERT_DEBUG(!m_move_mapping.count(new_ndx));
 
-    // If the source row was already moved, update the exist move
+    // If the source row was already moved, update the existing move
     auto it = m_move_mapping.find(old_ndx);
     if (it != m_move_mapping.end() && it->first == old_ndx) {
         m_move_mapping[new_ndx] = it->second;
@@ -439,14 +440,14 @@ struct RowInfo {
 //
 // This function is not strictly required, as calculate_moves_sorted() will
 // produce correct results even for the scenarios where this function is used.
-// However, this function has asymtotically better worst-case performance and
+// However, this function has asymptotically better worst-case performance and
 // extremely cheap best-case performance, and is guaranteed to produce a minimal
 // diff when the only row moves are due to move_last_over().
 void calculate_moves_unsorted(std::vector<RowInfo>& new_rows, IndexSet& removed,
                               IndexSet const& move_candidates,
                               CollectionChangeSet& changeset)
 {
-    // Here we track which row we expect to see, which in the absense of swap()
+    // Here we track which row we expect to see, which in the absence of swap()
     // is always the row immediately after the last row which was not moved.
     size_t expected = 0;
     for (auto& row : new_rows) {

--- a/src/impl/collection_change_builder.hpp
+++ b/src/impl/collection_change_builder.hpp
@@ -21,6 +21,8 @@
 
 #include "collection_notifications.hpp"
 
+#include <realm/util/optional.hpp>
+
 #include <unordered_map>
 
 namespace realm {
@@ -39,24 +41,38 @@ public:
 
     // Calculate where rows need to be inserted or deleted from old_rows to turn
     // it into new_rows, and check all matching rows for modifications
+    // If `move_candidates` is supplied they it will eb used to do more accurate
+    // determination of which rows moved. This is only supported when the rows
+    // are in table order (i.e. not sorted or from a LinkList)
     static CollectionChangeBuilder calculate(std::vector<size_t> const& old_rows,
                                              std::vector<size_t> const& new_rows,
                                              std::function<bool (size_t)> row_did_change,
-                                             bool sort);
+                                             util::Optional<IndexSet> const& move_candidates = util::none);
 
+    // generic operations {
+    CollectionChangeSet finalize() &&;
     void merge(CollectionChangeBuilder&&);
-    void clean_up_stale_moves();
 
     void insert(size_t ndx, size_t count=1, bool track_moves=true);
     void modify(size_t ndx);
     void erase(size_t ndx);
-    void move_over(size_t ndx, size_t last_ndx, bool track_moves=true);
     void clear(size_t old_size);
+    // }
+
+    // operations only implemented for LinkList semantics {
+    void clean_up_stale_moves();
     void move(size_t from, size_t to);
+    // }
+
+    // operations only implemented for Row semantics {
+    void move_over(size_t ndx, size_t last_ndx, bool track_moves=true);
+    // must be followed by move_over(old_ndx, ...)
+    // precondition: `new_ndx` must be a new insertion
+    void subsume(size_t old_ndx, size_t new_ndx, bool track_moves=true);
+    void swap(size_t ndx_1, size_t ndx_2, bool track_moves=true);
 
     void parse_complete();
-
-    CollectionChangeSet finalize() &&;
+    // }
 
 private:
     std::unordered_map<size_t, size_t> m_move_mapping;

--- a/src/impl/collection_change_builder.hpp
+++ b/src/impl/collection_change_builder.hpp
@@ -41,7 +41,7 @@ public:
 
     // Calculate where rows need to be inserted or deleted from old_rows to turn
     // it into new_rows, and check all matching rows for modifications
-    // If `move_candidates` is supplied they it will eb used to do more accurate
+    // If `move_candidates` is supplied they it will be used to do more accurate
     // determination of which rows moved. This is only supported when the rows
     // are in table order (i.e. not sorted or from a LinkList)
     static CollectionChangeBuilder calculate(std::vector<size_t> const& old_rows,

--- a/src/impl/results_notifier.cpp
+++ b/src/impl/results_notifier.cpp
@@ -111,6 +111,7 @@ void ResultsNotifier::calculate_changes()
         for (size_t i = 0; i < m_tv.size(); ++i)
             next_rows.push_back(m_tv[i].get_index());
 
+        util::Optional<IndexSet> move_candidates;
         if (changes) {
             auto const& moves = changes->moves;
             for (auto& idx : m_previous_rows) {
@@ -123,11 +124,13 @@ void ResultsNotifier::calculate_changes()
                 else
                     REALM_ASSERT_DEBUG(!changes->insertions.contains(idx));
             }
+            if (m_target_is_in_table_order && !m_sort)
+                move_candidates = changes->insertions;
         }
 
         m_changes = CollectionChangeBuilder::calculate(m_previous_rows, next_rows,
                                                        get_modification_checker(*m_info, *m_query->get_table()),
-                                                       m_target_is_in_table_order && !m_sort);
+                                                       move_candidates);
 
         m_previous_rows = std::move(next_rows);
     }

--- a/tests/handover.cpp
+++ b/tests/handover.cpp
@@ -89,16 +89,8 @@ TEST_CASE("handover") {
     }
 
     SECTION("cleanup properly unpins version") {
-#if REALM_VER_MAJOR >= 2
-        auto history = realm::make_in_realm_history(config.path);
-#else
-        auto history = realm::make_client_history(config.path, config.encryption_key.data());   
-#endif
-#ifdef REALM_GROUP_SHARED_OPTIONS_HPP
-        SharedGroup shared_group(*history, SharedGroupOptions(SharedGroupOptions::Durability::MemOnly));
-#else
-        SharedGroup shared_group(*history, SharedGroup::durability_MemOnly);
-#endif
+        auto history = config.make_history();
+        SharedGroup shared_group(*history, config.options());
 
         auto get_current_version = [&]() -> SharedGroup::VersionID {
             shared_group.begin_read();

--- a/tests/list.cpp
+++ b/tests/list.cpp
@@ -367,28 +367,44 @@ TEST_CASE("list") {
             REQUIRE(lst.size() == 11);
             REQUIRE(lst.get(10).get_index() == 1);
 
-            // delete the row after it, then the row before it so that it
-            // is moved by the deletion
+            // swap the row containing it with another row
             write([&] {
-                origin->move_last_over(3);
-                origin->move_last_over(0);
+                origin->swap_rows(2, 3);
                 lv->add(2);
             });
             REQUIRE_INDICES(change.insertions, 11);
             REQUIRE(lst.size() == 12);
             REQUIRE(lst.get(11).get_index() == 2);
 
+            // swap it back to verify both of the rows in the swap are handled
+            write([&] {
+                origin->swap_rows(2, 3);
+                lv->add(3);
+            });
+            REQUIRE_INDICES(change.insertions, 12);
+            REQUIRE(lst.size() == 13);
+            REQUIRE(lst.get(12).get_index() == 3);
+
+            // delete a row so that it's moved (as it's at the end)
+            write([&] {
+                origin->move_last_over(0);
+                lv->add(4);
+            });
+            REQUIRE_INDICES(change.insertions, 13);
+            REQUIRE(lst.size() == 14);
+            REQUIRE(lst.get(13).get_index() == 4);
+
 #if REALM_VER_MAJOR >= 2
             // add a new row with the same primary key
             write([&] {
                 size_t row = origin->add_empty_row(2);
-                origin->set_int_unique(0, 2, 1);
-                origin->get_linklist(1, 2)->add(3);
+                origin->set_int_unique(0, row, 1);
+                origin->get_linklist(1, row)->add(5);
             });
-            REQUIRE(origin->size() == 3);
-            REQUIRE_INDICES(change.insertions, 12);
-            REQUIRE(lst.size() == 13);
-            REQUIRE(lst.get(12).get_index() == 3);
+            REQUIRE(origin->size() == 4);
+            REQUIRE_INDICES(change.insertions, 14);
+            REQUIRE(lst.size() == 15);
+            REQUIRE(lst.get(14).get_index() == 5);
 #endif
         }
     }

--- a/tests/list.cpp
+++ b/tests/list.cpp
@@ -393,19 +393,6 @@ TEST_CASE("list") {
             REQUIRE_INDICES(change.insertions, 13);
             REQUIRE(lst.size() == 14);
             REQUIRE(lst.get(13).get_index() == 4);
-
-#if REALM_VER_MAJOR >= 2
-            // add a new row with the same primary key
-            write([&] {
-                size_t row = origin->add_empty_row(2);
-                origin->set_int_unique(0, row, 1);
-                origin->get_linklist(1, row)->add(5);
-            });
-            REQUIRE(origin->size() == 4);
-            REQUIRE_INDICES(change.insertions, 14);
-            REQUIRE(lst.size() == 15);
-            REQUIRE(lst.get(14).get_index() == 5);
-#endif
         }
     }
 

--- a/tests/transaction_log_parsing.cpp
+++ b/tests/transaction_log_parsing.cpp
@@ -23,6 +23,7 @@
 
 #include "impl/collection_notifier.hpp"
 #include "impl/transact_log_handler.hpp"
+#include "binding_context.hpp"
 #include "property.hpp"
 #include "object_schema.hpp"
 #include "schema.hpp"
@@ -1083,6 +1084,505 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
                 lv->add(0);
             }
             REQUIRE_INDICES(changes.insertions, 10, 11, 12);
+        }
+    }
+
+    SECTION("object change information") {
+        config.cache = false;
+        auto realm = Realm::get_shared_realm(config);
+        realm->update_schema({
+            {"origin", {
+                {"pk", PropertyType::Int, "", "", true, true},
+                {"link", PropertyType::Object, "target", "", false, false, true},
+                {"array", PropertyType::Array, "target"}
+            }},
+            {"origin 2", {
+                {"pk", PropertyType::Int, "", "", true, true},
+                {"link", PropertyType::Object, "target", "", false, false, true},
+                {"array", PropertyType::Array, "target"}
+            }},
+            {"target", {
+                {"pk", PropertyType::Int, "", "", true, true},
+                {"value 1", PropertyType::Int},
+                {"value 2", PropertyType::Int},
+            }},
+        });
+
+        auto origin = realm->read_group().get_table("class_origin");
+        auto target = realm->read_group().get_table("class_target");
+
+        realm->begin_transaction();
+
+        target->add_empty_row(10);
+        for (int i = 0; i < 10; ++i) {
+            if (i > 0)
+                target->set_int_unique(0, i, i);
+            target->set_int(1, i, i);
+            target->set_int(2, i, i);
+        }
+
+        origin->add_empty_row(3);
+        origin->set_int(0, 0, 5);
+        origin->set_int(0, 1, 1);
+        origin->set_int(0, 2, 2);
+
+        origin->set_link(1, 0, 5);
+        origin->set_link(1, 1, 6);
+
+        LinkViewRef lv = origin->get_linklist(2, 0);
+        for (int i = 0; i < 10; ++i)
+            lv->add(i);
+        LinkViewRef lv2 = origin->get_linklist(2, 1);
+        lv2->add(0);
+
+        realm->read_group().get_table("class_origin 2")->add_empty_row();
+
+        realm->commit_transaction();
+
+        class Context : public BindingContext {
+        public:
+            Context(std::initializer_list<Row> rows)
+            {
+                m_result.reserve(rows.size());
+                for (auto& row : rows) {
+                    m_result.push_back(ObserverState{row.get_table()->get_index_in_group(), row.get_index(),
+                        (void *)(uintptr_t)m_result.size()});
+                }
+            }
+
+            bool modified(size_t index, size_t col)
+            {
+                auto it = std::find_if(begin(m_result), end(m_result),
+                                       [=](auto&& change) { return (void *)(uintptr_t)index == change.info; });
+                if (it == m_result.end() || col >= it->changes.size())
+                    return false;
+                return it->changes[col].kind != BindingContext::ColumnInfo::Kind::None;
+            }
+
+            bool invalidated(size_t index)
+            {
+                return std::find(begin(m_invalidated), end(m_invalidated), (void *)(uintptr_t)index) != end(m_invalidated);
+            }
+
+            bool has_array_change(size_t index, size_t col, ColumnInfo::Kind kind, IndexSet values)
+            {
+                auto& changes = m_result[index].changes;
+                if (changes.size() <= col)
+                    return kind == ColumnInfo::Kind::None;
+                auto& column = changes[col];
+                return column.kind == kind && std::equal(column.indices.as_indexes().begin(), column.indices.as_indexes().end(),
+                                                         values.as_indexes().begin(), values.as_indexes().end());
+            }
+
+        private:
+            std::vector<ObserverState> m_result;
+            std::vector<void*> m_invalidated;
+
+            std::vector<ObserverState> get_observed_rows() override
+            {
+                return m_result;
+            }
+
+            void did_change(std::vector<ObserverState> const& observers,
+                            std::vector<void*> const& invalidated) override
+            {
+                m_invalidated = invalidated;
+                m_result = observers;
+            }
+        };
+
+        auto observe = [&](std::initializer_list<Row> rows, auto&& fn) {
+            auto history = config.make_history();
+            SharedGroup sg(*history, config.options());
+            auto& group = sg.begin_read();
+
+            Context observer(rows);
+
+            realm->begin_transaction();
+            fn();
+            realm->commit_transaction();
+
+            _impl::transaction::advance(sg, &observer, SchemaMode::Automatic);
+            return observer;
+        };
+
+        SECTION("setting a property marks that property as changed") {
+            Row r = target->get(0);
+            auto changes = observe({r}, [&] {
+                r.set_int(0, 1);
+            });
+            REQUIRE(changes.modified(0, 0));
+            REQUIRE_FALSE(changes.modified(0, 1));
+            REQUIRE_FALSE(changes.modified(0, 2));
+        }
+
+        SECTION("self-assignment marks as changed") {
+            Row r = target->get(0);
+            auto changes = observe({r}, [&] {
+                r.set_int(0, r.get_int(0));
+            });
+            REQUIRE(changes.modified(0, 0));
+            REQUIRE_FALSE(changes.modified(0, 1));
+            REQUIRE_FALSE(changes.modified(0, 2));
+        }
+
+        SECTION("SetDefault does not mark as changed") {
+            Row r = target->get(0);
+            auto changes = observe({r}, [&] {
+                r.get_table()->set_int(0, r.get_index(), 5, true);
+            });
+            REQUIRE_FALSE(changes.modified(0, 0));
+            REQUIRE_FALSE(changes.modified(0, 1));
+            REQUIRE_FALSE(changes.modified(0, 2));
+
+        }
+
+        SECTION("multiple properties on a single object are handled properly") {
+            Row r = target->get(0);
+            auto changes = observe({r}, [&] {
+                r.set_int(1, 1);
+            });
+            REQUIRE_FALSE(changes.modified(0, 0));
+            REQUIRE(changes.modified(0, 1));
+            REQUIRE_FALSE(changes.modified(0, 2));
+
+            changes = observe({r}, [&] {
+                r.set_int(2, 1);
+            });
+            REQUIRE_FALSE(changes.modified(0, 0));
+            REQUIRE_FALSE(changes.modified(0, 1));
+            REQUIRE(changes.modified(0, 2));
+
+            changes = observe({r}, [&] {
+                r.set_int(0, 1);
+                r.set_int(2, 1);
+            });
+            REQUIRE(changes.modified(0, 0));
+            REQUIRE_FALSE(changes.modified(0, 1));
+            REQUIRE(changes.modified(0, 2));
+
+            changes = observe({r}, [&] {
+                r.set_int(0, 1);
+                r.set_int(1, 1);
+                r.set_int(2, 1);
+            });
+            REQUIRE(changes.modified(0, 0));
+            REQUIRE(changes.modified(0, 1));
+            REQUIRE(changes.modified(0, 2));
+        }
+
+        SECTION("setting other objects does not mark as changed") {
+            Row r = target->get(0);
+            auto changes = observe({r}, [&] {
+                target->set_int(0, r.get_index() + 1, 5);
+            });
+            REQUIRE_FALSE(changes.modified(0, 0));
+            REQUIRE_FALSE(changes.modified(0, 1));
+            REQUIRE_FALSE(changes.modified(0, 2));
+        }
+
+        SECTION("deleting an observed object adds it to invalidated") {
+            Row r = target->get(0);
+            auto changes = observe({r}, [&] {
+                r.move_last_over();
+            });
+            REQUIRE(changes.invalidated(0));
+        }
+
+        SECTION("deleting an unobserved object does nothing") {
+            Row r = target->get(0);
+            auto changes = observe({r}, [&] {
+                target->move_last_over(r.get_index() + 1);
+            });
+            REQUIRE_FALSE(changes.invalidated(0));
+        }
+
+        SECTION("moving an observed object over another observed object") {
+            Row r1 = target->get(0);
+            Row r2 = target->back();
+            auto changes = observe({r1, r2}, [&] {
+                r1.set_int(0, 1);
+                r2.set_int(1, 1);
+                r1.move_last_over();
+                r2.set_int(2, 1);
+            });
+            REQUIRE(changes.invalidated(0));
+            REQUIRE_FALSE(changes.modified(1, 0));
+            REQUIRE(changes.modified(1, 1));
+            REQUIRE(changes.modified(1, 2));
+        }
+
+        SECTION("moving an observed object in between two other observed objects") {
+            Row r1 = target->get(1);
+            Row r2 = target->get(4);
+            Row r3 = target->back();
+            auto changes = observe({r1, r2, r3}, [&] {
+                r3.set_int(0, 1);
+                target->get(3);
+                r3.set_int(1, 1);
+            });
+            REQUIRE(changes.modified(2, 0));
+            REQUIRE(changes.modified(2, 1));
+            REQUIRE_FALSE(changes.modified(2, 2));
+        }
+
+        SECTION("deleting the target of a link marks the link as modified") {
+            Row r = origin->get(0);
+            auto changes = observe({r}, [&] {
+                target->move_last_over(r.get_link(1));
+            });
+            REQUIRE(changes.modified(0, 1));
+        }
+
+        SECTION("clearing the target table of a link marks the link as modified") {
+            Row r = origin->get(0);
+            auto changes = observe({r}, [&] {
+                target->clear();
+            });
+            REQUIRE(changes.modified(0, 1));
+        }
+
+        SECTION("moving the target of a link does not mark the link as modified") {
+            Row r = origin->get(0);
+            auto changes = observe({r}, [&] {
+                target->swap_rows(5, 9);
+            });
+            REQUIRE_FALSE(changes.modified(0, 1));
+
+            changes = observe({r}, [&] {
+                target->move_last_over(0);
+            });
+            REQUIRE_FALSE(changes.modified(0, 1));
+        }
+
+        SECTION("clearing a table invalidates all observers for that table") {
+            Row r1 = target->get(0);
+            Row r2 = target->get(5);
+            Row r3 = origin->get(0);
+            auto changes = observe({r1, r2, r3}, [&] {
+                target->clear();
+            });
+            REQUIRE(changes.invalidated(0));
+            REQUIRE(changes.invalidated(1));
+            REQUIRE_FALSE(changes.invalidated(2));
+        }
+
+        SECTION("moving an observed object with insert_empty_row() does not interfere with tracking") {
+            Row r = target->get(0);
+            auto changes = observe({r}, [&] {
+                target->insert_empty_row(0);
+                r.set_int(0, 5);
+            });
+            REQUIRE(changes.modified(0, 0));
+        }
+
+        SECTION("moving an observed object with move_last_over() does not interfere with tracking") {
+            Row r = target->back();
+            auto changes = observe({r}, [&] {
+                target->move_last_over(0);
+                r.set_int(0, 5);
+            });
+            REQUIRE(changes.modified(0, 0));
+        }
+
+        SECTION("inserting a column into an observed table does not break tracking") {
+            Row r = target->get(0);
+            auto changes = observe({r}, [&] {
+                r.set_int(0, 5);
+                target->insert_column(0, type_String, "col");
+                r.set_int(3, 5);
+            });
+            REQUIRE_FALSE(changes.modified(0, 0));
+            REQUIRE(changes.modified(0, 1));
+            REQUIRE_FALSE(changes.modified(0, 2));
+            REQUIRE(changes.modified(0, 3));
+        }
+
+        SECTION("moving columns in observed tables does not break tracking") {
+            Row r = target->get(0);
+            auto changes = observe({r}, [&] {
+                r.set_int(0, 5);
+                _impl::TableFriend::move_column(*target->get_descriptor(), 0, 1);
+                r.set_int(2, 5);
+            });
+            REQUIRE_FALSE(changes.modified(0, 0));
+            REQUIRE(changes.modified(0, 1));
+            REQUIRE(changes.modified(0, 2));
+        }
+
+        SECTION("moving an observed table does not break tracking") {
+            // move via move()
+            Row r = target->get(0);
+            auto changes = observe({r}, [&] {
+                r.set_int(0, 5);
+                realm->read_group().move_table(r.get_table()->get_index_in_group(), 0);
+                r.set_int(1, 5);
+            });
+            REQUIRE(changes.modified(0, 0));
+            REQUIRE(changes.modified(0, 1));
+
+            // move via insertion()
+            changes = observe({r}, [&] {
+                r.set_int(0, 5);
+                realm->read_group().insert_table(0, "new table");
+                r.set_int(1, 5);
+            });
+            REQUIRE(changes.modified(0, 0));
+            REQUIRE(changes.modified(0, 1));
+
+            // move by shifting around surrounding tables
+            changes = observe({r}, [&] {
+                r.set_int(0, 5);
+                realm->read_group().move_table(0, realm->read_group().size() - 1);
+                r.set_int(1, 5);
+            });
+            REQUIRE(changes.modified(0, 0));
+            REQUIRE(changes.modified(0, 1));
+            changes = observe({r}, [&] {
+                r.set_int(0, 5);
+                realm->read_group().move_table(realm->read_group().size() - 1, 0);
+                r.set_int(1, 5);
+            });
+            REQUIRE(changes.modified(0, 0));
+            REQUIRE(changes.modified(0, 1));
+        }
+
+        using Kind = BindingContext::ColumnInfo::Kind;
+        SECTION("array: add()") {
+            Row r = origin->get(0);
+            auto changes = observe({r}, [&] {
+                lv->add(0);
+            });
+            REQUIRE(changes.has_array_change(0, 2, Kind::Insert, {10}));
+        }
+
+        SECTION("array: insert()") {
+            Row r = origin->get(0);
+            auto changes = observe({r}, [&] {
+                lv->insert(4, 0);
+                lv->insert(2, 0);
+                lv->insert(8, 0);
+            });
+            REQUIRE(changes.has_array_change(0, 2, Kind::Insert, {2, 5, 8}));
+        }
+
+        SECTION("array: remove()") {
+            Row r = origin->get(0);
+            auto changes = observe({r}, [&] {
+                lv->remove(0);
+                lv->remove(2);
+            });
+            REQUIRE(changes.has_array_change(0, 2, Kind::Remove, {0, 3}));
+        }
+
+        SECTION("array: set()") {
+            Row r = origin->get(0);
+            auto changes = observe({r}, [&] {
+                lv->set(0, 3);
+                lv->set(2, 3);
+            });
+            REQUIRE(changes.has_array_change(0, 2, Kind::Set, {0, 2}));
+        }
+
+        SECTION("array: move()") {
+            Row r = origin->get(0);
+            auto changes = observe({r}, [&] {
+                lv->move(5, 3);
+            });
+            REQUIRE(changes.has_array_change(0, 2, Kind::Set, {3, 4, 5}));
+        }
+
+        SECTION("array: swap()") {
+            Row r = origin->get(0);
+            auto changes = observe({r}, [&] {
+                lv->swap(5, 3);
+            });
+            REQUIRE(changes.has_array_change(0, 2, Kind::Set, {3, 5}));
+        }
+
+        SECTION("array: clear()") {
+            Row r = origin->get(0);
+            auto changes = observe({r}, [&] {
+                lv->clear();
+            });
+            REQUIRE(changes.has_array_change(0, 2, Kind::Remove, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+        }
+
+        SECTION("array: clear() after add()") {
+            Row r = origin->get(0);
+            auto changes = observe({r}, [&] {
+                lv->add(0);
+                lv->clear();
+            });
+            REQUIRE(changes.has_array_change(0, 2, Kind::Remove, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+        }
+
+        SECTION("array: clear() after set()") {
+            Row r = origin->get(0);
+            auto changes = observe({r}, [&] {
+                lv->set(5, 3);
+                lv->clear();
+            });
+            REQUIRE(changes.has_array_change(0, 2, Kind::Remove, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+        }
+
+        SECTION("array: clear() after remove()") {
+            Row r = origin->get(0);
+            auto changes = observe({r}, [&] {
+                lv->remove(2);
+                lv->clear();
+            });
+            REQUIRE(changes.has_array_change(0, 2, Kind::Remove, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+        }
+
+        SECTION("array: multiple change kinds") {
+            Row r = origin->get(0);
+            auto changes = observe({r}, [&] {
+                lv->add(0);
+                lv->remove(0);
+            });
+            REQUIRE(changes.has_array_change(0, 2, Kind::SetAll, {}));
+        }
+
+        SECTION("array: modifying different array does not produce changes") {
+            Row r = origin->get(0);
+            auto changes = observe({r}, [&] {
+                lv2->add(0);
+            });
+            REQUIRE_FALSE(changes.modified(0, 2));
+        }
+
+        SECTION("array: modifying different table does not produce changes") {
+            Row r = origin->get(0);
+            auto changes = observe({r}, [&] {
+                realm->read_group().get_table("class_origin 2")->get_linklist(2, 0)->add(0);
+            });
+            REQUIRE_FALSE(changes.modified(0, 2));
+        }
+
+        SECTION("array: moving the observed object via insert_empty_row() does not interrupt tracking") {
+            Row r = origin->get(0);
+            auto changes = observe({r}, [&] {
+                lv->add(0);
+                origin->insert_empty_row(0);
+                lv->add(0);
+            });
+            REQUIRE(changes.has_array_change(0, 2, Kind::Insert, {10, 11}));
+        }
+
+        SECTION("array: moving the observed object via move_last_over() does not interrupt tracking") {
+            Row r = origin->get(0);
+
+            realm->begin_transaction();
+            origin->swap_rows(0, 1);
+            realm->commit_transaction();
+
+            auto changes = observe({r}, [&] {
+                lv->add(0);
+                origin->move_last_over(0);
+                lv->add(0);
+            });
+            REQUIRE(changes.has_array_change(0, 2, Kind::Insert, {10, 11}));
         }
     }
 }

--- a/tests/transaction_log_parsing.cpp
+++ b/tests/transaction_log_parsing.cpp
@@ -461,39 +461,6 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             REQUIRE(info.tables[2].empty());
         }
 
-        SECTION("moving a row via a PK conflict marks it as moved") {
-            auto info = track_changes({false, false, true}, [&] {
-                table.add_empty_row(2);
-                table.set_int_unique(0, 10, 5);
-            });
-            REQUIRE(info.tables.size() == 3);
-            // 10 assumed identity of old 5, but 11 was moved over it, so 5
-            // is a new insert and 10 is a move.
-            REQUIRE_INDICES(info.tables[2].insertions, 5, 10);
-            REQUIRE_INDICES(info.tables[2].deletions, 5);
-            REQUIRE_MOVES(info.tables[2], {5, 10});
-        }
-
-        SECTION("modifying a row before a PK-conflict move marks it as modified") {
-            auto info = track_changes({false, false, true}, [&] {
-                table.set_int(1, 5, 15);
-                table.add_empty_row(2);
-                table.set_int_unique(0, 10, 5);
-            });
-            REQUIRE(info.tables.size() == 3);
-            REQUIRE_INDICES(info.tables[2].modifications, 10);
-        }
-
-        SECTION("modifying a row after a PK-conflict move marks it as modified") {
-            auto info = track_changes({false, false, true}, [&] {
-                table.add_empty_row(2);
-                table.set_int_unique(0, 10, 5);
-                table.set_int(1, 10, 15);
-            });
-            REQUIRE(info.tables.size() == 3);
-            REQUIRE_INDICES(info.tables[2].modifications, 10);
-        }
-
         SECTION("non-conflicting set_int_unique() does not mark a row as modified") {
             auto info = track_changes({false, false, true}, [&] {
                 table.set_int_unique(0, 0, 20);

--- a/tests/transaction_log_parsing.cpp
+++ b/tests/transaction_log_parsing.cpp
@@ -425,6 +425,7 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             REQUIRE_INDICES(info.tables[1].insertions, 10, 11, 12);
         }
 
+#if REALM_VER_MAJOR >= 2
         SECTION("swap_rows() reports a pair of moves") {
             auto info = track_changes({false, false, true}, [&] {
                 table.swap_rows(1, 5);
@@ -449,7 +450,6 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             REQUIRE_INDICES(table.modifications, 8);
         }
 
-#if REALM_VER_MAJOR >= 2
         SECTION("PK conflict from last row produces no net change") {
             auto info = track_changes({false, false, true}, [&] {
                 table.add_empty_row();
@@ -1193,6 +1193,7 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             REQUIRE_FALSE(changes.modified(0, 2));
         }
 
+#if REALM_MAJOR_VER >= 2
         SECTION("SetDefault does not mark as changed") {
             Row r = target->get(0);
             auto changes = observe({r}, [&] {
@@ -1201,8 +1202,8 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             REQUIRE_FALSE(changes.modified(0, 0));
             REQUIRE_FALSE(changes.modified(0, 1));
             REQUIRE_FALSE(changes.modified(0, 2));
-
         }
+#endif
 
         SECTION("multiple properties on a single object are handled properly") {
             Row r = target->get(0);
@@ -1311,15 +1312,17 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
 
         SECTION("moving the target of a link does not mark the link as modified") {
             Row r = origin->get(0);
+#if REALM_VER_MAJOR >= 2
             auto changes = observe({r}, [&] {
                 target->swap_rows(5, 9);
             });
             REQUIRE_FALSE(changes.modified(0, 1));
+#endif
 
-            changes = observe({r}, [&] {
+            auto changes2 = observe({r}, [&] {
                 target->move_last_over(0);
             });
-            REQUIRE_FALSE(changes.modified(0, 1));
+            REQUIRE_FALSE(changes2.modified(0, 1));
         }
 
         SECTION("clearing a table invalidates all observers for that table") {
@@ -1352,6 +1355,7 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             REQUIRE(changes.modified(0, 0));
         }
 
+#if REALM_VER_MAJOR >= 2
         SECTION("moving an observed object with swap() does not interfere with tracking") {
             Row r1 = target->get(1), r2 = target->get(3);
 
@@ -1429,6 +1433,7 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             REQUIRE(changes.modified(0, 1));
             REQUIRE(changes.modified(0, 2));
         }
+#endif
 
         SECTION("inserting a column into an observed table does not break tracking") {
             Row r = target->get(0);
@@ -1615,6 +1620,7 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             REQUIRE(changes.has_array_change(0, 2, Kind::Insert, {10, 11}));
         }
 
+#if REALM_VER_MAJOR >= 2
         SECTION("array: moving the observed object via swap() does not interrupt tracking") {
             Row r = origin->get(0);
             auto changes = observe({r}, [&] {
@@ -1659,6 +1665,7 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             });
             REQUIRE(changes.has_array_change(0, 2, Kind::Insert, {12, 13}));
         }
+#endif
     }
 }
 

--- a/tests/util/test_file.hpp
+++ b/tests/util/test_file.hpp
@@ -21,9 +21,25 @@
 
 #include "shared_realm.hpp"
 
+#include <realm/group_shared.hpp>
+
 struct TestFile : realm::Realm::Config {
     TestFile();
     ~TestFile();
+
+    std::unique_ptr<realm::Replication> make_history() const;
+
+    auto options() const
+    {
+#ifdef REALM_GROUP_SHARED_OPTIONS_HPP
+        realm::SharedGroupOptions options;
+        options.durability = in_memory ? realm::SharedGroupOptions::Durability::MemOnly
+                                       : realm::SharedGroupOptions::Durability::Full;
+        return options;
+#else
+        return in_memory ? realm::SharedGroup::durability_MemOnly : realm::SharedGroup::durability_Full;
+#endif
+    }
 };
 
 struct InMemoryTestFile : TestFile {


### PR DESCRIPTION
This adds handling for row swapping, primary key conflict resolution, and SetDefault to the transaction log handler used for collection notifications, along with fixes to the changeset calculation to handle the fact that rows in table order can move in more ways now.