### PR TITLE
Attempt to resolve object store deadlocks

### DIFF
--- a/tests/sync/session.cpp
+++ b/tests/sync/session.cpp
@@ -231,10 +231,6 @@ TEST_CASE("sync: log-in", "[sync]") {
         CHECK(session->is_in_error_state());
     }
 
-#if 0
-    // FIXME: This test currently deadlocks when SyncSession's error handler attempts to change the
-    // session's state. Should be fixed by https://github.com/realm/realm-object-store/pull/181.
-
     SECTION("Session is invalid after invalid token while waiting on download to complete") {
         std::atomic<int> error_count(0);
         auto session = sync_session(server, user, "/test",
@@ -250,7 +246,6 @@ TEST_CASE("sync: log-in", "[sync]") {
         EventLoop::main().run_until([&] { return error_count > 0; });
         CHECK(session->is_in_error_state());
     }
-#endif
 
     // TODO: write a test that logs out a Realm with multiple sessions, then logs it back in?
 }


### PR DESCRIPTION
@bdash @tgoyne 

Fixes #178

This PR does two things:
- The session's state lock is never held through the duration of a call to `wait_for_upload_complete_or_client_stopped()` or `wait_for_download_complete_or_client_stopped()`. This prevents certain deadlocks from happening: for example, if the error handler is invoked while the binding is waiting (and the lock is being held), it will attempt to move the state to `error` but will never be able to acquire the lock, and the blocking call won't return and relinquish the lock because the error handler can't return.
- Any time those two APIs are called the lifetime of the `sync::Session` is now guaranteed until the call returns.

Maybe there's a better way to do this? Ideas welcome...
