### PR TITLE
Conditionally build sync

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,11 @@ include(Sanitizers)
 include(RealmCore)
 set(REALM_CORE_VERSION "1.5.0" CACHE STRING "")
 use_realm_core(${REALM_CORE_VERSION})
-build_realm_sync(${REALM_SYNC_PREFIX})
+
+option(REALM_ENABLE_SYNC "Build realm object store with sync extensions" OFF)
+if(REALM_ENABLE_SYNC)
+  build_realm_sync(${REALM_SYNC_PREFIX})
+endif()
 
 set(PEGTL_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/pegtl)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,6 @@ include(RealmCore)
 set(REALM_CORE_VERSION "1.5.0" CACHE STRING "")
 use_realm_core(${REALM_CORE_VERSION})
 
-option(REALM_ENABLE_SYNC "Build realm object store with sync extensions" OFF)
 if(REALM_SYNC_PREFIX)
   set(REALM_ENABLE_SYNC ON)
   build_realm_sync(${REALM_SYNC_PREFIX})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,8 @@ set(REALM_CORE_VERSION "1.5.0" CACHE STRING "")
 use_realm_core(${REALM_CORE_VERSION})
 
 option(REALM_ENABLE_SYNC "Build realm object store with sync extensions" OFF)
-if(REALM_ENABLE_SYNC)
+if(REALM_SYNC_PREFIX)
+  set(REALM_ENABLE_SYNC ON)
   build_realm_sync(${REALM_SYNC_PREFIX})
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,10 @@ if(REALM_SYNC_PREFIX)
   build_realm_sync(${REALM_SYNC_PREFIX})
 endif()
 
+if(REALM_ENABLE_SYNC)
+  add_definitions(-DREALM_ENABLE_SYNC)
+endif()
+
 set(PEGTL_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/external/pegtl)
 
 add_subdirectory(src)

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The given core tree will be built as part of the object store build.
 Specify the path to realm-core and realm-sync when invoking `cmake`:
 
 ```
-cmake -DREALM_CORE_VERSION=/path/to/realm-core -DREALM_SYNC_PREFIX=/path/to/realm-sync
+cmake -DREALM_CORE_VERSION=/path/to/realm-core -DREALM_SYNC_PREFIX=/path/to/realm-sync -DREALM_ENABLE_SYNC=ON
 ```
 
 Prebuilt sync binaries are currently not supported.

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ The given core tree will be built as part of the object store build.
 Specify the path to realm-core and realm-sync when invoking `cmake`:
 
 ```
-cmake -DREALM_CORE_VERSION=/path/to/realm-core -DREALM_SYNC_PREFIX=/path/to/realm-sync -DREALM_ENABLE_SYNC=ON
+cmake -DREALM_CORE_VERSION=/path/to/realm-core -DREALM_SYNC_PREFIX=/path/to/realm-sync
 ```
 
 Prebuilt sync binaries are currently not supported.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,11 +74,13 @@ set(INCLUDE_DIRS
     ${UV_INCLUDE_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR})
 
-# Add the sync files separately to reduce merge conflicts.
-list(APPEND HEADERS sync_config.hpp sync_manager.hpp sync_metadata.hpp sync_session.hpp impl/sync_client.hpp)
-list(APPEND SOURCES sync_manager.cpp sync_metadata.cpp sync_session.cpp)
-find_package(ZLIB REQUIRED)
-list(APPEND INCLUDE_DIRS ${REALM_SYNC_INCLUDE_DIR} ${ZLIB_INCLUDE_DIRS})
+if(REALM_ENABLE_SYNC)
+    # Add the sync files separately to reduce merge conflicts.
+    list(APPEND HEADERS sync_config.hpp sync_manager.hpp sync_metadata.hpp sync_session.hpp impl/sync_client.hpp)
+    list(APPEND SOURCES sync_manager.cpp sync_metadata.cpp sync_session.cpp)
+    find_package(ZLIB REQUIRED)
+    list(APPEND INCLUDE_DIRS ${REALM_SYNC_INCLUDE_DIR} ${ZLIB_INCLUDE_DIRS})
+endif()
 
 add_library(realm-object-store STATIC ${SOURCES} ${HEADERS})
 set_target_properties(realm-object-store PROPERTIES POSITION_INDEPENDENT_CODE 1)
@@ -86,5 +88,7 @@ target_compile_definitions(realm-object-store PRIVATE ${PLATFORM_DEFINES})
 target_include_directories(realm-object-store PUBLIC ${INCLUDE_DIRS})
 target_link_libraries(realm-object-store PUBLIC realm ${PLATFORM_LIBRARIES})
 
-# Add the sync libraries separately to reduce merge conflicts.
-target_link_libraries(realm-object-store PUBLIC realm-sync ${ZLIB_LIBRARIES})
+if(REALM_ENABLE_SYNC)
+    # Add the sync libraries separately to reduce merge conflicts.
+    target_link_libraries(realm-object-store PUBLIC realm-sync ${ZLIB_LIBRARIES})
+endif()

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -103,7 +103,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
         }
     }
 
