### PR TITLE
Fix a race condition when delivering collection notifiers

### DIFF
--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -123,7 +123,7 @@ private:
     void open_helper_shared_group();
     void advance_helper_shared_group_to_latest();
     void clean_up_dead_notifiers();
-    std::vector<std::shared_ptr<_impl::CollectionNotifier>> notifiers_to_deliver(Realm&);
+    std::vector<std::shared_ptr<_impl::CollectionNotifier>> notifiers_to_deliver(Realm&, VersionID& version);
 };
 
 } // namespace _impl


### PR DESCRIPTION
The current version of the notifier was being checked rather than the version of the notifier's prepared handover object, which could result in a BadVersion exception if the notifier happens to run in between when the handover object is packaged for delivery and when the version is checked.

Fixes the repo case from https://github.com/realm/realm-cocoa/issues/3412#issuecomment-253185742.