### PR TITLE
Add sync-related file management functionality to object store

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,8 +76,8 @@ set(INCLUDE_DIRS
 
 if(REALM_ENABLE_SYNC)
     # Add the sync files separately to reduce merge conflicts.
-    list(APPEND HEADERS sync_config.hpp sync_manager.hpp sync_metadata.hpp sync_session.hpp impl/sync_client.hpp)
-    list(APPEND SOURCES sync_manager.cpp sync_metadata.cpp sync_session.cpp)
+    list(APPEND HEADERS sync_config.hpp sync_manager.hpp sync_metadata.hpp sync_session.hpp sync_file.hpp impl/sync_client.hpp)
+    list(APPEND SOURCES sync_manager.cpp sync_metadata.cpp sync_session.cpp sync_file.cpp)
     find_package(ZLIB REQUIRED)
     list(APPEND INCLUDE_DIRS ${REALM_SYNC_INCLUDE_DIR} ${ZLIB_INCLUDE_DIRS})
 endif()

--- a/src/sync_file.cpp
+++ b/src/sync_file.cpp
@@ -1,0 +1,262 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "sync_file.hpp"
+
+#include <realm/util/file.hpp>
+
+using File = realm::util::File;
+
+namespace realm {
+
+static uint8_t value_of_hex_digit(char hex_digit)
+{
+    if (hex_digit >= '0' && hex_digit <= '9') {
+        return hex_digit - '0';
+    } else if (hex_digit >= 'A' && hex_digit <= 'F') {
+        return 10 + hex_digit - 'A';
+    } else if (hex_digit >= 'a' && hex_digit <= 'f') {
+        return 10 + hex_digit - 'a';
+    } else {
+        throw std::invalid_argument("Cannot get the value of a character that isn't a hex digit.");
+    }
+}
+
+static bool character_is_unreserved(char character)
+{
+    bool is_capital_letter = (character >= 'A' && character <= 'Z');
+    bool is_lowercase_letter = (character >= 'a' && character <= 'z');
+    bool is_number = (character >= '0' && character <= '9');
+    bool is_allowed_symbol = (character == '-' || character == '_');
+    return is_capital_letter || is_lowercase_letter || is_number || is_allowed_symbol;
+}
+
+static char decoded_char_for(const std::string& percent_encoding, size_t index)
+{
+    if (index+2 >= percent_encoding.length()) {
+        throw std::invalid_argument("Malformed string: not enough characters after '%' before end of string.");
+    }
+    REALM_ASSERT(percent_encoding[index] == '%');
+    return (16*value_of_hex_digit(percent_encoding[index + 1])) + value_of_hex_digit(percent_encoding[index + 2]);
+}
+
+void remove_nonempty_dir(const std::string& path)
+{
+#ifdef _WIN32
+    // Not implemented yet.
+    REALM_ASSERT(false);
+#else
+    // Open the directory and list all the files.
+    DIR *dir_listing = opendir(path.c_str());
+    if (!dir_listing) {
+        return;
+    }
+    while (struct dirent *file = readdir(dir_listing)) {
+        auto file_type = file->d_type;
+        std::string file_name = file->d_name;
+        if (file_name == "." || file_name == "..") {
+            continue;
+        }
+        if (file_type == DT_REG || file_type == DT_FIFO) {
+            // Regular file (this really shouldn't ever throw, so if it does don't bother catching the exception).
+            File::remove(file_path_by_appending_component(path, file_name));
+        } else if (file_type == DT_DIR) {
+            // Directory, recurse
+            remove_nonempty_dir(file_path_by_appending_component(path, file_name, true));
+        }
+    }
+    closedir(dir_listing);
+    // Delete the directory itself
+    util::remove_dir(path);
+#endif
+}
+
+std::string make_percent_encoded_string(const std::string& raw_string)
+{
+    std::string buffer;
+    buffer.reserve(raw_string.length());
+    for (char character : raw_string) {
+        if (character_is_unreserved(character)) {
+            buffer.push_back(character);
+        } else {
+            char b[4] = {0, 0, 0, 0};
+            snprintf(b, 4, "%%%2X", character);
+            buffer.append(b);
+        }
+    }
+    return buffer;
+}
+
+std::string make_raw_string(const std::string& percent_encoded_string)
+{
+    std::string buffer;
+    size_t input_len = percent_encoded_string.length();
+    buffer.reserve(input_len);
+    size_t idx = 0;
+    while (idx < input_len) {
+        char current = percent_encoded_string[idx];
+        if (current == '%') {
+            // Decode. +3.
+            buffer.push_back(decoded_char_for(percent_encoded_string, idx));
+            idx += 3;
+        } else {
+            // No need to decode. +1.
+            if (!character_is_unreserved(current)) {
+                throw std::invalid_argument("Input string is invalid: contains reserved characters.");
+            }
+            buffer.push_back(current);
+            idx++;
+        }
+    }
+    return buffer;
+}
+
+std::string file_path_by_appending_component(const std::string& path, const std::string& component, bool is_directory)
+{
+    // FIXME: Does this have to be changed to accomodate Windows platforms?
+    std::string terminal = "";
+    if (is_directory && component[component.length() - 1] != '/') {
+        terminal = "/";
+    }
+    char path_last = path[path.length() - 1];
+    char component_first = component[0];
+    if (path_last == '/' && component_first == '/') {
+        return path + component.substr(1) + terminal;
+    } else if (path_last == '/' || component_first == '/') {
+        return path + component + terminal;
+    } else {
+        return path + "/" + component + terminal;
+    }
+}
+
+std::string file_path_by_appending_extension(const std::string& path, const std::string& extension)
+{
+    char path_last = path[path.length() - 1];
+    char extension_first = extension[0];
+    if (path_last == '.' && extension_first == '.') {
+        return path + extension.substr(1);
+    } else if (path_last == '.' || extension_first == '.') {
+        return path + extension;
+    } else {
+        return path + "." + extension;
+    }
+}
+
+std::string SyncFileManager::get_utility_directory()
+{
+    auto util_path = file_path_by_appending_component(get_base_sync_directory(), c_utility_directory, true);
+    util::try_make_dir(util_path);
+    return util_path;
+}
+
+std::string SyncFileManager::get_base_sync_directory()
+{
+    auto sync_path = file_path_by_appending_component(m_base_path, c_sync_directory, true);
+    util::try_make_dir(sync_path);
+    return sync_path;
+}
+
+std::string SyncFileManager::user_directory(std::string user_identity)
+{
+    if (user_identity.length() == 0) {
+        throw std::invalid_argument("user_identity cannot be an empty string");
+    }
+    auto user_path = file_path_by_appending_component(get_base_sync_directory(), std::move(user_identity), true);
+    util::try_make_dir(user_path);
+    return user_path;
+}
+
+void SyncFileManager::remove_user_directory(std::string user_identity)
+{
+    if (user_identity.length() == 0) {
+        throw std::invalid_argument("user_identity cannot be an empty string");
+    }
+    auto user_path = file_path_by_appending_component(get_base_sync_directory(), std::move(user_identity), true);
+    try {
+        remove_nonempty_dir(user_path);
+    } catch(File::AccessError) {
+    }
+}
+
+bool SyncFileManager::remove_realm(std::string user_identity, std::string raw_realm_path)
+{
+    if (user_identity.length() == 0) {
+        throw std::invalid_argument("user_identity cannot be an empty string");
+    } else if (raw_realm_path.length() == 0) {
+        throw std::invalid_argument("path cannot be an empty string");
+    }
+    auto escaped = make_percent_encoded_string(raw_realm_path);
+    auto realm_path = file_path_by_appending_component(user_directory(std::move(user_identity)), std::move(escaped));
+    bool success = true;
+    // Remove the base Realm file (e.g. "example.realm").
+    try {
+        File::remove(realm_path);
+    } catch(File::NotFound) {
+    } catch(File::AccessError) {
+        success = false;
+    }
+    // Remove the lock file (e.g. "example.realm.lock").
+    auto lock_path = file_path_by_appending_extension(realm_path, "lock");
+    try {
+        File::remove(lock_path);
+    } catch(File::NotFound) {
+    } catch(File::AccessError) {
+        success = false;
+    }
+    // Remove the management directory (e.g. "example.realm.management").
+    auto management_path = file_path_by_appending_extension(realm_path, "management");
+    try {
+        remove_nonempty_dir(management_path);
+    } catch(File::NotFound) {
+    } catch(File::AccessError) {
+        success = false;
+    }
+    return success;
+}
+
+std::string SyncFileManager::path(std::string user_identity, std::string raw_realm_path)
+{
+    if (user_identity.length() == 0) {
+        throw std::invalid_argument("user_identity cannot be an empty string");
+    } else if (raw_realm_path.length() == 0) {
+        throw std::invalid_argument("path cannot be an empty string");
+    }
+    auto escaped = make_percent_encoded_string(raw_realm_path);
+    auto realm_path = file_path_by_appending_component(user_directory(std::move(user_identity)), std::move(escaped));
+    return realm_path;
+}
+
+std::string SyncFileManager::metadata_path()
+{
+    auto dir_path = file_path_by_appending_component(get_utility_directory(), c_metadata_directory, true);
+    util::try_make_dir(dir_path);
+    return file_path_by_appending_component(std::move(dir_path), c_metadata_realm);
+}
+
+bool SyncFileManager::remove_metadata_realm()
+{
+    auto dir_path = file_path_by_appending_component(get_utility_directory(), c_metadata_directory, true);
+    try {
+        remove_nonempty_dir(dir_path);
+        return true;
+    } catch(File::AccessError) {
+        return false;
+    }
+}
+
+}

--- a/src/sync_file.hpp
+++ b/src/sync_file.hpp
@@ -1,0 +1,79 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_OS_SYNC_FILE_HPP
+#define REALM_OS_SYNC_FILE_HPP
+
+#include <string>
+
+namespace realm {
+
+/// Given a string, turn it into a percent-encoded string.
+std::string make_percent_encoded_string(const std::string& raw_string);
+
+/// Given a percent-encoded string, turn it into the original (non-encoded) string.
+std::string make_raw_string(const std::string& percent_encoded_string);
+
+/// Given a file path and a path component, return a new path created by appending the component to the path.
+std::string file_path_by_appending_component(const std::string& path,
+                                             const std::string& component,
+                                             bool is_directory=false);
+
+/// Given a file path and an extension, append the extension to the path.
+std::string file_path_by_appending_extension(const std::string& path, const std::string& extension);
+
+/// Remove a directory, including non-empty directories.
+void remove_nonempty_dir(const std::string& path);
+
+class SyncFileManager {
+public:
+    SyncFileManager(std::string base_path) : m_base_path(std::move(base_path)) { }
+
+    /// Return the user directory for a given user, creating it if it does not already exist.
+    std::string user_directory(std::string user_identity);
+
+    /// Remove the user directory for a given user.
+    void remove_user_directory(std::string user_identity);
+
+    /// Return the path for a given Realm, creating the user directory if it does not already exist.
+    std::string path(std::string user_identity, std::string raw_realm_path);
+
+    /// Remove the Realm at a given path for a given user. Returns `true` if the remove operation fully succeeds.
+    bool remove_realm(std::string user_identity, std::string raw_realm_path);
+
+    /// Return the path for the metadata Realm files.
+    std::string metadata_path();
+
+    /// Remove the metadata Realm.
+    bool remove_metadata_realm();
+
+private:
+    std::string m_base_path;
+
+    const std::string c_sync_directory = "realm-object-server";
+    const std::string c_utility_directory = "io.realm.object-server-utility";
+    const std::string c_metadata_directory = "metadata";
+    const std::string c_metadata_realm = "sync_metadata.realm";
+
+    std::string get_utility_directory();
+    std::string get_base_sync_directory();
+};
+
+}
+
+#endif // REALM_OS_SYNC_FILE_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ set(SOURCES
     results.cpp
     schema.cpp
     transaction_log_parsing.cpp
+    sync/sync_file.cpp
     util/event_loop.cpp
     util/test_file.cpp
 )

