### PR TITLE
Update to core 2.1.3/sync beta 3.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ include(CompilerFlags)
 include(Sanitizers)
 
 include(RealmCore)
-set(REALM_CORE_VERSION "2.1.0" CACHE STRING "")
+set(REALM_CORE_VERSION "2.1.3" CACHE STRING "")
 use_realm_core(${REALM_CORE_VERSION})
 
 if(REALM_SYNC_PREFIX)

--- a/src/sync_session.cpp
+++ b/src/sync_session.cpp
@@ -292,6 +292,7 @@ void SyncSession::create_sync_session()
 
         switch (strong_code) {
             // Client errors; all ignored (for now)
+            case Error::invalid_error:
             case Error::connection_closed:
             case Error::other_error:
             case Error::unknown_message:
@@ -304,6 +305,7 @@ void SyncSession::create_sync_session()
             case Error::bad_message_order:
                 return;
             // Session errors
+            case Error::disabled_session:
             case Error::session_closed:
             case Error::other_session_error:
                 // The binding doesn't need to be aware of these because they are strictly informational, and do not


### PR DESCRIPTION
Sync beta 3.1 adds some new error types that need to be handled.