### PR TITLE
Fix an issue where the "wait for upload/download" APIs could cause an error

### DIFF
--- a/src/sync_session.cpp
+++ b/src/sync_session.cpp
@@ -418,13 +418,21 @@ void SyncSession::unregister(std::unique_lock<std::mutex>& lock)
     SyncManager::shared().unregister_session(m_realm_path);
 }
 
+bool SyncSession::can_wait_for_network_completion() const
+{
+    return m_state == &State::active || m_state == &State::dying;
+}
+
 void SyncSession::wait_for_upload_completion(std::function<void()> callback)
 {
+    // FIXME: If the session is waiting for a token, the `wait_for_upload` should be deferred until the `bind()`
+    // instead of just calling the callback immediately.
     REALM_ASSERT(shared_from_this());
     auto thread = std::thread([this, callback=std::move(callback), self=shared_from_this()]() {
         {
             std::unique_lock<std::mutex> lock(m_state_mutex);
-            if (m_session) {
+            if (can_wait_for_network_completion()) {
+                REALM_ASSERT(m_session);
                 m_session->wait_for_upload_complete_or_client_stopped();
             }
         }
@@ -436,11 +444,14 @@ void SyncSession::wait_for_upload_completion(std::function<void()> callback)
 
 void SyncSession::wait_for_download_completion(std::function<void()> callback)
 {
+    // FIXME: If the session is waiting for a token, the `wait_for_upload` should be deferred until the `bind()`
+    // instead of just calling the callback immediately.
     REALM_ASSERT(shared_from_this());
     auto thread = std::thread([this, callback=std::move(callback), self=shared_from_this()]() {
         {
             std::unique_lock<std::mutex> lock(m_state_mutex);
-            if (m_session) {
+            if (can_wait_for_network_completion()) {
+                REALM_ASSERT(m_session);
                 m_session->wait_for_download_complete_or_client_stopped();
             }
         }

--- a/src/sync_session.hpp
+++ b/src/sync_session.hpp
@@ -110,6 +110,8 @@ private:
     bool is_inactive() const;
     // }
 
+    bool can_wait_for_network_completion() const;
+
     void set_sync_transact_callback(std::function<SyncSessionTransactCallback>);
     void set_error_handler(std::function<SyncSessionErrorHandler>);
     void nonsync_transact_notify(VersionID::version_type);


### PR DESCRIPTION
@tgoyne @bdash 

I pulled this small change out of https://github.com/realm/realm-object-store/pull/181, since it's not related to the deadlocks that issue tries to address.

`bind()` must be called before `wait_for_upload_complete_or_client_stopped()` and `wait_for_download_complete_or_client_stopped()` can be called; this change enforces that precondition