### PR TITLE
Create metadata and pk table when set the schema version

### DIFF
--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -207,7 +207,9 @@ void validate_primary_column_uniqueness(Group const& group)
 }
 } // anonymous namespace
 
+// FIXME remove this after integrating OS's migration related logic into Realm java
 void ObjectStore::set_schema_version(Group& group, uint64_t version) {
+    ::create_metadata_tables(group);
     ::set_schema_version(group, version);
 }
 

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -48,7 +48,7 @@ public:
     static uint64_t get_schema_version(Group const& group);
 
     // set the schema version without any checks
-    // and the table for schema version is created if it doesn't exist
+    // and the tables for the schema version and the primary key are created if they don't exist
     // NOTE: must be performed within a write transaction
     // FIXME remove this after integrating OS's migration related logic into Realm java
     static void set_schema_version(Group& group, uint64_t version);


### PR DESCRIPTION
Object store always creates both metadata and pk table when creating a new Realm database.
This change aligns the behavior of Realm Java to ObjectStore. It is also required from realm/realm-java#3424

At first, I was thinking that I should expose `create_metadata_tables()` separately to be able to call it only at the creation of Realm, but finally I always call `create_metadata_tables()` from the `ObjectStore::set_schema_version()` since current OS always calls it on schema change.
