### PR TITLE
Send notifications on refresh and begin write

### DIFF
--- a/src/impl/collection_notifier.cpp
+++ b/src/impl/collection_notifier.cpp
@@ -368,9 +368,8 @@ NotifierPackage::NotifierPackage(Realm& realm, std::exception_ptr error,
 
 void NotifierPackage::package_and_wait(SharedGroup& sg)
 {
-    if (!m_lock || m_error)
+    if (!m_lock || m_error || !*this)
         return;
-    REALM_ASSERT(*this);
 
     using sgf = SharedGroupFriend;
     auto target_version = sgf::get_version_of_latest_snapshot(sg);

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -120,6 +120,7 @@ public:
     // ------------------------------------------------------------------------
     // API for RealmCoordinator to manage running things and calling callbacks
 
+    bool is_for_realm(Realm&) const noexcept;
     Realm* get_realm() const noexcept { return m_realm.get(); }
 
     // Get the SharedGroup version which this collection can attach to (if it's
@@ -134,10 +135,8 @@ public:
 
     // Prepare to deliver the new collection and call callbacks. Returns the
     // transaction version which it can deliver to if applicable, and a
-    // default-constructed version if this notifier has nothing to deliver to
-    // this Realm (either due to being for a different Realm, or just because
-    // nothing has changed since it last delivered).
-    VersionID package_for_delivery(Realm&);
+    // default-constructed version if this notifier has nothing to deliver.
+    VersionID package_for_delivery();
 
     // Deliver the new state to the target collection using the given SharedGroup
     virtual void deliver(SharedGroup&) { }
@@ -167,8 +166,8 @@ public:
     template <typename T>
     class Handle;
 
-protected:
     bool have_callbacks() const noexcept { return m_have_callbacks; }
+protected:
     void add_changes(CollectionChangeBuilder change) { m_accumulated_changes.merge(std::move(change)); }
     void set_table(Table const& table);
     std::unique_lock<std::mutex> lock_target();
@@ -253,6 +252,52 @@ public:
             std::shared_ptr<T>::reset();
         }
     }
+};
+
+// A package of CollectionNotifiers for a single Realm instance which is passed
+// around to the various places which need to actually trigger the notifications
+class NotifierPackage {
+public:
+    NotifierPackage() = default;
+
+    // Package the error if it's non-null, and otherwise the subset of the
+    // notifiers which are for the given realm and are ready to deliver without
+    // blocking
+    NotifierPackage(Realm& realm, std::exception_ptr error,
+                    std::vector<std::shared_ptr<CollectionNotifier>> notifiers);
+
+    // Package the error if it's non-null, and otherwise gather the subset of
+    // the given notifiers which are for the given realm, including ones which
+    // are not yet ready to deliver and will need to block
+    NotifierPackage(Realm& realm, std::exception_ptr error,
+                    std::vector<std::shared_ptr<CollectionNotifier>> notifiers,
+                    std::condition_variable& cv, std::unique_lock<std::mutex>& lock);
+
+    explicit operator bool() { return !m_notifiers.empty(); }
+
+    // Get the version which this package can deliver into, or VersionID{} if
+    // it has not yet been packaged
+    VersionID version() { return m_version; }
+
+    // Package the notifiers for delivery, blocking if they aren't ready for
+    // delivery into the given sg.
+    // No-op if it has already been called or if this was created with the
+    // constructor that does not take a cv and lock.
+    void package_and_wait(SharedGroup& sg);
+
+    // Sent the before-change notifications
+    void before_advance();
+    // Deliver the payload associated with the contained notifiers and/or the error
+    void deliver(SharedGroup& sg);
+    // Sent the after-change notifications
+    void after_advance();
+
+private:
+    VersionID m_version;
+    std::vector<std::shared_ptr<CollectionNotifier>> m_notifiers;
+    std::condition_variable* m_cv = nullptr;
+    std::unique_lock<std::mutex>* m_lock = nullptr;
+    std::exception_ptr m_error;
 };
 
 } // namespace _impl

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -125,6 +125,7 @@ public:
 
     // Get the SharedGroup version which this collection can attach to (if it's
     // in handover mode), or can deliver to (if it's been handed over to the BG worker alredad)
+    // precondition: RealmCoordinator::m_notifier_mutex is locked
     VersionID version() const noexcept { return m_sg_version; }
 
     // Release references to all core types
@@ -133,34 +134,46 @@ public:
     // CollectionNotifier is released on a different thread
     virtual void release_data() noexcept = 0;
 
