### PR TITLE
Set the schema properly when no changes are needed in ResetFile mode

### DIFF
--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -211,12 +211,18 @@ bool Realm::read_schema_from_group_if_needed()
     return true;
 }
 
-void Realm::reset_file_if_needed(Schema const& schema, uint64_t version, std::vector<SchemaChange>& required_changes)
+bool Realm::reset_file_if_needed(Schema& schema, uint64_t version, std::vector<SchemaChange>& required_changes)
 {
     if (m_schema_version == ObjectStore::NotVersioned)
-        return;
-    if (m_schema_version == version && !ObjectStore::needs_migration(required_changes))
-        return;
+        return false;
+    if (m_schema_version == version) {
+        if (required_changes.empty()) {
+            set_schema(std::move(schema), version);
+            return true;
+        }
+        if (!ObjectStore::needs_migration(required_changes))
+            return false;
+    }
 
     // FIXME: this does not work if multiple processes try to open the file at
     // the same time, or even multiple threads if there is not any external
@@ -231,6 +237,7 @@ void Realm::reset_file_if_needed(Schema const& schema, uint64_t version, std::ve
     m_schema = ObjectStore::schema_from_group(read_group());
     m_schema_version = ObjectStore::get_schema_version(read_group());
     required_changes = m_schema.compare(schema);
+    return false;
 }
 
 void Realm::update_schema(Schema schema, uint64_t version, MigrationFunction migration_function)
@@ -262,8 +269,7 @@ void Realm::update_schema(Schema schema, uint64_t version, MigrationFunction mig
                 return true;
 
             case SchemaMode::ResetFile:
-                reset_file_if_needed(schema, version, required_changes);
-                return required_changes.empty();
+                return reset_file_if_needed(schema, version, required_changes);
 
             case SchemaMode::Additive:
                 if (required_changes.empty()) {

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -298,7 +298,7 @@ private:
     int upgrade_initial_version = 0, upgrade_final_version = 0;
 
     void set_schema(Schema schema, uint64_t version);
-    void reset_file_if_needed(Schema const& schema, uint64_t version, std::vector<SchemaChange>& changes_required);
+    bool reset_file_if_needed(Schema& schema, uint64_t version, std::vector<SchemaChange>& changes_required);
 
     // Ensure that m_schema and m_schema_version match that of the current
     // version of the file, and return true if it changed

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -897,6 +897,9 @@ TEST_CASE("migration: ResetFile") {
         {"object", {
             {"value", PropertyType::Int, "", "", false, false, false},
         }},
+        {"object 2", {
+            {"value", PropertyType::Int, "", "", false, false, false},
+        }},
     };
 
     {
@@ -920,10 +923,18 @@ TEST_CASE("migration: ResetFile") {
     }
 
     SECTION("file is not reset when adding a new table") {
-        realm->update_schema(add_table(schema, {"object 2", {
+        realm->update_schema(add_table(schema, {"object 3", {
             {"value", PropertyType::Int, "", "", false, false, false},
         }}));
         REQUIRE(ObjectStore::table_for_object_type(realm->read_group(), "object")->size() == 1);
+        REQUIRE(realm->schema().size() == 3);
+    }
+
+    SECTION("file is not reset when removing a table") {
+        realm->update_schema(remove_table(schema, "object 2"));
+        REQUIRE(ObjectStore::table_for_object_type(realm->read_group(), "object")->size() == 1);
+        REQUIRE(ObjectStore::table_for_object_type(realm->read_group(), "object 2"));
+        REQUIRE(realm->schema().size() == 1);
     }
 
     SECTION("file is not reset when adding an index") {


### PR DESCRIPTION
The Realm's schema needs to be set to the passed-in schema even if no changes are needed as the schema from disk may include additional object types that are not in the requested schema. This was already done properly for all schema modes except for ResetFile.

See https://github.com/realm/realm-cocoa/issues/4190.