-    #if REALM_ENABLE_SYNC
+#if REALM_ENABLE_SYNC
     if (config.sync_config && !m_sync_session) {
         m_sync_session = SyncManager::shared().get_session(config.path, *config.sync_config);
         SyncSession::Internal::set_sync_transact_callback(*m_sync_session, [this](VersionID, VersionID) {
@@ -114,7 +114,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
             SyncSession::Internal::set_error_handler(*m_sync_session, config.sync_config->error_handler);
         }
     }
-    #endif
+#endif
 
     auto realm = Realm::make_shared_realm(std::move(config));
     if (!config.read_only() && !m_notifier && config.automatic_change_notifications) {
@@ -232,16 +232,16 @@ void RealmCoordinator::send_commit_notifications(Realm& source_realm)
     if (m_notifier) {
         m_notifier->notify_others();
     }
-    #if REALM_ENABLE_SYNC
+#if REALM_ENABLE_SYNC
     if (m_sync_session) {
         auto& sg = Realm::Internal::get_shared_group(source_realm);
         auto version = LangBindHelper::get_version_of_latest_snapshot(sg);
         SyncSession::Internal::nonsync_transact_notify(*m_sync_session, version);
     }
-    #else
+#else
     // Silence "unused parameter 'source_realm'" warning
     (void)source_realm;
-    #endif
+#endif
 }
 
 void RealmCoordinator::pin_version(uint_fast64_t version, uint_fast32_t index)

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -26,9 +26,11 @@
 #include "object_store.hpp"
 #include "schema.hpp"
 
+#if REALM_ENABLE_SYNC
 #include "sync_config.hpp"
 #include "sync_manager.hpp"
 #include "sync_session.hpp"
+#endif
 
 #include <realm/group_shared.hpp>
 #include <realm/lang_bind_helper.hpp>
@@ -101,6 +103,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
         }
     }
 
+    #if REALM_ENABLE_SYNC
     if (config.sync_config && !m_sync_session) {
         m_sync_session = SyncManager::shared().get_session(config.path, *config.sync_config);
         SyncSession::Internal::set_sync_transact_callback(*m_sync_session, [this](VersionID, VersionID) {
@@ -111,6 +114,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
             SyncSession::Internal::set_error_handler(*m_sync_session, config.sync_config->error_handler);
         }
     }
+    #endif
 
     auto realm = Realm::make_shared_realm(std::move(config));
     if (!config.read_only() && !m_notifier && config.automatic_change_notifications) {
@@ -228,11 +232,16 @@ void RealmCoordinator::send_commit_notifications(Realm& source_realm)
     if (m_notifier) {
         m_notifier->notify_others();
     }
+    #if REALM_ENABLE_SYNC
     if (m_sync_session) {
         auto& sg = Realm::Internal::get_shared_group(source_realm);
         auto version = LangBindHelper::get_version_of_latest_snapshot(sg);
         SyncSession::Internal::nonsync_transact_notify(*m_sync_session, version);
     }
+    #else
+    // Silence "unused parameter 'source_realm'" warning
+    (void)source_realm;
+    #endif
 }
 
 void RealmCoordinator::pin_version(uint_fast64_t version, uint_fast32_t index)

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -36,7 +36,9 @@
 #include <realm/commit_log.hpp>
 #endif
 
+#if REALM_ENABLE_SYNC
 #include <realm/sync/history.hpp>
+#endif
 #include <realm/util/scope_exit.hpp>
 
 using namespace realm;
@@ -156,7 +158,9 @@ void Realm::open_with_config(const Config& config,
             // probably has to be transmuted to an NSError.
             bool server_synchronization_mode = bool(config.sync_config);
             if (server_synchronization_mode) {
+                #if REALM_ENABLE_SYNC
                 history = realm::sync::make_sync_history(config.path);
+                #endif
             }
             else {
 #if REALM_VER_MAJOR >= 2

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -158,9 +158,9 @@ void Realm::open_with_config(const Config& config,
             // probably has to be transmuted to an NSError.
             bool server_synchronization_mode = bool(config.sync_config);
             if (server_synchronization_mode) {
-                #if REALM_ENABLE_SYNC
+#if REALM_ENABLE_SYNC
                 history = realm::sync::make_sync_history(config.path);
-                #endif
+#endif
             }
             else {
 #if REALM_VER_MAJOR >= 2

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -23,7 +23,9 @@
 
 #include <realm/util/optional.hpp>
 
+#if REALM_ENABLE_SYNC
 #include <realm/sync/client.hpp>
+#endif
 
 #include <memory>
 #include <thread>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,7 +26,9 @@ set(SOURCES
 add_executable(tests ${SOURCES} ${HEADERS})
 target_compile_definitions(tests PRIVATE ${PLATFORM_DEFINES})
 target_link_libraries(tests realm-object-store ${PLATFORM_LIBRARIES})
+if(REALM_ENABLE_SYNC)
 target_link_libraries(tests realm-sync)
+endif()
 
 create_coverage_target(generate-coverage tests)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,9 +26,6 @@ set(SOURCES
 add_executable(tests ${SOURCES} ${HEADERS})
 target_compile_definitions(tests PRIVATE ${PLATFORM_DEFINES})
 target_link_libraries(tests realm-object-store ${PLATFORM_LIBRARIES})
-if(REALM_ENABLE_SYNC)
-target_link_libraries(tests realm-sync)
-endif()
 
 create_coverage_target(generate-coverage tests)
 


### PR DESCRIPTION
This PR merges `master` into `cocoa` and introduces a `REALM_ENABLE_SYNC` CMake option, which defaults to `OFF`.

Would love to know if there's a better way to do this @bdash. I'd rather not check for the presence of `REALM_SYNC_PREFIX` since when building realm cocoa the source for sync may not be available.