-    // Prepare to deliver the new collection and call callbacks. Returns the
-    // transaction version which it can deliver to if applicable, and a
-    // default-constructed version if this notifier has nothing to deliver.
-    VersionID package_for_delivery();
+    // Prepare to deliver the new collection and call callbacks.
+    // Returns whether or not it has anything to deliver.
+    // precondition: RealmCoordinator::m_notifier_mutex is locked
+    bool package_for_delivery();
 
     // Deliver the new state to the target collection using the given SharedGroup
+    // precondition: RealmCoordinator::m_notifier_mutex is unlocked
     virtual void deliver(SharedGroup&) { }
 
     // Pass the given error to all registered callbacks, then remove them
+    // precondition: RealmCoordinator::m_notifier_mutex is unlocked
     void deliver_error(std::exception_ptr);
 
     // Call each of the given callbacks with the changesets prepared by package_for_delivery()
+    // precondition: RealmCoordinator::m_notifier_mutex is unlocked
     void before_advance();
     void after_advance();
 
     bool is_alive() const noexcept;
 
+    // precondition: RealmCoordinator::m_notifier_mutex is locked *or* is called on worker thread
+    bool has_run() const noexcept { return m_has_run; }
+
     // Attach the handed-over query to `sg`. Must not be already attached to a SharedGroup.
+    // precondition: RealmCoordinator::m_notifier_mutex is locked
     void attach_to(SharedGroup& sg);
     // Create a new query handover object and stop using the previously attached
     // SharedGroup
+    // precondition: RealmCoordinator::m_notifier_mutex is locked
     void detach();
 
     // Set `info` as the new ChangeInfo that will be populated by the next
     // transaction advance, and register all required information in it
+    // precondition: RealmCoordinator::m_notifier_mutex is locked
     void add_required_change_info(TransactionChangeInfo& info);
 
+    // precondition: RealmCoordinator::m_notifier_mutex is unlocked
     virtual void run() = 0;
+
+    // precondition: RealmCoordinator::m_notifier_mutex is locked
     void prepare_handover();
 
     template <typename T>
@@ -187,6 +200,7 @@ private:
     VersionID m_sg_version;
     SharedGroup* m_sg = nullptr;
 
+    bool m_has_run = false;
     bool m_error = false;
     CollectionChangeBuilder m_accumulated_changes;
     CollectionChangeSet m_changes_to_deliver;
@@ -259,17 +273,7 @@ public:
 class NotifierPackage {
 public:
     NotifierPackage() = default;
-
-    // Package the error if it's non-null, and otherwise the subset of the
-    // notifiers which are for the given realm and are ready to deliver without
-    // blocking
-    NotifierPackage(Realm& realm, std::exception_ptr error,
-                    std::vector<std::shared_ptr<CollectionNotifier>> notifiers);
-
-    // Package the error if it's non-null, and otherwise gather the subset of
-    // the given notifiers which are for the given realm, including ones which
-    // are not yet ready to deliver and will need to block
-    NotifierPackage(Realm& realm, std::exception_ptr error,
+    NotifierPackage(std::exception_ptr error,
                     std::vector<std::shared_ptr<CollectionNotifier>> notifiers,
                     std::condition_variable& cv, std::unique_lock<std::mutex>& lock);
 
@@ -277,13 +281,12 @@ public:
 
     // Get the version which this package can deliver into, or VersionID{} if
     // it has not yet been packaged
-    VersionID version() { return m_version; }
+    util::Optional<VersionID> version() { return m_version; }
 
     // Package the notifiers for delivery, blocking if they aren't ready for
-    // delivery into the given sg.
-    // No-op if it has already been called or if this was created with the
-    // constructor that does not take a cv and lock.
-    void package_and_wait(SharedGroup& sg);
+    // the given version.
+    // No-op if called multiple times
+    void package_and_wait(util::Optional<VersionID::version_type> target_version);
 
     // Sent the before-change notifications
     void before_advance();
@@ -293,10 +296,11 @@ public:
     void after_advance();
 
 private:
-    VersionID m_version;
+    util::Optional<VersionID> m_version;
     std::vector<std::shared_ptr<CollectionNotifier>> m_notifiers;
+
     std::condition_variable* m_cv = nullptr;
-    std::unique_lock<std::mutex>* m_lock = nullptr;
+    std::unique_lock<std::mutex>* m_lock = nullptr; // RealmCoordinator::m_notifier_mutex
     std::exception_ptr m_error;
 };
 

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -498,6 +498,7 @@ void RealmCoordinator::run_async_notifiers()
     }
     m_notifiers = std::move(notifiers);
     clean_up_dead_notifiers();
