### PR TITLE
Fix a BadVersion exception when async notifiers run during delivery

### DIFF
--- a/src/impl/results_notifier.cpp
+++ b/src/impl/results_notifier.cpp
@@ -159,6 +159,10 @@ void ResultsNotifier::run()
 void ResultsNotifier::do_prepare_handover(SharedGroup& sg)
 {
     if (!m_tv.is_attached()) {
+        // if the table version didn't change we can just reuse the same handover
+        // object and bump its version to the current SG version
+        if (m_tv_handover)
+            m_tv_handover->version = sg.get_version_of_current_transaction();
         return;
     }
 
@@ -188,7 +192,6 @@ void ResultsNotifier::deliver(SharedGroup& sg)
 
     REALM_ASSERT(!m_query_handover);
     if (m_tv_to_deliver) {
-        m_tv_to_deliver->version = version();
         Results::Internal::set_table_view(*m_target_results,
                                           std::move(*sg.import_from_handover(std::move(m_tv_to_deliver))));
     }


### PR DESCRIPTION
The version for reused handover objects was being bumped on delivery to the most recent version that had been calculated, which may be more recent than the version actually being delivered. Instead bump it to the point where we would normally recreate the handover object so that it is guaranteed to get the correct version.

No new test for this because it was a race condition and thus not meaningfully testable. Fixes https://secure.helpscout.net/conversation/259511081/6838/ and probably fixes realm/realm-cocoa#4144.

@bdash 