--- a/tests/sync/sync_file.cpp
+++ b/tests/sync/sync_file.cpp
@@ -1,0 +1,255 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "catch.hpp"
+
+#include "shared_realm.hpp"
+#include "sync_file.hpp"
+#include <realm/util/file.hpp>
+
+using namespace realm;
+using File = realm::util::File;
+
+static const std::string base_path = "/tmp/realm_objectstore_sync_file/";
+
+static void prepare_sync_manager_test(void) {
+    // Remove the base directory in /tmp where all test-related file status lives.
+    remove_nonempty_dir(base_path);
+    const std::string manager_path = base_path + "syncmanager/";
+    util::make_dir(base_path);
+    util::make_dir(manager_path);
+}
+
+/// Open a Realm at a given path, creating its files.
+static bool create_dummy_realm(std::string path) {
+    Realm::Config config;
+    config.path = std::move(path);
+    try {
+        return Realm::make_shared_realm(config) != nullptr;
+    } catch(std::exception) {
+        return false;
+    }
+}
+
+#define REQUIRE_DIR_EXISTS(macro_path) \
+{ \
+DIR *dir_listing = opendir((macro_path).c_str()); \
+REQUIRE(dir_listing); \
+if (dir_listing) closedir(dir_listing); \
+}
+
+#define REQUIRE_DIR_DOES_NOT_EXIST(macro_path) \
+{ \
+DIR *dir_listing = opendir((macro_path).c_str()); \
+REQUIRE(dir_listing == NULL); \
+if (dir_listing) closedir(dir_listing); \
+}
+
+
+TEST_CASE("sync_file: percent-encoding APIs") {
+	SECTION("does not encode a string that has no restricted characters") {
+		const std::string expected = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_-";
+		auto actual = make_percent_encoded_string(expected);
+		REQUIRE(actual == expected);
+	}
+
+    SECTION("properly encodes a sample Realm URL") {
+    	const std::string expected = "realms%3A%2F%2Fexample%2Ecom%2F%7E%2Ffoo_bar%2Fuser-realm";
+    	const std::string raw_string = "realms://example.com/~/foo_bar/user-realm";
+    	auto actual = make_percent_encoded_string(raw_string);
+    	REQUIRE(actual == expected);
+    }
+
+    SECTION("properly decodes a sample Realm URL") {
+        const std::string expected = "realms://example.com/~/foo_bar/user-realm";
+        const std::string encoded_string = "realms%3A%2F%2Fexample%2Ecom%2F%7E%2Ffoo_bar%2Fuser-realm";
+        auto actual = make_raw_string(encoded_string);
+        REQUIRE(actual == expected);
+    }
+}
+
+TEST_CASE("sync_file: URL manipulation APIs") {
+    SECTION("properly concatenates a path when the path has a trailing slash") {
+        const std::string expected = "/foo/bar";
+        const std::string path = "/foo/";
+        const std::string component = "bar";
+        auto actual = file_path_by_appending_component(path, component);
+        REQUIRE(actual == expected);
+    }
+
+    SECTION("properly concatenates a path when the component has a leading slash") {
+        const std::string expected = "/foo/bar";
+        const std::string path = "/foo";
+        const std::string component = "/bar";
+        auto actual = file_path_by_appending_component(path, component);
+        REQUIRE(actual == expected);
+    }
+
+    SECTION("properly concatenates a path when both arguments have slashes") {
+        const std::string expected = "/foo/bar";
+        const std::string path = "/foo/";
+        const std::string component = "/bar";
+        auto actual = file_path_by_appending_component(path, component);
+        REQUIRE(actual == expected);
+    }
+
+    SECTION("properly concatenates a directory path when the component doesn't have a trailing slash") {
+        const std::string expected = "/foo/bar/";
+        const std::string path = "/foo/";
+        const std::string component = "/bar";
+        auto actual = file_path_by_appending_component(path, component, true);
+        REQUIRE(actual == expected);
+    }
+
+    SECTION("properly concatenates a directory path when the component has a trailing slash") {
+        const std::string expected = "/foo/bar/";
+        const std::string path = "/foo/";
+        const std::string component = "/bar/";
+        auto actual = file_path_by_appending_component(path, component, true);
+        REQUIRE(actual == expected);
+    }
+
+    SECTION("properly concatenates an extension when the path has a trailing dot") {
+        const std::string expected = "/foo.management";
+        const std::string path = "/foo.";
+        const std::string component = "management";
+        auto actual = file_path_by_appending_extension(path, component);
+        REQUIRE(actual == expected);
+    }
+
+    SECTION("properly concatenates a path when the extension has a leading dot") {
+        const std::string expected = "/foo.management";
+        const std::string path = "/foo";
+        const std::string component = ".management";
+        auto actual = file_path_by_appending_extension(path, component);
+        REQUIRE(actual == expected);
+    }
+
+    SECTION("properly concatenates a path when both arguments have dots") {
+        const std::string expected = "/foo.management";
+        const std::string path = "/foo.";
+        const std::string component = ".management";
+        auto actual = file_path_by_appending_extension(path, component);
+        REQUIRE(actual == expected);
+    }
+}
+
+TEST_CASE("sync_file: SyncFileManager APIs") {    
+    const std::string identity = "123456789";
+    const std::string manager_path = base_path + "syncmanager/";
+    prepare_sync_manager_test();
+    auto manager = SyncFileManager(manager_path);
+
+    SECTION("user directory APIs") {
+        const std::string expected = manager_path + "realm-object-server/123456789/";
+
+        SECTION("getting a user directory") {
+            SECTION("that didn't exist before succeeds") {
+                auto actual = manager.user_directory(identity);
+                REQUIRE(actual == expected);
+                REQUIRE_DIR_EXISTS(expected);
+            }
+            SECTION("that already existed succeeds") {
+                auto actual = manager.user_directory(identity);
+                REQUIRE(actual == expected);
+                REQUIRE_DIR_EXISTS(expected);
+            }
+        }
+
+        SECTION("deleting a user directory") {
+            manager.user_directory(identity);
+            REQUIRE_DIR_EXISTS(expected);
+            SECTION("that wasn't yet deleted succeeds") {
+                manager.remove_user_directory(identity);
+                REQUIRE_DIR_DOES_NOT_EXIST(expected);
+            }
+            SECTION("that was already deleted succeeds") {
+                manager.remove_user_directory(identity);
+                REQUIRE(opendir(expected.c_str()) == NULL);
+                REQUIRE_DIR_DOES_NOT_EXIST(expected);
+            }
+        }
+    }
+
+    SECTION("Realm path APIs") {
+        auto relative_path = "realms://r.example.com/~/my/realm/path";
+
+        SECTION("getting a Realm path") {
+            const std::string expected = manager_path + "realm-object-server/123456789/realms%3A%2F%2Fr%2Eexample%2Ecom%2F%7E%2Fmy%2Frealm%2Fpath";
+            auto actual = manager.path(identity, relative_path);
+            REQUIRE(expected == actual);
+        }
+
+        SECTION("deleting a Realm for a valid user") {
+            manager.path(identity, relative_path);
+            // Create the required files
+            auto realm_base_path = manager_path + "realm-object-server/123456789/realms%3A%2F%2Fr%2Eexample%2Ecom%2F%7E%2Fmy%2Frealm%2Fpath";
+            REQUIRE(create_dummy_realm(realm_base_path));
+            REQUIRE(File::exists(realm_base_path));
+            REQUIRE(File::exists(realm_base_path + ".lock"));
+            REQUIRE_DIR_EXISTS(realm_base_path + ".management");
+            // Delete the Realm
+            manager.remove_realm(identity, relative_path);
+            // Ensure the files don't exist anymore
+            REQUIRE(!File::exists(realm_base_path));
+            REQUIRE(!File::exists(realm_base_path + ".lock"));
+            REQUIRE_DIR_DOES_NOT_EXIST(realm_base_path + ".management");
+        }
+
+        SECTION("deleting a Realm for an invalid user") {
+            manager.remove_realm("invalid_user", relative_path);
+        }
+
+        SECTION("deleting a Realm with an empty user ID string") {
+            bool did_throw = false;
+            try {
+                manager.remove_realm("", relative_path);
+            } catch (std::invalid_argument) {
+                did_throw = true;
+            }
+            REQUIRE(did_throw);
+        }
+
+        SECTION("deleting a Realm with an empty raw Realm path string") {
+            manager.path(identity, relative_path);
+            bool did_throw = false;
+            try {
+                manager.remove_realm(identity, "");
+            } catch (std::invalid_argument) {
+                did_throw = true;
+            }
+            REQUIRE(did_throw);
+        }
+    }
+
+    SECTION("Utility path APIs") {
+        auto metadata_dir = manager_path + "realm-object-server/io.realm.object-server-utility/metadata/";
+
+        SECTION("getting the metadata path") {
+            auto path = manager.metadata_path();
+            REQUIRE(path == (metadata_dir + "sync_metadata.realm"));
+        }
+
+        SECTION("removing the metadata Realm") {
+            manager.metadata_path();
+            REQUIRE_DIR_EXISTS(metadata_dir);
+            manager.remove_metadata_realm();
+            REQUIRE_DIR_DOES_NOT_EXIST(metadata_dir);
+        }
+    }
+}


### PR DESCRIPTION
Tested and ready for review. Ari has been asking for this, so we should consider pulling it in. Otherwise, this can wait until after we get out of beta.

@alazier @jpsim @tgoyne @bdash 

Supersedes https://github.com/realm/realm-object-store-private/pull/47