+    m_notifier_cv.notify_all();
 }
 
 void RealmCoordinator::open_helper_shared_group()
@@ -521,66 +522,76 @@ void RealmCoordinator::open_helper_shared_group()
     }
 }
 
-
-std::vector<std::shared_ptr<_impl::CollectionNotifier>> RealmCoordinator::notifiers_to_deliver(Realm& realm, VersionID& version)
-{
-    std::unique_lock<std::mutex> lock(m_notifier_mutex);
-    decltype(m_notifiers) notifiers;
-    if (m_async_error) {
-        auto error = m_async_error;
-        notifiers = m_notifiers;
-        lock.unlock();
-        for (auto& notifier : notifiers)
-            notifier->deliver_error(error);
-        return {};
-    }
-
-    for (auto& notifier : m_notifiers) {
-        auto notifier_version = notifier->package_for_delivery(realm);
-        if (notifier_version == VersionID{})
-            continue;
-        version = notifier_version;
-        notifiers.push_back(notifier);
-    }
-
-    return notifiers;
-}
-
 void RealmCoordinator::advance_to_ready(Realm& realm)
 {
+    std::unique_lock<std::mutex> lock(m_notifier_mutex);
+    _impl::NotifierPackage notifiers(realm, m_async_error, m_notifiers);
+    lock.unlock();
+
     auto& sg = Realm::Internal::get_shared_group(realm);
-    VersionID version;
-    auto notifiers = notifiers_to_deliver(realm, version);
-    if (notifiers.empty()) {
-        transaction::advance(sg, realm.m_binding_context.get(), m_config.schema_mode);
+    if (!notifiers) {
+        transaction::advance(sg, realm.m_binding_context.get(), m_config.schema_mode, VersionID{});
         return;
     }
 
+    auto version = notifiers.version();
     if (version <= sg.get_version_of_current_transaction())
         return;
 
-    for (auto& notifier : notifiers)
-        notifier->before_advance();
-    transaction::advance(sg, realm.m_binding_context.get(), m_config.schema_mode, version);
-    for (auto& notifier : notifiers)
-        notifier->deliver(sg);
-    for (auto& notifier : notifiers)
-        notifier->after_advance();
+    transaction::advance(sg, realm.m_binding_context.get(), m_config.schema_mode, notifiers);
+}
+
+std::unique_lock<std::mutex> RealmCoordinator::wait_for_notifiers(Realm& realm, uint64_t min_version)
+{
+    std::unique_lock<std::mutex> lock(m_notifier_mutex);
+    m_notifier_cv.wait(lock, [&] {
+        if (m_async_error)
+            return true;
+        return std::all_of(begin(m_notifiers), end(m_notifiers), [&](auto const& n) {
+            return n->version().version >= min_version || !n->is_for_realm(realm);
+        });
+    });
+    return lock;
+}
+
+bool RealmCoordinator::advance_to_latest(Realm& realm)
+{
+    auto& sg = Realm::Internal::get_shared_group(realm);
+    using sgf = SharedGroupFriend;
+    auto lock = wait_for_notifiers(realm, sgf::get_version_of_latest_snapshot(sg));
+    _impl::NotifierPackage notifiers(realm, m_async_error, m_notifiers);
+    lock.unlock();
+
+    auto version = sg.get_version_of_current_transaction();
+    transaction::advance(sg, realm.m_binding_context.get(), m_config.schema_mode, notifiers);
+    return version != sg.get_version_of_current_transaction();
+}
+
+void RealmCoordinator::promote_to_write(Realm& realm)
+{
+    REALM_ASSERT(!realm.is_in_transaction());
+
+    auto lock = wait_for_notifiers(realm, 0);
+    _impl::NotifierPackage notifiers(realm, m_async_error, m_notifiers, m_notifier_cv, lock);
+    lock.unlock();
+
+    auto& sg = Realm::Internal::get_shared_group(realm);
+    transaction::begin(sg, realm.m_binding_context.get(), m_config.schema_mode, notifiers);
 }
 
 void RealmCoordinator::process_available_async(Realm& realm)
 {
-    VersionID version;
-    auto notifiers = notifiers_to_deliver(realm, version);
-    if (notifiers.empty())
-        return;
+    REALM_ASSERT(!realm.is_in_transaction());
 
-    auto& sg = Realm::Internal::get_shared_group(realm);
-    if (version != sg.get_version_of_current_transaction())
-        return;
+    std::unique_lock<std::mutex> lock(m_notifier_mutex);
+    _impl::NotifierPackage notifiers(realm, m_async_error, m_notifiers);
+    lock.unlock();
 
-    for (auto& notifier : notifiers)
-        notifier->deliver(sg);
-    for (auto& notifier : notifiers)
-        notifier->after_advance();
+    if (notifiers) {
+        // no before advance because the Realm is already at the given version,
+        // because we're either sending initial notifications or the write was
+        // done on this Realm instance
+        notifiers.deliver(Realm::Internal::get_shared_group(realm));
+        notifiers.after_advance();
+    }
 }

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -548,7 +548,7 @@ std::unique_lock<std::mutex> RealmCoordinator::wait_for_notifiers(Realm& realm, 
         if (m_async_error)
             return true;
         return std::all_of(begin(m_notifiers), end(m_notifiers), [&](auto const& n) {
-            return n->version().version >= min_version || !n->is_for_realm(realm);
+            return n->version().version >= min_version || !n->have_callbacks() || !n->is_for_realm(realm);
         });
     });
     return lock;

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -525,8 +525,9 @@ void RealmCoordinator::open_helper_shared_group()
 void RealmCoordinator::advance_to_ready(Realm& realm)
 {
     std::unique_lock<std::mutex> lock(m_notifier_mutex);
-    _impl::NotifierPackage notifiers(realm, m_async_error, m_notifiers);
+    _impl::NotifierPackage notifiers(m_async_error, notifiers_for_realm(realm), m_notifier_cv, lock);
     lock.unlock();
+    notifiers.package_and_wait(util::none);
 
     auto& sg = Realm::Internal::get_shared_group(realm);
     if (!notifiers) {
@@ -535,32 +536,35 @@ void RealmCoordinator::advance_to_ready(Realm& realm)
     }
 
     auto version = notifiers.version();
-    if (version <= sg.get_version_of_current_transaction())
+    if (version && *version <= sg.get_version_of_current_transaction())
         return;
 
     transaction::advance(sg, realm.m_binding_context.get(), m_config.schema_mode, notifiers);
 }
 
