### PR TITLE
Fix the type used for the error code for KeychainAccessException.

### DIFF
--- a/src/impl/apple/keychain_helper.cpp
+++ b/src/impl/apple/keychain_helper.cpp
@@ -33,7 +33,7 @@ using realm::util::adoptCF;
 namespace realm {
 namespace keychain {
 
-KeychainAccessException::KeychainAccessException(size_t error_code)
+KeychainAccessException::KeychainAccessException(int32_t error_code)
 : std::runtime_error(util::format("Keychain returned unexpected status code: %1", error_code)) { }
 
 CFPtr<CFStringRef> convert_string(const std::string& string);

--- a/src/impl/apple/keychain_helper.hpp
+++ b/src/impl/apple/keychain_helper.hpp
@@ -29,7 +29,7 @@ std::vector<char> metadata_realm_encryption_key();
 
 class KeychainAccessException : public std::runtime_error {
 public:
-    KeychainAccessException(size_t error_code);
+    KeychainAccessException(int32_t error_code);
 };
 
 }


### PR DESCRIPTION
`size_t` is an unsigned type, so using it was resulting in a large positive error code being printed for keychain errors, rather than the real small negative error code.

/cc @austinzheng 