### PR TITLE
Use unnested VersionID

### DIFF
--- a/src/impl/collection_notifier.cpp
+++ b/src/impl/collection_notifier.cpp
@@ -21,6 +21,7 @@
 #include "impl/realm_coordinator.hpp"
 #include "shared_realm.hpp"
 
+#include <realm/group_shared.hpp>
 #include <realm/link_view.hpp>
 
 using namespace realm;
@@ -288,17 +289,17 @@ void CollectionNotifier::deliver_error(std::exception_ptr error)
     m_error = true;
 }
 
-SharedGroup::VersionID CollectionNotifier::package_for_delivery(Realm& realm)
+VersionID CollectionNotifier::package_for_delivery(Realm& realm)
 {
     {
         std::lock_guard<std::mutex> lock(m_realm_mutex);
         if (m_realm.get() != &realm) {
-            return SharedGroup::VersionID{};
+            return VersionID{};
         }
     }
 
     if (!prepare_to_deliver()) {
-        return SharedGroup::VersionID{};
+        return VersionID{};
     }
     m_changes_to_deliver = std::move(m_accumulated_changes).finalize();
     return version();

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -21,7 +21,7 @@
 
 #include "impl/collection_change_builder.hpp"
 
-#include <realm/group_shared.hpp>
+#include <realm/version_id.hpp>
 
 #include <array>
 #include <atomic>
@@ -32,6 +32,8 @@
 
 namespace realm {
 class Realm;
+class SharedGroup;
+class Table;
 
 namespace _impl {
 struct ListChangeInfo {
@@ -122,7 +124,7 @@ public:
 
     // Get the SharedGroup version which this collection can attach to (if it's
     // in handover mode), or can deliver to (if it's been handed over to the BG worker alredad)
-    SharedGroup::VersionID version() const noexcept { return m_sg_version; }
+    VersionID version() const noexcept { return m_sg_version; }
 
     // Release references to all core types
     // This is called on the worker thread to ensure that non-thread-safe things
@@ -135,7 +137,7 @@ public:
     // default-constructed version if this notifier has nothing to deliver to
     // this Realm (either due to being for a different Realm, or just because
     // nothing has changed since it last delivered).
-    SharedGroup::VersionID package_for_delivery(Realm&);
+    VersionID package_for_delivery(Realm&);
 
     // Deliver the new state to the target collection using the given SharedGroup
     virtual void deliver(SharedGroup&) { }
@@ -183,7 +185,7 @@ private:
     mutable std::mutex m_realm_mutex;
     std::shared_ptr<Realm> m_realm;
 
-    SharedGroup::VersionID m_sg_version;
+    VersionID m_sg_version;
     SharedGroup* m_sg = nullptr;
 
     bool m_error = false;
@@ -211,7 +213,7 @@ private:
 
     // Iteration variable for looping over callbacks
     // remove_callback() updates this when needed
-    size_t m_callback_index = npos;
+    size_t m_callback_index = -1;
 
     CollectionChangeCallback next_callback(bool has_changes, bool pre);
 };

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -117,7 +117,7 @@ private:
     std::unique_ptr<_impl::ExternalCommitHelper> m_notifier;
 
     // must be called with m_notifier_mutex locked
-    void pin_version(uint_fast64_t version, uint_fast32_t index);
+    void pin_version(VersionID version);
 
     void run_async_notifiers();
     void open_helper_shared_group();

--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -25,6 +25,7 @@
 
 #include <realm/group_shared.hpp>
 #include <realm/lang_bind_helper.hpp>
+
 #include <algorithm>
 
 using namespace realm;
@@ -792,7 +793,7 @@ public:
 namespace realm {
 namespace _impl {
 namespace transaction {
-void advance(SharedGroup& sg, BindingContext* context, SchemaMode schema_mode, SharedGroup::VersionID version)
+void advance(SharedGroup& sg, BindingContext* context, SchemaMode schema_mode, VersionID version)
 {
     TransactLogObserver(context, sg, [&](auto&&... args) {
         LangBindHelper::advance_read(sg, std::move(args)..., version);
@@ -829,7 +830,7 @@ void cancel(SharedGroup& sg, BindingContext* context)
 
 void advance(SharedGroup& sg,
              TransactionChangeInfo& info,
-             SharedGroup::VersionID version)
+             VersionID version)
 {
     if (info.table_modifications_needed.empty() && info.lists.empty()) {
         LangBindHelper::advance_read(sg, version);

--- a/src/impl/transact_log_handler.hpp
+++ b/src/impl/transact_log_handler.hpp
@@ -19,10 +19,12 @@
 #ifndef REALM_TRANSACT_LOG_HANDLER_HPP
 #define REALM_TRANSACT_LOG_HANDLER_HPP
 
-#include <realm/group_shared.hpp>
+#include <cstdint>
+#include <realm/version_id.hpp>
 
 namespace realm {
 class BindingContext;
+class SharedGroup;
 enum class SchemaMode : uint8_t;
 
 namespace _impl {
@@ -33,7 +35,7 @@ namespace transaction {
 // Must not be called from within a write transaction.
 void advance(SharedGroup& sg, BindingContext* binding_context,
              SchemaMode schema_mode,
-             SharedGroup::VersionID version=SharedGroup::VersionID{});
+             VersionID version=VersionID{});
 
 // Begin a write transaction
 // If the read transaction version is not up to date, will first advance to the
@@ -51,7 +53,7 @@ void cancel(SharedGroup& sg, BindingContext* binding_context);
 // Advance the read transaction version, with change information gathered in info
 void advance(SharedGroup& sg,
              TransactionChangeInfo& info,
-             SharedGroup::VersionID version=SharedGroup::VersionID{});
+             VersionID version=VersionID{});
 } // namespace transaction
 } // namespace _impl
 } // namespace realm

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -567,16 +567,15 @@ util::Optional<int> Realm::file_format_upgraded_from_version() const
 
 Realm::HandoverPackage::HandoverPackage(HandoverPackage&&) = default;
 Realm::HandoverPackage& Realm::HandoverPackage::operator=(HandoverPackage&&) = default;
-Realm::HandoverPackage::VersionID::VersionID() : VersionID(SharedGroup::VersionID()) { }
 
 // Precondition: `m_version` is not greater than `new_version`
 // Postcondition: `m_version` is equal to `new_version`
 void Realm::HandoverPackage::advance_to_version(VersionID new_version)
 {
-    if (SharedGroup::VersionID(new_version) == SharedGroup::VersionID(m_version_id)) {
+    if (new_version == m_version_id) {
         return;
     }
-    REALM_ASSERT_DEBUG((SharedGroup::VersionID(new_version) > SharedGroup::VersionID(m_version_id)));
+    REALM_ASSERT_DEBUG(new_version > m_version_id);
 
     // Open `Realm` at handover version
     _impl::RealmCoordinator& coordinator = get_coordinator();
@@ -650,7 +649,7 @@ std::vector<AnyThreadConfined> Realm::accept_handover(Realm::HandoverPackage han
     else {
         auto current_version = m_shared_group->get_version_of_current_transaction();
 
-        if (SharedGroup::VersionID(handover.m_version_id) <= current_version) {
+        if (handover.m_version_id <= current_version) {
             // The handover is behind, so advance it to our version
             handover.advance_to_version(current_version);
         } else {

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -22,6 +22,7 @@
 #include "schema.hpp"
 
 #include <realm/util/optional.hpp>
+#include <realm/version_id.hpp>
 
 #include <memory>
 #include <thread>
@@ -227,24 +228,6 @@ public:
     private:
         friend HandoverPackage Realm::package_for_handover(std::vector<AnyThreadConfined> objects_to_hand_over);
         friend std::vector<AnyThreadConfined> Realm::accept_handover(Realm::HandoverPackage handover);
-
-        struct VersionID { // SharedGroup::VersionID without including header
-            uint_fast64_t version;
-            uint_fast32_t index;
-
-            VersionID();
-
-            template<typename T>
-            VersionID(T value) : version(value.version), index(value.index) { }
-
-            template<typename T>
-            operator T() const {
-                T version_id; // Don't use initializer list for better type safety
-                version_id.version = version;
-                version_id.index = index;
-                return version_id;
-            }
-        };
 
         VersionID m_version_id;
         std::vector<_impl::AnyHandover> m_objects;

--- a/tests/handover.cpp
+++ b/tests/handover.cpp
@@ -87,7 +87,7 @@ TEST_CASE("handover") {
         auto history = make_in_realm_history(config.path);
         SharedGroup shared_group(*history, config.options());
 
-        auto get_current_version = [&]() -> SharedGroup::VersionID {
+        auto get_current_version = [&]() -> VersionID {
             shared_group.begin_read();
             auto version = shared_group.get_version_of_current_transaction();
             shared_group.end_read();


### PR DESCRIPTION
Eliminates a bit of cruft done to avoid dragging in group_shared.hpp.