-std::unique_lock<std::mutex> RealmCoordinator::wait_for_notifiers(Realm& realm, uint64_t min_version)
+std::vector<std::shared_ptr<_impl::CollectionNotifier>> RealmCoordinator::notifiers_for_realm(Realm& realm)
 {
-    std::unique_lock<std::mutex> lock(m_notifier_mutex);
-    m_notifier_cv.wait(lock, [&] {
-        if (m_async_error)
-            return true;
-        return std::all_of(begin(m_notifiers), end(m_notifiers), [&](auto const& n) {
-            return n->version().version >= min_version || !n->have_callbacks() || !n->is_for_realm(realm);
-        });
-    });
-    return lock;
+    std::vector<std::shared_ptr<_impl::CollectionNotifier>> ret;
+    for (auto& notifier : m_new_notifiers) {
+        if (notifier->is_for_realm(realm))
+            ret.push_back(notifier);
+    }
+    for (auto& notifier : m_notifiers) {
+        if (notifier->is_for_realm(realm))
+            ret.push_back(notifier);
+    }
+    return ret;
 }
 
 bool RealmCoordinator::advance_to_latest(Realm& realm)
 {
-    auto& sg = Realm::Internal::get_shared_group(realm);
     using sgf = SharedGroupFriend;
-    auto lock = wait_for_notifiers(realm, sgf::get_version_of_latest_snapshot(sg));
-    _impl::NotifierPackage notifiers(realm, m_async_error, m_notifiers);
+
+    auto& sg = Realm::Internal::get_shared_group(realm);
+    std::unique_lock<std::mutex> lock(m_notifier_mutex);
+    _impl::NotifierPackage notifiers(m_async_error, notifiers_for_realm(realm), m_notifier_cv, lock);
     lock.unlock();
+    notifiers.package_and_wait(sgf::get_version_of_latest_snapshot(sg));
 
     auto version = sg.get_version_of_current_transaction();
     transaction::advance(sg, realm.m_binding_context.get(), m_config.schema_mode, notifiers);
@@ -571,8 +575,8 @@ void RealmCoordinator::promote_to_write(Realm& realm)
 {
     REALM_ASSERT(!realm.is_in_transaction());
 
-    auto lock = wait_for_notifiers(realm, 0);
-    _impl::NotifierPackage notifiers(realm, m_async_error, m_notifiers, m_notifier_cv, lock);
+    std::unique_lock<std::mutex> lock(m_notifier_mutex);
+    _impl::NotifierPackage notifiers(m_async_error, notifiers_for_realm(realm), m_notifier_cv, lock);
     lock.unlock();
 
     auto& sg = Realm::Internal::get_shared_group(realm);
@@ -584,14 +588,37 @@ void RealmCoordinator::process_available_async(Realm& realm)
     REALM_ASSERT(!realm.is_in_transaction());
 
     std::unique_lock<std::mutex> lock(m_notifier_mutex);
-    _impl::NotifierPackage notifiers(realm, m_async_error, m_notifiers);
+    auto notifiers = notifiers_for_realm(realm);
+    if (notifiers.empty())
+        return;
+
+    if (auto error = m_async_error) {
+        lock.unlock();
+        for (auto& notifier : notifiers)
+            notifier->deliver_error(m_async_error);
+        return;
+    }
+
+    bool in_read = realm.is_in_read_transaction();
+    auto& sg = Realm::Internal::get_shared_group(realm);
+    auto version = sg.get_version_of_current_transaction();
+    auto package = [&](auto& notifier) {
+        return !(notifier->has_run() && (!in_read || notifier->version() == version) && notifier->package_for_delivery());
+    };
+    notifiers.erase(std::remove_if(begin(notifiers), end(notifiers), package), end(notifiers));
     lock.unlock();
 
-    if (notifiers) {
-        // no before advance because the Realm is already at the given version,
-        // because we're either sending initial notifications or the write was
-        // done on this Realm instance
-        notifiers.deliver(Realm::Internal::get_shared_group(realm));
-        notifiers.after_advance();
+    // no before advance because the Realm is already at the given version,
+    // because we're either sending initial notifications or the write was
+    // done on this Realm instance
+
+    // Skip delivering if the Realm isn't in a read transaction
+    if (in_read) {
+        for (auto& notifier : notifiers)
+            notifier->deliver(sg);
     }
+
+    // but still call the change callbacks
+    for (auto& notifier : notifiers)
+        notifier->after_advance();
 }

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -139,6 +139,7 @@ private:
     // wait for all notifiers targeting the given realm to be ready for the
     // given version or any later version
     std::unique_lock<std::mutex> wait_for_notifiers(Realm& realm, uint64_t min_version);
+    std::vector<std::shared_ptr<_impl::CollectionNotifier>> notifiers_for_realm(Realm&);
 };
 
 } // namespace _impl

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -88,7 +88,18 @@ public:
     // Advance the Realm to the most recent transaction version which all async
     // work is complete for
     void advance_to_ready(Realm& realm);
