### PR TITLE
Proposal for API to move sync functionality into object store

### DIFF
--- a/src/sync_config.hpp
+++ b/src/sync_config.hpp
@@ -21,8 +21,11 @@
 
 #include <functional>
 #include <string>
+#include <memory>
 
 namespace realm {
+
+class SyncUser;
 
 enum class SyncSessionStopPolicy;
 
@@ -36,16 +39,18 @@ enum class SyncSessionError {
 using SyncSessionErrorHandler = void(int error_code, std::string message, SyncSessionError);
 
 struct SyncConfig {
-    SyncConfig(std::string user_tag, std::string realm_url, std::function<SyncSessionErrorHandler> error_handler,
+    SyncConfig(std::shared_ptr<SyncUser> user,
+               std::string realm_url,
+               std::function<SyncSessionErrorHandler> error_handler,
                SyncSessionStopPolicy stop_policy)
-    : user_tag(std::move(user_tag))
+    : user(std::move(user))
     , realm_url(std::move(realm_url))
     , error_handler(std::move(error_handler))
     , stop_policy(stop_policy)
     {
     }
 
-    std::string user_tag;
+    std::shared_ptr<SyncUser> user;
     std::string realm_url;
     std::function<SyncSessionErrorHandler> error_handler;
     SyncSessionStopPolicy stop_policy;

--- a/src/sync_session.hpp
+++ b/src/sync_session.hpp
@@ -29,6 +29,7 @@
 namespace realm {
 
 class SyncManager;
+class SyncUser;
 
 namespace _impl {
 class RealmCoordinator;
@@ -71,6 +72,11 @@ struct SyncSession : public std::enable_shared_from_this<SyncSession> {
 
     // Inform the sync session that it should log out.
     void log_out();
+
+    std::shared_ptr<SyncUser> user() const
+    {
+        return m_user.lock();
+    }
 
     // Expose some internal functionality to other parts of the ObjectStore
     // without making it public to everyone
@@ -128,6 +134,8 @@ private:
     size_t m_pending_upload_threads = 0;
 
     SyncConfig m_config;
+
+    std::weak_ptr<SyncUser> m_user;
 
     std::string m_realm_path;
     std::shared_ptr<_impl::SyncClient> m_client;

--- a/src/sync_user.hpp
+++ b/src/sync_user.hpp
@@ -1,0 +1,93 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_OS_SYNC_USER_HPP
+#define REALM_OS_SYNC_USER_HPP
+
+#include <string>
+#include <memory>
+#include <unordered_map>
+
+namespace realm {
+
+struct SyncSession;
+
+// A `SyncUser` represents a single user account. Each user manages the sessions that
+// are associated with it.
+class SyncUser {
+public:	
+	enum class State {
+		LoggedOut, Active, Error;
+	}
+
+	// Don't use this directly; use the `SyncManager` APIs. Public for use with `make_shared`.
+	SyncUser(std::string refresh_token, bool is_admin=false);
+
+	// Return a list of all users.
+	static std::vector<std::shared_ptr<SyncUser>> all_users();
+
+	// Return a list of all sessions belonging to this user.
+	std::vector<std::shared_ptr<SyncSession>> all_sessions();
+
+	// Return a session for a given file path.
+	std::shared_ptr<SyncSession> session_for_path(const std::string path&);
+
+	// Log the user out and mark it as invalid. This will also close its associated Sessions.
+	void log_out();
+
+	// Whether the user was configured as an 'admin user' (directly uses its user token
+	// to open Realms).
+	bool is_admin() const
+	{
+		return m_is_admin;
+	}
+
+	std::string identity() const
+	{
+		return m_identity;
+	}
+
+	State state() const
+	{
+		return m_state;
+	}
+
+	// The auth server URL. Bindings should set this appropriately when they retrieve
+	// instances of `SyncUser`s.
+	// FIXME: once the new token system is implemented, this can be removed completely.
+	std::string server_url;
+
+private:
+	State m_state;
+	
+	// Whether the user is an 'admin' user. Admin users use the admin tokens they were
+	// configured with to directly open sessions, and do not make network requests.
+	bool m_is_admin;
+	// The user's refresh token.
+	std::string m_refresh_token;
+	// Set by the server. The unique ID of the user account on the Realm Object Server.
+	std::string m_identity;
+
+    // Sessions are owned by the SyncManager, but the user keeps a map of weak references
+    // to them.
+    std::unordered_map<std::string, std::weak_ptr<SyncSession>> m_sessions;
+}
+
+}
+
+#endif // REALM_OS_SYNC_USER_HPP


### PR DESCRIPTION
I want to start a conversation, per @alazier's request, about eventually moving most of the sync functionality into the object store. This commit isn't meant to be merged, but rather to propose API changes through header file changes.

@jpsim @bdash @tgoyne @cmelchior 

This is what I envision. (Updated 10/5)

## `SyncUser`

`SyncUser` is a new object store type. It represents a user whose identity is known (e.g. the result of a binding successfully "logging in" using a Credential object). It does not own users, but does have weak pointers to the sessions associated with it.

## `SyncConfig` changes:

Rather than carrying a string "tag" to a user, the config now carries a shared pointer to the user object itself.

## `SyncManager` changes:

The `SyncManager` is now responsible for vending out users, as well as sessions.

## `SyncSession` changes:

Sync sessions now have a weak pointer to the user that owns them.

The sync session state machine should be changed such that the session does not automatically try to bind with the callback as soon as it's created, but waits for the user to ask it to do so. (The user might do so immediately, if it's logged in, or it might wait until it becomes active again if it were logged out previously.)

## Minimum binding requirement

A hypothetical binding which wanted to support the minimal sync feature set given this new object store design would do the following:

1. Create a `SyncConfiguration` type which wraps `realm::SyncConfig`, and allow the user to set it as a property on a `RealmConfiguration`, updating the underlying `realm::Realm::Config`.
2. Create a `User` type which wraps a `realm::SyncUser`. This user object needs to be able to make the login call to the auth server using a credential, and might have other APIs like `logOut()`. 
3. Set the global "bind session" callback.

The object store would transparently take care of everything else, from closing sessions upon completion to persisting and loading user info in the metadata database.