+
+    // Advance the Realm to the most recent transaction version, blocking if
+    // async notifiers are not yet ready for that version
+    // returns whether it actually changed the version
+    bool advance_to_latest(Realm& realm);
+
+    // Deliver any notifications which are ready for the Realm's version
     void process_available_async(Realm& realm);
+
+    // Deliver notifications for the Realm, blocking if some aren't ready yet
+    // The calling Realm must be in a write transaction
+    void promote_to_write(Realm& realm);
 
 private:
     Realm::Config m_config;
@@ -99,6 +110,7 @@ private:
     std::vector<WeakRealmNotifier> m_weak_realm_notifiers;
 
     std::mutex m_notifier_mutex;
+    std::condition_variable m_notifier_cv;
     std::vector<std::shared_ptr<_impl::CollectionNotifier>> m_new_notifiers;
     std::vector<std::shared_ptr<_impl::CollectionNotifier>> m_notifiers;
 
@@ -123,7 +135,10 @@ private:
     void open_helper_shared_group();
     void advance_helper_shared_group_to_latest();
     void clean_up_dead_notifiers();
-    std::vector<std::shared_ptr<_impl::CollectionNotifier>> notifiers_to_deliver(Realm&, VersionID& version);
+
+    // wait for all notifiers targeting the given realm to be ready for the
+    // given version or any later version
+    std::unique_lock<std::mutex> wait_for_notifiers(Realm& realm, uint64_t min_version);
 };
 
 } // namespace _impl

--- a/src/impl/results_notifier.hpp
+++ b/src/impl/results_notifier.hpp
@@ -62,10 +62,6 @@ private:
     CollectionChangeBuilder m_changes;
     TransactionChangeInfo* m_info = nullptr;
 
-    // Flag for whether or not the query has been run at all, as goofy timing
-    // can lead to deliver() being called before that
-    bool m_initial_run_complete = false;
-
     bool need_to_run();
     void calculate_changes();
     void deliver(SharedGroup&) override;

--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -221,6 +221,9 @@ class TransactLogObserver : public TransactLogValidationMixin, public MarkDirtyM
     // Change information for the currently selected LinkList, if any
     ColumnInfo* m_active_linklist = nullptr;
 
+    _impl::NotifierPackage& m_notifiers;
+    SharedGroup& m_sg;
+
     // Get the change info for the given column, creating it if needed
     static ColumnInfo& get_change(ObserverState& state, size_t i)
     {
@@ -250,14 +253,19 @@ class TransactLogObserver : public TransactLogValidationMixin, public MarkDirtyM
 
 public:
     template<typename Func>
-    TransactLogObserver(BindingContext* context, SharedGroup& sg, Func&& func, util::Optional<SchemaMode> schema_mode)
+    TransactLogObserver(BindingContext* context, SharedGroup& sg, Func&& func,
+                        util::Optional<SchemaMode> schema_mode,
+                        _impl::NotifierPackage& notifiers)
     : m_context(context)
+    , m_notifiers(notifiers)
+    , m_sg(sg)
     {
         auto old_version = sg.get_version_of_current_transaction();
         if (context) {
             m_observers = context->get_observed_rows();
         }
-        if (m_observers.empty()) {
+        if (m_observers.empty() && (!m_notifiers || m_notifiers.version() != VersionID())) {
+            m_notifiers.before_advance();
             if (schema_mode) {
                 func(TransactLogValidator(*schema_mode));
             }
@@ -267,12 +275,18 @@ public:
             if (context && old_version != sg.get_version_of_current_transaction()) {
                 context->did_change({}, {});
             }
+            m_notifiers.deliver(sg);
+            m_notifiers.after_advance();
             return;
         }
 
         std::sort(begin(m_observers), end(m_observers));
         func(*this);
-        context->did_change(m_observers, invalidated);
+        if (context)
+            context->did_change(m_observers, invalidated);
+        m_notifiers.package_and_wait(sg); // is a no-op if parse_complete() was called
+        m_notifiers.deliver(sg); // only will ever deliver errors
+        m_notifiers.after_advance();
     }
 
     // Mark the given row/col as needing notifications sent
@@ -288,7 +302,10 @@ public:
     // is advanced
     void parse_complete()
     {
-        m_context->will_change(m_observers, invalidated);
+        if (m_context)
+            m_context->will_change(m_observers, invalidated);
+        m_notifiers.package_and_wait(m_sg);
+        m_notifiers.before_advance();
     }
 
     bool insert_group_level_table(size_t table_ndx, size_t prior_size, StringData name)
@@ -792,12 +809,21 @@ public:
 
 namespace realm {
 namespace _impl {
+
 namespace transaction {
 void advance(SharedGroup& sg, BindingContext* context, SchemaMode schema_mode, VersionID version)
 {
+    _impl::NotifierPackage notifiers;
     TransactLogObserver(context, sg, [&](auto&&... args) {
         LangBindHelper::advance_read(sg, std::move(args)..., version);
-    }, schema_mode);
+    }, schema_mode, notifiers);
+}
+
+void advance(SharedGroup& sg, BindingContext* context, SchemaMode schema_mode, NotifierPackage& notifiers)
+{
+    TransactLogObserver(context, sg, [&](auto&&... args) {
+        LangBindHelper::advance_read(sg, std::move(args)..., notifiers.version());
+    }, schema_mode, notifiers);
 }
 
 void begin_without_validation(SharedGroup& sg)
@@ -805,11 +831,12 @@ void begin_without_validation(SharedGroup& sg)
     LangBindHelper::promote_to_write(sg);
 }
 
-void begin(SharedGroup& sg, BindingContext* context, SchemaMode schema_mode)
+void begin(SharedGroup& sg, BindingContext* context, SchemaMode schema_mode,
+           NotifierPackage& notifiers)
 {
     TransactLogObserver(context, sg, [&](auto&&... args) {
         LangBindHelper::promote_to_write(sg, std::move(args)...);
-    }, schema_mode);
+    }, schema_mode, notifiers);
 }
 
 void commit(SharedGroup& sg, BindingContext* context)
@@ -823,9 +850,10 @@ void commit(SharedGroup& sg, BindingContext* context)
 
 void cancel(SharedGroup& sg, BindingContext* context)
 {
+    _impl::NotifierPackage notifiers;
     TransactLogObserver(context, sg, [&](auto&&... args) {
         LangBindHelper::rollback_and_continue_as_read(sg, std::move(args)...);
-    }, util::none);
+    }, util::none, notifiers);
 }
 
 void advance(SharedGroup& sg,

--- a/src/impl/transact_log_handler.hpp
+++ b/src/impl/transact_log_handler.hpp
@@ -28,19 +28,22 @@ class SharedGroup;
 enum class SchemaMode : uint8_t;
 
 namespace _impl {
+class NotifierPackage;
 struct TransactionChangeInfo;
 
 namespace transaction {
 // Advance the read transaction version, with change notifications sent to delegate
 // Must not be called from within a write transaction.
 void advance(SharedGroup& sg, BindingContext* binding_context,
-             SchemaMode schema_mode,
-             VersionID version=VersionID{});
+             SchemaMode schema_mode, NotifierPackage&);
+void advance(SharedGroup& sg, BindingContext* binding_context,
+             SchemaMode schema_mode, VersionID);
 
 // Begin a write transaction
 // If the read transaction version is not up to date, will first advance to the
 // most recent read transaction and sent notifications to delegate
-void begin(SharedGroup& sg, BindingContext* binding_context, SchemaMode schema_mode);
+void begin(SharedGroup& sg, BindingContext* binding_context, SchemaMode schema_mode,
+           NotifierPackage&);
 void begin_without_validation(SharedGroup& sg);
 
 // Commit a write transaction

--- a/src/results.cpp
+++ b/src/results.cpp
@@ -524,6 +524,9 @@ Results Results::snapshot() &&
 
 void Results::prepare_async()
 {
+    if (m_notifier) {
+        return;
+    }
     if (m_realm->config().read_only()) {
         throw InvalidTransactionException("Cannot create asynchronous query for read-only Realms");
     }
@@ -534,11 +537,9 @@ void Results::prepare_async()
         throw std::logic_error("Cannot create asynchronous query for snapshotted Results.");
     }
 
-    if (!m_notifier) {
-        m_wants_background_updates = true;
-        m_notifier = std::make_shared<_impl::ResultsNotifier>(*this);
-        _impl::RealmCoordinator::register_notifier(m_notifier);
-    }
+    m_wants_background_updates = true;
+    m_notifier = std::make_shared<_impl::ResultsNotifier>(*this);
+    _impl::RealmCoordinator::register_notifier(m_notifier);
 }
 
 NotificationToken Results::async(std::function<void (std::exception_ptr)> target)

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -488,7 +488,7 @@ void Realm::write_copy(StringData path, BinaryData key)
 
 void Realm::notify()
 {
-    if (is_closed()) {
+    if (is_closed() || is_in_transaction()) {
         return;
     }
 

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -391,10 +391,23 @@ void Realm::begin_transaction()
         throw InvalidTransactionException("The Realm is already in a write transaction");
     }
 
+    // If we're already in the middle of sending notifications, just begin the
+    // write transaction without sending more notifications. If this actually
+    // advances the read version this could leave the user in an inconsistent
+    // state, but that's unavoidable.
+    if (m_is_sending_notifications) {
+        _impl::NotifierPackage notifiers;
+        transaction::begin(*m_shared_group, m_binding_context.get(), m_config.schema_mode, notifiers);
+        return;
+    }
+
     // make sure we have a read transaction
     read_group();
 
-    transaction::begin(*m_shared_group, m_binding_context.get(), m_config.schema_mode);
+    m_is_sending_notifications = true;
+    auto cleanup = util::make_scope_exit([this]() noexcept { m_is_sending_notifications = false; });
+
+    m_coordinator->promote_to_write(*this);
 }
 
 void Realm::commit_transaction()
@@ -481,6 +494,9 @@ void Realm::notify()
 
     verify_thread();
 
+    m_is_sending_notifications = true;
+    auto cleanup = util::make_scope_exit([this]() noexcept { m_is_sending_notifications = false; });
+
     if (m_shared_group->has_changed()) { // Throws
         if (m_binding_context) {
             m_binding_context->changes_available();
@@ -489,8 +505,11 @@ void Realm::notify()
             if (m_group) {
                 m_coordinator->advance_to_ready(*this);
             }
-            else if (m_binding_context) {
-                m_binding_context->did_change({}, {});
+            else  {
+                if (m_binding_context) {
+                    m_binding_context->did_change({}, {});
+                }
+                m_coordinator->process_available_async(*this);
             }
         }
     }
@@ -508,21 +527,22 @@ bool Realm::refresh()
     if (is_in_transaction()) {
         return false;
     }
-
-    // advance transaction if database has changed
-    if (!m_shared_group->has_changed()) { // Throws
+    // don't advance if we're already in the process of advancing as that just
+    // makes things needlessly complicated
+    if (m_is_sending_notifications) {
         return false;
     }
 
+    m_is_sending_notifications = true;
+    auto cleanup = util::make_scope_exit([this]() noexcept { m_is_sending_notifications = false; });
+
     if (m_group) {
-        transaction::advance(*m_shared_group, m_binding_context.get(), m_config.schema_mode);
-        m_coordinator->process_available_async(*this);
-    }
-    else {
-        // Create the read transaction
-        read_group();
+        return m_coordinator->advance_to_latest(*this);
     }
 
+    // No current read transaction, so just create a new one
+    read_group();
+    m_coordinator->process_available_async(*this);
     return true;
 }
 

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -297,6 +297,8 @@ private:
     // File format versions populated when a file format upgrade takes place during realm opening
     int upgrade_initial_version = 0, upgrade_final_version = 0;
 
+    bool m_is_sending_notifications = false;
+
     void set_schema(Schema schema, uint64_t version);
     bool reset_file_if_needed(Schema& schema, uint64_t version, std::vector<SchemaChange>& changes_required);
 

--- a/tests/handover.cpp
+++ b/tests/handover.cpp
@@ -26,6 +26,7 @@
 #include "property.hpp"
 #include "schema.hpp"
 #include "thread_confined.hpp"
+#include "impl/realm_coordinator.hpp"
 
 #include <realm/history.hpp>
 #include <realm/util/optional.hpp>
@@ -114,11 +115,13 @@ TEST_CASE("handover") {
     }
 
     SECTION("version mismatch") {
+        auto coordinator = _impl::RealmCoordinator::get_existing_coordinator(config.path);
         SECTION("import into older version") {
             r->begin_transaction();
             Object num = create_object(r, int_object);
             num.row().set_int(0, 7);
             r->commit_transaction();
+            coordinator->on_change();
 
             REQUIRE(num.row().get_int(0) == 7);
             auto h = std::async([config]() -> auto {

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -343,6 +343,19 @@ TEST_CASE("notifications: async delivery") {
             thread.join();
         }
 
+        SECTION("refresh() does not block for results without callbacks") {
+            token = {};
+            // this would deadlock if it waits for the notifier to be ready
+            r->refresh();
+        }
+
+        SECTION("begin_transaction() does not block for results without callbacks") {
+            token = {};
+            // this would deadlock if it waits for the notifier to be ready
+            r->begin_transaction();
+            r->cancel_transaction();
+        }
+
         SECTION("begin_transaction() does not block for Results for different Realms") {
             // this would deadlock if beginning the write on the secondary Realm
             // waited for the primary Realm to be ready

--- a/tests/transaction_log_parsing.cpp
+++ b/tests/transaction_log_parsing.cpp
@@ -1258,7 +1258,8 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             fn();
             realm->commit_transaction();
 
-            _impl::transaction::advance(sg, &observer, SchemaMode::Automatic);
+            _impl::NotifierPackage notifiers;
+            _impl::transaction::advance(sg, &observer, SchemaMode::Automatic, notifiers);
             return observer;
         };
 
@@ -1282,7 +1283,6 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             REQUIRE_FALSE(changes.modified(0, 2));
         }
 
-#if REALM_MAJOR_VER >= 2
         SECTION("SetDefault does not mark as changed") {
             Row r = target->get(0);
             auto changes = observe({r}, [&] {
@@ -1292,7 +1292,6 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             REQUIRE_FALSE(changes.modified(0, 1));
             REQUIRE_FALSE(changes.modified(0, 2));
         }
-#endif
 
         SECTION("multiple properties on a single object are handled properly") {
             Row r = target->get(0);


### PR DESCRIPTION
This is a prerequisite for suppressing specific notifications from a write transaction, as we can't have notifications cover a range of commits with a gap, and generally makes it harder to get into inconsistent states.

The new behavior is that autorefresh works as it always did (advancing the most recent version with notifications ready), but now `refresh()` and `begin_transaction()` block if the notifications for the newest version are not ready yet. In the case of `refresh()`, the "newest version" means "the version that was newest at the time when refresh() was called or any version after that (which may still not be the actual latest version)". For `begin_transaction()` it blocks after acquiring the write lock, so it actually will be notifications for the latest version.

This makes `refresh()` within a notifications a no-op, and does not send notifications if `begin_transaction()` is called from within a notification, as I was unable to come up with a model for nested notifications which was clearly better than not doing them at all.

This does not attempt to make version advances from importing handover objects robustly produce notifications.
