### PR TITLE
Add support for suppressing specific local notifications from a write

### DIFF
--- a/src/binding_context.hpp
+++ b/src/binding_context.hpp
@@ -54,7 +54,7 @@ namespace realm {
 //     }
 //
 //     // Override the did_change method to call each registered notification
-//     void did_change(std::vector<ObserverState> const&, std::vector<void*> const&) override
+//     void did_change(std::vector<ObserverState> const&, std::vector<void*> const&, bool) override
 //     {
 //         // Loop oddly so that unregistering a notification from within the
 //         // registered function works
@@ -102,7 +102,8 @@ public:
     // requested or if the Realm is not actually in a read transaction, although
     // both vectors will be empty in that case.
     virtual void did_change(std::vector<ObserverState> const& observers,
-                            std::vector<void*> const& invalidated);
+                            std::vector<void*> const& invalidated,
+                            bool version_changed=true);
 
     // Change information for a single field of a row
     struct ColumnInfo {
@@ -153,7 +154,7 @@ public:
 };
 
 inline void BindingContext::will_change(std::vector<ObserverState> const&, std::vector<void*> const&) { }
-inline void BindingContext::did_change(std::vector<ObserverState> const&, std::vector<void*> const&) { }
+inline void BindingContext::did_change(std::vector<ObserverState> const&, std::vector<void*> const&, bool) { }
 } // namespace realm
 
 #endif /* BINDING_CONTEXT_HPP */

--- a/src/collection_notifications.cpp
+++ b/src/collection_notifications.cpp
@@ -54,3 +54,8 @@ NotificationToken& NotificationToken::operator=(realm::NotificationToken&& rgt)
     }
     return *this;
 }
+
+void NotificationToken::suppress_next()
+{
+    m_notifier.load()->suppress_next_notification(m_token);
+}

--- a/src/collection_notifications.hpp
+++ b/src/collection_notifications.hpp
@@ -44,6 +44,8 @@ struct NotificationToken {
     NotificationToken(NotificationToken const&) = delete;
     NotificationToken& operator=(NotificationToken const&) = delete;
 
+    void suppress_next();
+
 private:
     util::AtomicSharedPtr<_impl::CollectionNotifier> m_notifier;
     size_t m_token;

--- a/src/impl/apple/keychain_helper.hpp
+++ b/src/impl/apple/keychain_helper.hpp
@@ -19,10 +19,11 @@
 #ifndef REALM_OS_KEYCHAIN_HELPER_HPP
 #define REALM_OS_KEYCHAIN_HELPER_HPP
 
+#include <cstdint>
+#include <stdexcept>
 #include <vector>
 
 namespace realm {
-
 namespace keychain {
 
 std::vector<char> metadata_realm_encryption_key();
@@ -34,6 +35,5 @@ public:
 
 }
 }
-
 
 #endif // REALM_OS_KEYCHAIN_HELPER_HPP

--- a/src/impl/collection_notifier.cpp
+++ b/src/impl/collection_notifier.cpp
@@ -368,9 +368,8 @@ NotifierPackage::NotifierPackage(Realm& realm, std::exception_ptr error,
 
 void NotifierPackage::package_and_wait(SharedGroup& sg)
 {
-    if (!m_lock || m_error)
+    if (!m_lock || m_error || !*this)
         return;
-    REALM_ASSERT(*this);
 
     using sgf = SharedGroupFriend;
     auto target_version = sgf::get_version_of_latest_snapshot(sg);

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -194,7 +194,7 @@ public:
 
     bool have_callbacks() const noexcept { return m_have_callbacks; }
 protected:
-    void add_changes(CollectionChangeBuilder change) { m_accumulated_changes.merge(std::move(change)); }
+    void add_changes(CollectionChangeBuilder change);
     void set_table(Table const& table);
     std::unique_lock<std::mutex> lock_target();
 
@@ -215,13 +215,12 @@ private:
 
     bool m_has_run = false;
     bool m_error = false;
-    CollectionChangeBuilder m_accumulated_changes;
-    CollectionChangeSet m_changes_to_deliver;
-
     std::vector<DeepChangeChecker::RelatedTable> m_related_tables;
 
     struct Callback {
         CollectionChangeCallback fn;
+        CollectionChangeBuilder accumulated_changes;
+        CollectionChangeSet changes_to_deliver;
         size_t token;
         bool initial_delivered;
     };
@@ -242,6 +241,9 @@ private:
     size_t m_callback_index = -1;
 
     CollectionChangeCallback next_callback(bool has_changes, bool pre);
+
+    template<typename Fn>
+    void for_each_callback(Fn&& fn);
 };
 
 // A smart pointer to a CollectionNotifier that unregisters the notifier when

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -130,6 +130,8 @@ public:
     // called from any thread.
     void remove_callback(size_t token);
 
+    void suppress_next_notification(size_t token);
+
     // ------------------------------------------------------------------------
     // API for RealmCoordinator to manage running things and calling callbacks
 
@@ -223,6 +225,7 @@ private:
         CollectionChangeSet changes_to_deliver;
         size_t token;
         bool initial_delivered;
+        bool skip_next;
     };
 
     // Currently registered callbacks and a mutex which must always be held
@@ -240,10 +243,10 @@ private:
     // remove_callback() updates this when needed
     size_t m_callback_index = -1;
 
-    CollectionChangeCallback next_callback(bool has_changes, bool pre);
-
     template<typename Fn>
     void for_each_callback(Fn&& fn);
+
+    std::vector<Callback>::iterator find_callback(size_t token);
 };
 
 // A smart pointer to a CollectionNotifier that unregisters the notifier when

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -308,11 +308,11 @@ public:
     // No-op if called multiple times
     void package_and_wait(util::Optional<VersionID::version_type> target_version);
 
-    // Sent the before-change notifications
+    // Send the before-change notifications
     void before_advance();
     // Deliver the payload associated with the contained notifiers and/or the error
     void deliver(SharedGroup& sg);
-    // Sent the after-change notifications
+    // Send the after-change notifications
     void after_advance();
 
 private:

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -36,6 +36,8 @@ class SharedGroup;
 class Table;
 
 namespace _impl {
+class RealmCoordinator;
+
 struct ListChangeInfo {
     size_t table_ndx;
     size_t row_ndx;
@@ -293,7 +295,7 @@ public:
     NotifierPackage() = default;
     NotifierPackage(std::exception_ptr error,
                     std::vector<std::shared_ptr<CollectionNotifier>> notifiers,
-                    std::condition_variable& cv, std::unique_lock<std::mutex>& lock);
+                    RealmCoordinator* coordinator);
 
     explicit operator bool() { return !m_notifiers.empty(); }
 
@@ -317,8 +319,7 @@ private:
     util::Optional<VersionID> m_version;
     std::vector<std::shared_ptr<CollectionNotifier>> m_notifiers;
 
-    std::condition_variable* m_cv = nullptr;
-    std::unique_lock<std::mutex>* m_lock = nullptr; // RealmCoordinator::m_notifier_mutex
+    RealmCoordinator* m_coordinator = nullptr;
     std::exception_ptr m_error;
 };
 

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -624,7 +624,7 @@ std::unique_lock<std::mutex> RealmCoordinator::wait_for_notifiers(Realm& realm, 
         if (m_async_error)
             return true;
         return std::all_of(begin(m_notifiers), end(m_notifiers), [&](auto const& n) {
-            return n->version().version >= min_version || !n->is_for_realm(realm);
+            return n->version().version >= min_version || !n->have_callbacks() || !n->is_for_realm(realm);
         });
     });
     return lock;

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -650,7 +650,7 @@ void RealmCoordinator::open_helper_shared_group()
 void RealmCoordinator::advance_to_ready(Realm& realm)
 {
     std::unique_lock<std::mutex> lock(m_notifier_mutex);
-    _impl::NotifierPackage notifiers(m_async_error, notifiers_for_realm(realm), m_notifier_cv, lock);
+    _impl::NotifierPackage notifiers(m_async_error, notifiers_for_realm(realm), this);
     lock.unlock();
     notifiers.package_and_wait(util::none);
 
@@ -687,7 +687,7 @@ bool RealmCoordinator::advance_to_latest(Realm& realm)
 
     auto& sg = Realm::Internal::get_shared_group(realm);
     std::unique_lock<std::mutex> lock(m_notifier_mutex);
-    _impl::NotifierPackage notifiers(m_async_error, notifiers_for_realm(realm), m_notifier_cv, lock);
+    _impl::NotifierPackage notifiers(m_async_error, notifiers_for_realm(realm), this);
     lock.unlock();
     notifiers.package_and_wait(sgf::get_version_of_latest_snapshot(sg));
 
@@ -701,7 +701,7 @@ void RealmCoordinator::promote_to_write(Realm& realm)
     REALM_ASSERT(!realm.is_in_transaction());
 
     std::unique_lock<std::mutex> lock(m_notifier_mutex);
-    _impl::NotifierPackage notifiers(m_async_error, notifiers_for_realm(realm), m_notifier_cv, lock);
+    _impl::NotifierPackage notifiers(m_async_error, notifiers_for_realm(realm), this);
     lock.unlock();
 
     auto& sg = Realm::Internal::get_shared_group(realm);

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -277,6 +277,8 @@ void RealmCoordinator::clear_all_caches()
 void RealmCoordinator::wake_up_notifier_worker()
 {
     if (m_notifier) {
+        // FIXME: this wakes up the notification workers for all processes and
+        // not just us. This might be worth optimizing in the future.
         m_notifier->notify_others();
     }
 }

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -21,6 +21,7 @@
 
 #include "shared_realm.hpp"
 
+#include <condition_variable>
 #include <mutex>
 
 namespace realm {

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -91,11 +91,20 @@ public:
     // Advance the Realm to the most recent transaction version which all async
     // work is complete for
     void advance_to_ready(Realm& realm);
+
+    // Advance the Realm to the most recent transaction version, blocking if
+    // async notifiers are not yet ready for that version
+    // returns whether it actually changed the version
+    bool advance_to_latest(Realm& realm);
+
+    // Deliver any notifications which are ready for the Realm's version
     void process_available_async(Realm& realm);
 
-    void notify_others();
-
     void set_transaction_callback(std::function<void(VersionID, VersionID)>);
+
+    // Deliver notifications for the Realm, blocking if some aren't ready yet
+    // The calling Realm must be in a write transaction
+    void promote_to_write(Realm& realm);
 
 private:
     Realm::Config m_config;
@@ -106,6 +115,7 @@ private:
     std::vector<WeakRealmNotifier> m_weak_realm_notifiers;
 
     std::mutex m_notifier_mutex;
+    std::condition_variable m_notifier_cv;
     std::vector<std::shared_ptr<_impl::CollectionNotifier>> m_new_notifiers;
     std::vector<std::shared_ptr<_impl::CollectionNotifier>> m_notifiers;
 
@@ -136,7 +146,10 @@ private:
     void open_helper_shared_group();
     void advance_helper_shared_group_to_latest();
     void clean_up_dead_notifiers();
-    std::vector<std::shared_ptr<_impl::CollectionNotifier>> notifiers_to_deliver(Realm&, VersionID& version);
+
+    // wait for all notifiers targeting the given realm to be ready for the
+    // given version or any later version
+    std::unique_lock<std::mutex> wait_for_notifiers(Realm& realm, uint64_t min_version);
 };
 
 } // namespace _impl

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -63,6 +63,8 @@ public:
     // Asynchronously call notify() on every Realm instance for this coordinator's
     // path, including those in other processes
     void send_commit_notifications(Realm&);
+    
+    void wake_up_notifier_worker();
 
     // Clear the weak Realm cache for all paths
     // Should only be called in test code, as continuing to use the previously
@@ -106,6 +108,10 @@ public:
     // The calling Realm must be in a write transaction
     void promote_to_write(Realm& realm);
 
+    // Commit a Realm's current write transaction and send notifications to all
+    // other Realm instances for that path, including in other processes
+    void commit_write(Realm& realm);
+
 private:
     Realm::Config m_config;
     Schema m_schema;
@@ -118,6 +124,7 @@ private:
     std::condition_variable m_notifier_cv;
     std::vector<std::shared_ptr<_impl::CollectionNotifier>> m_new_notifiers;
     std::vector<std::shared_ptr<_impl::CollectionNotifier>> m_notifiers;
+    VersionID m_notifier_skip_version = {0, 0};
 
     // SharedGroup used for actually running async notifiers
     // Will have a read transaction iff m_notifiers is non-empty

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -150,6 +150,7 @@ private:
     // wait for all notifiers targeting the given realm to be ready for the
     // given version or any later version
     std::unique_lock<std::mutex> wait_for_notifiers(Realm& realm, uint64_t min_version);
+    std::vector<std::shared_ptr<_impl::CollectionNotifier>> notifiers_for_realm(Realm&);
 };
 
 } // namespace _impl

--- a/src/impl/results_notifier.hpp
+++ b/src/impl/results_notifier.hpp
@@ -62,10 +62,6 @@ private:
     CollectionChangeBuilder m_changes;
     TransactionChangeInfo* m_info = nullptr;
 
-    // Flag for whether or not the query has been run at all, as goofy timing
-    // can lead to deliver() being called before that
-    bool m_initial_run_complete = false;
-
     bool need_to_run();
     void calculate_changes();
     void deliver(SharedGroup&) override;

--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -221,6 +221,9 @@ class TransactLogObserver : public TransactLogValidationMixin, public MarkDirtyM
     // Change information for the currently selected LinkList, if any
     ColumnInfo* m_active_linklist = nullptr;
 
+    _impl::NotifierPackage& m_notifiers;
+    SharedGroup& m_sg;
+
     // Get the change info for the given column, creating it if needed
     static ColumnInfo& get_change(ObserverState& state, size_t i)
     {
@@ -250,14 +253,19 @@ class TransactLogObserver : public TransactLogValidationMixin, public MarkDirtyM
 
 public:
     template<typename Func>
-    TransactLogObserver(BindingContext* context, SharedGroup& sg, Func&& func, util::Optional<SchemaMode> schema_mode)
+    TransactLogObserver(BindingContext* context, SharedGroup& sg, Func&& func,
+                        util::Optional<SchemaMode> schema_mode,
+                        _impl::NotifierPackage& notifiers)
     : m_context(context)
+    , m_notifiers(notifiers)
+    , m_sg(sg)
     {
         auto old_version = sg.get_version_of_current_transaction();
         if (context) {
             m_observers = context->get_observed_rows();
         }
-        if (m_observers.empty()) {
+        if (m_observers.empty() && (!m_notifiers || m_notifiers.version() != VersionID())) {
+            m_notifiers.before_advance();
             if (schema_mode) {
                 func(TransactLogValidator(*schema_mode));
             }
@@ -267,12 +275,18 @@ public:
             if (context && old_version != sg.get_version_of_current_transaction()) {
                 context->did_change({}, {});
             }
+            m_notifiers.deliver(sg);
+            m_notifiers.after_advance();
             return;
         }
 
         std::sort(begin(m_observers), end(m_observers));
         func(*this);
-        context->did_change(m_observers, invalidated);
+        if (context)
+            context->did_change(m_observers, invalidated);
+        m_notifiers.package_and_wait(sg); // is a no-op if parse_complete() was called
+        m_notifiers.deliver(sg); // only will ever deliver errors
+        m_notifiers.after_advance();
     }
 
     // Mark the given row/col as needing notifications sent
@@ -288,7 +302,10 @@ public:
     // is advanced
     void parse_complete()
     {
-        m_context->will_change(m_observers, invalidated);
+        if (m_context)
+            m_context->will_change(m_observers, invalidated);
+        m_notifiers.package_and_wait(m_sg);
+        m_notifiers.before_advance();
     }
 
     bool insert_group_level_table(size_t table_ndx, size_t prior_size, StringData name)
@@ -792,12 +809,21 @@ public:
 
 namespace realm {
 namespace _impl {
+
 namespace transaction {
 void advance(SharedGroup& sg, BindingContext* context, SchemaMode schema_mode, VersionID version)
 {
+    _impl::NotifierPackage notifiers;
     TransactLogObserver(context, sg, [&](auto&&... args) {
         LangBindHelper::advance_read(sg, std::move(args)..., version);
-    }, schema_mode);
+    }, schema_mode, notifiers);
+}
+
+void advance(SharedGroup& sg, BindingContext* context, SchemaMode schema_mode, NotifierPackage& notifiers)
+{
+    TransactLogObserver(context, sg, [&](auto&&... args) {
+        LangBindHelper::advance_read(sg, std::move(args)..., notifiers.version());
+    }, schema_mode, notifiers);
 }
 
 void begin_without_validation(SharedGroup& sg)
@@ -805,11 +831,12 @@ void begin_without_validation(SharedGroup& sg)
     LangBindHelper::promote_to_write(sg);
 }
 
-void begin(SharedGroup& sg, BindingContext* context, SchemaMode schema_mode)
+void begin(SharedGroup& sg, BindingContext* context, SchemaMode schema_mode,
+           NotifierPackage& notifiers)
 {
     TransactLogObserver(context, sg, [&](auto&&... args) {
         LangBindHelper::promote_to_write(sg, std::move(args)...);
-    }, schema_mode);
+    }, schema_mode, notifiers);
 }
 
 void commit(SharedGroup& sg, BindingContext* context)
@@ -823,9 +850,10 @@ void commit(SharedGroup& sg, BindingContext* context)
 
 void cancel(SharedGroup& sg, BindingContext* context)
 {
+    _impl::NotifierPackage notifiers;
     TransactLogObserver(context, sg, [&](auto&&... args) {
         LangBindHelper::rollback_and_continue_as_read(sg, std::move(args)...);
-    }, util::none);
+    }, util::none, notifiers);
 }
 
 void advance(SharedGroup& sg,

--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -287,7 +287,7 @@ public:
         std::sort(begin(m_observers), end(m_observers));
         func(*this);
         if (context)
-            context->did_change(m_observers, invalidated);
+            context->did_change(m_observers, invalidated, old_version != sg.get_version_of_current_transaction());
         m_notifiers.package_and_wait(sg.get_version_of_current_transaction().version); // is a no-op if parse_complete() was called
         m_notifiers.deliver(sg); // only will ever deliver errors
         m_notifiers.after_advance();

--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -844,13 +844,9 @@ void begin(SharedGroup& sg, BindingContext* context, SchemaMode schema_mode,
     }, schema_mode, notifiers);
 }
 
-void commit(SharedGroup& sg, BindingContext* context)
+void commit(SharedGroup& sg)
 {
     LangBindHelper::commit_and_continue_as_read(sg);
-
-    if (context) {
-        context->did_change({}, {});
-    }
 }
 
 void cancel(SharedGroup& sg, BindingContext* context)

--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -264,7 +264,11 @@ public:
         if (context) {
             m_observers = context->get_observed_rows();
         }
-        if (m_observers.empty() && (!m_notifiers || m_notifiers.version() != VersionID())) {
+
+        // If we have collection notifiers we have to use the transaction log
+        // observer to send will_change notifications once we know what the
+        // target version is, despite not otherwise needing to observe anything
+        if (m_observers.empty() && (!m_notifiers || m_notifiers.version())) {
             m_notifiers.before_advance();
             if (schema_mode) {
                 func(TransactLogValidator(*schema_mode));
@@ -284,7 +288,7 @@ public:
         func(*this);
         if (context)
             context->did_change(m_observers, invalidated);
-        m_notifiers.package_and_wait(sg); // is a no-op if parse_complete() was called
+        m_notifiers.package_and_wait(sg.get_version_of_current_transaction().version); // is a no-op if parse_complete() was called
         m_notifiers.deliver(sg); // only will ever deliver errors
         m_notifiers.after_advance();
     }
@@ -304,7 +308,8 @@ public:
     {
         if (m_context)
             m_context->will_change(m_observers, invalidated);
-        m_notifiers.package_and_wait(m_sg);
+        using sgf = _impl::SharedGroupFriend;
+        m_notifiers.package_and_wait(sgf::get_version_of_latest_snapshot(m_sg));
         m_notifiers.before_advance();
     }
 
@@ -822,7 +827,7 @@ void advance(SharedGroup& sg, BindingContext* context, SchemaMode schema_mode, V
 void advance(SharedGroup& sg, BindingContext* context, SchemaMode schema_mode, NotifierPackage& notifiers)
 {
     TransactLogObserver(context, sg, [&](auto&&... args) {
-        LangBindHelper::advance_read(sg, std::move(args)..., notifiers.version());
+        LangBindHelper::advance_read(sg, std::move(args)..., notifiers.version().value_or(VersionID{}));
     }, schema_mode, notifiers);
 }
 

--- a/src/impl/transact_log_handler.hpp
+++ b/src/impl/transact_log_handler.hpp
@@ -28,19 +28,22 @@ class SharedGroup;
 enum class SchemaMode : uint8_t;
 
 namespace _impl {
+class NotifierPackage;
 struct TransactionChangeInfo;
 
 namespace transaction {
 // Advance the read transaction version, with change notifications sent to delegate
 // Must not be called from within a write transaction.
 void advance(SharedGroup& sg, BindingContext* binding_context,
-             SchemaMode schema_mode,
-             VersionID version=VersionID{});
+             SchemaMode schema_mode, NotifierPackage&);
+void advance(SharedGroup& sg, BindingContext* binding_context,
+             SchemaMode schema_mode, VersionID);
 
 // Begin a write transaction
 // If the read transaction version is not up to date, will first advance to the
 // most recent read transaction and sent notifications to delegate
-void begin(SharedGroup& sg, BindingContext* binding_context, SchemaMode schema_mode);
+void begin(SharedGroup& sg, BindingContext* binding_context, SchemaMode schema_mode,
+           NotifierPackage&);
 void begin_without_validation(SharedGroup& sg);
 
 // Commit a write transaction

--- a/src/impl/transact_log_handler.hpp
+++ b/src/impl/transact_log_handler.hpp
@@ -47,7 +47,7 @@ void begin(SharedGroup& sg, BindingContext* binding_context, SchemaMode schema_m
 void begin_without_validation(SharedGroup& sg);
 
 // Commit a write transaction
-void commit(SharedGroup& sg, BindingContext* binding_context);
+void commit(SharedGroup& sg);
 
 // Cancel a write transaction and roll back all changes, with change notifications
 // for reverting to the old values sent to delegate

--- a/src/results.cpp
+++ b/src/results.cpp
@@ -524,6 +524,9 @@ Results Results::snapshot() &&
 
 void Results::prepare_async()
 {
+    if (m_notifier) {
+        return;
+    }
     if (m_realm->config().read_only()) {
         throw InvalidTransactionException("Cannot create asynchronous query for read-only Realms");
     }
@@ -534,11 +537,9 @@ void Results::prepare_async()
         throw std::logic_error("Cannot create asynchronous query for snapshotted Results.");
     }
 
-    if (!m_notifier) {
-        m_wants_background_updates = true;
-        m_notifier = std::make_shared<_impl::ResultsNotifier>(*this);
-        _impl::RealmCoordinator::register_notifier(m_notifier);
-    }
+    m_wants_background_updates = true;
+    m_notifier = std::make_shared<_impl::ResultsNotifier>(*this);
+    _impl::RealmCoordinator::register_notifier(m_notifier);
 }
 
 NotificationToken Results::async(std::function<void (std::exception_ptr)> target)

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -476,8 +476,7 @@ void Realm::commit_transaction()
         throw InvalidTransactionException("Can't commit a non-existing write transaction");
     }
 
-    transaction::commit(*m_shared_group, m_binding_context.get());
-    m_coordinator->send_commit_notifications(*this);
+    m_coordinator->commit_write(*this);
 }
 
 void Realm::cancel_transaction()

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -545,7 +545,7 @@ void Realm::write_copy(StringData path, BinaryData key)
 
 void Realm::notify()
 {
-    if (is_closed()) {
+    if (is_closed() || is_in_transaction()) {
         return;
     }
 

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -448,10 +448,23 @@ void Realm::begin_transaction()
         throw InvalidTransactionException("The Realm is already in a write transaction");
     }
 
+    // If we're already in the middle of sending notifications, just begin the
+    // write transaction without sending more notifications. If this actually
+    // advances the read version this could leave the user in an inconsistent
+    // state, but that's unavoidable.
+    if (m_is_sending_notifications) {
+        _impl::NotifierPackage notifiers;
+        transaction::begin(*m_shared_group, m_binding_context.get(), m_config.schema_mode, notifiers);
+        return;
+    }
+
     // make sure we have a read transaction
     read_group();
 
-    transaction::begin(*m_shared_group, m_binding_context.get(), m_config.schema_mode);
+    m_is_sending_notifications = true;
+    auto cleanup = util::make_scope_exit([this]() noexcept { m_is_sending_notifications = false; });
+
+    m_coordinator->promote_to_write(*this);
 }
 
 void Realm::commit_transaction()
@@ -538,6 +551,9 @@ void Realm::notify()
 
     verify_thread();
 
+    m_is_sending_notifications = true;
+    auto cleanup = util::make_scope_exit([this]() noexcept { m_is_sending_notifications = false; });
+
     if (m_shared_group->has_changed()) { // Throws
         if (m_binding_context) {
             m_binding_context->changes_available();
@@ -546,8 +562,11 @@ void Realm::notify()
             if (m_group) {
                 m_coordinator->advance_to_ready(*this);
             }
-            else if (m_binding_context) {
-                m_binding_context->did_change({}, {});
+            else  {
+                if (m_binding_context) {
+                    m_binding_context->did_change({}, {});
+                }
+                m_coordinator->process_available_async(*this);
             }
         }
     }
@@ -565,21 +584,22 @@ bool Realm::refresh()
     if (is_in_transaction()) {
         return false;
     }
-
-    // advance transaction if database has changed
-    if (!m_shared_group->has_changed()) { // Throws
+    // don't advance if we're already in the process of advancing as that just
+    // makes things needlessly complicated
+    if (m_is_sending_notifications) {
         return false;
     }
 
+    m_is_sending_notifications = true;
+    auto cleanup = util::make_scope_exit([this]() noexcept { m_is_sending_notifications = false; });
+
     if (m_group) {
-        transaction::advance(*m_shared_group, m_binding_context.get(), m_config.schema_mode);
-        m_coordinator->process_available_async(*this);
-    }
-    else {
-        // Create the read transaction
-        read_group();
+        return m_coordinator->advance_to_latest(*this);
     }
 
+    // No current read transaction, so just create a new one
+    read_group();
+    m_coordinator->process_available_async(*this);
     return true;
 }
 

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -314,6 +314,8 @@ private:
     // File format versions populated when a file format upgrade takes place during realm opening
     int upgrade_initial_version = 0, upgrade_final_version = 0;
 
+    bool m_is_sending_notifications = false;
+
     void set_schema(Schema schema, uint64_t version);
     bool reset_file_if_needed(Schema& schema, uint64_t version, std::vector<SchemaChange>& changes_required);
 

--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -91,7 +91,7 @@ void remove_nonempty_dir(const std::string& path)
     try {
         util::remove_dir(path);    
     }
-    catch (File::NotFound) {
+    catch (File::NotFound const&) {
     }
 }
 
@@ -250,9 +250,9 @@ bool SyncFileManager::remove_realm(const std::string& user_identity, const std::
     try {
         util::remove_nonempty_dir(management_path);
     }
-    catch (File::NotFound) {
+    catch (File::NotFound const&) {
     }
-    catch (File::AccessError) {
+    catch (File::AccessError const&) {
         success = false;
     }
     return success;
@@ -288,7 +288,7 @@ bool SyncFileManager::remove_metadata_realm() const
         util::remove_nonempty_dir(dir_path);
         return true;
     }
-    catch (File::AccessError) {
+    catch (File::AccessError const&) {
         return false;
     }
 }

--- a/src/sync/sync_config.hpp
+++ b/src/sync/sync_config.hpp
@@ -20,8 +20,8 @@
 #define REALM_OS_SYNC_CONFIG_HPP
 
 #include <functional>
-#include <string>
 #include <memory>
+#include <string>
 
 namespace realm {
 
@@ -31,41 +31,28 @@ class SyncSession;
 enum class SyncSessionStopPolicy;
 
 enum class SyncSessionError {
-    Debug,                  // An informational error, nothing to do. Only for debug purposes.
-    SessionFatal,           // The session is invalid and should be killed.
-    AccessDenied,           // Permissions error with the session.
-    UserFatal,              // The user associated with the session is invalid.
+    Debug,        // An informational error, nothing to do. Only for debug purposes.
+    SessionFatal, // The session is invalid and should be killed.
+    AccessDenied, // Permissions error with the session.
+    UserFatal,    // The user associated with the session is invalid.
 };
 
 struct SyncConfig;
-using SyncBindSessionHandler = void(const std::string&,                       // path on disk of the Realm file.
-                                    const SyncConfig&,                        // the sync configuration object.
-                                    std::shared_ptr<SyncSession>              // the session which should be bound.
+using SyncBindSessionHandler = void(const std::string&,          // path on disk of the Realm file.
+                                    const SyncConfig&,           // the sync configuration object.
+                                    std::shared_ptr<SyncSession> // the session which should be bound.
                                     );
 
 using SyncSessionErrorHandler = void(int error_code, std::string message, SyncSessionError);
 
 struct SyncConfig {
-    SyncConfig(std::shared_ptr<SyncUser> user,
-               std::string realm_url,
-               SyncSessionStopPolicy stop_policy,
-               std::function<SyncBindSessionHandler> bind_session_handler,
-               std::function<SyncSessionErrorHandler> error_handler={})
-    : user(std::move(user))
-    , realm_url(std::move(realm_url))
-    , bind_session_handler(std::move(bind_session_handler))
-    , error_handler(std::move(error_handler))
-    , stop_policy(stop_policy)
-    {
-    }
-
     std::shared_ptr<SyncUser> user;
     std::string realm_url;
+    SyncSessionStopPolicy stop_policy;
     std::function<SyncBindSessionHandler> bind_session_handler;
     std::function<SyncSessionErrorHandler> error_handler;
-    SyncSessionStopPolicy stop_policy;
 };
 
-} // realm
+} // namespace realm
 
 #endif // REALM_OS_SYNC_CONFIG_HPP

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -29,12 +29,6 @@
 using namespace realm;
 using namespace realm::_impl;
 
-struct SyncManager::UserCreationData {
-    std::string identity;
-    std::string user_token;
-    util::Optional<std::string> server_url;
-};
-
 SyncManager& SyncManager::shared()
 {
     // The singleton is heap-allocated in order to fix an issue when running unit tests where tests would crash after
@@ -47,6 +41,12 @@ void SyncManager::configure_file_system(const std::string& base_file_path,
                                         MetadataMode metadata_mode,
                                         util::Optional<std::vector<char>> custom_encryption_key)
 {
+    struct UserCreationData {
+        std::string identity;
+        std::string user_token;
+        util::Optional<std::string> server_url;
+    };
+
     std::vector<UserCreationData> users_to_add;
     {
         std::lock_guard<std::mutex> lock(m_file_system_mutex);

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -101,7 +101,7 @@ void SyncManager::configure_file_system(const std::string& base_file_path,
             try {
                 m_file_manager->remove_user_directory(user.identity());
                 dead_users.emplace_back(std::move(user));
-            } catch (util::File::AccessError) {
+            } catch (util::File::AccessError const&) {
                 continue;
             }
         }

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -104,8 +104,8 @@ public:
 
     // Reset part of the singleton state for testing purposes. DO NOT CALL OUTSIDE OF TESTING CODE.
     void reset_for_testing();
+
 private:
-    struct UserCreationData;
     void dropped_last_reference_to_session(SyncSession*);
 
     // Stop tracking the session for the given path if it is inactive.

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -57,6 +57,9 @@ public:
 
     std::string const& path() const { return m_realm_path; }
 
+    void wait_for_upload_completion();
+    void wait_for_download_completion();
+
     void wait_for_upload_completion(std::function<void()> callback);
     void wait_for_download_completion(std::function<void()> callback);
 

--- a/src/util/atomic_shared_ptr.hpp
+++ b/src/util/atomic_shared_ptr.hpp
@@ -76,6 +76,11 @@ public:
         return std::atomic_exchange(&m_ptr, std::move(ptr));
     }
 
+    std::shared_ptr<T> load() const noexcept
+    {
+        return std::atomic_load(&m_ptr);
+    }
+
 private:
     std::shared_ptr<T> m_ptr = nullptr;
 };
@@ -126,8 +131,14 @@ public:
         return ptr;
     }
 
+    std::shared_ptr<T> load() const noexcept
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        return m_ptr;
+    }
+
 private:
-    std::mutex m_mutex;
+    mutable std::mutex m_mutex;
     std::shared_ptr<T> m_ptr = nullptr;
 };
 

--- a/tests/handover.cpp
+++ b/tests/handover.cpp
@@ -26,6 +26,7 @@
 #include "property.hpp"
 #include "schema.hpp"
 #include "thread_confined.hpp"
+#include "impl/realm_coordinator.hpp"
 
 #include <realm/history.hpp>
 #include <realm/util/optional.hpp>
@@ -114,11 +115,13 @@ TEST_CASE("handover") {
     }
 
     SECTION("version mismatch") {
+        auto coordinator = _impl::RealmCoordinator::get_existing_coordinator(config.path);
         SECTION("import into older version") {
             r->begin_transaction();
             Object num = create_object(r, int_object);
             num.row().set_int(0, 7);
             r->commit_transaction();
+            coordinator->on_change();
 
             REQUIRE(num.row().get_int(0) == 7);
             auto h = std::async([config]() -> auto {

--- a/tests/handover.cpp
+++ b/tests/handover.cpp
@@ -26,7 +26,6 @@
 #include "property.hpp"
 #include "schema.hpp"
 #include "thread_confined.hpp"
-#include "impl/realm_coordinator.hpp"
 
 #include <realm/history.hpp>
 #include <realm/util/optional.hpp>
@@ -115,13 +114,11 @@ TEST_CASE("handover") {
     }
 
     SECTION("version mismatch") {
-        auto coordinator = _impl::RealmCoordinator::get_existing_coordinator(config.path);
         SECTION("import into older version") {
             r->begin_transaction();
             Object num = create_object(r, int_object);
             num.row().set_int(0, 7);
             r->commit_transaction();
-            coordinator->on_change();
 
             REQUIRE(num.row().get_int(0) == 7);
             auto h = std::async([config]() -> auto {

--- a/tests/list.cpp
+++ b/tests/list.cpp
@@ -346,8 +346,8 @@ TEST_CASE("list") {
 
         SECTION("tables-of-interest are tracked properly for multiple source versions") {
             // Add notifiers for different tables at different versions to verify
-            // that the tables of interest are updated correct as we process new
-            // notifiers
+            // that the tables of interest are updated correctly as we process
+            // new notifiers
             CollectionChangeSet changes1, changes2;
             auto token1 = lst.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
                 changes1 = std::move(c);

--- a/tests/notifications-fuzzer/command_file.cpp
+++ b/tests/notifications-fuzzer/command_file.cpp
@@ -178,10 +178,10 @@ static std::vector<T> read_int_list(std::istream& input_stream)
             ret.push_back(std::stoll(line));
             log("%lld\n", (long long)ret.back());
         }
-        catch (std::invalid_argument) {
+        catch (std::invalid_argument const&) {
             // not an error
         }
-        catch (std::out_of_range) {
+        catch (std::out_of_range const&) {
             // not an error
         }
     }

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -191,7 +191,7 @@ TEST_CASE("SharedRealm: notifications") {
         size_t* change_count;
         Context(size_t* out) : change_count(out) { }
 
-        void did_change(std::vector<ObserverState> const&, std::vector<void*> const&) override
+        void did_change(std::vector<ObserverState> const&, std::vector<void*> const&, bool) override
         {
             ++*change_count;
         }

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -343,6 +343,19 @@ TEST_CASE("notifications: async delivery") {
             thread.join();
         }
 
+        SECTION("refresh() does not block for results without callbacks") {
+            token = {};
+            // this would deadlock if it waits for the notifier to be ready
+            r->refresh();
+        }
+
+        SECTION("begin_transaction() does not block for results without callbacks") {
+            token = {};
+            // this would deadlock if it waits for the notifier to be ready
+            r->begin_transaction();
+            r->cancel_transaction();
+        }
+
         SECTION("begin_transaction() does not block for Results for different Realms") {
             // this would deadlock if beginning the write on the secondary Realm
             // waited for the primary Realm to be ready

--- a/tests/sync/session.cpp
+++ b/tests/sync/session.cpp
@@ -32,9 +32,6 @@
 using namespace realm;
 using namespace realm::util;
 
-// {"identity":"test", "access": ["download", "upload"]}
-static const std::string s_test_token = "eyJpZGVudGl0eSI6InRlc3QiLCAiYWNjZXNzIjogWyJkb3dubG9hZCIsICJ1cGxvYWQiXX0=";
-
 template <typename FetchAccessToken, typename ErrorHandler>
 std::shared_ptr<SyncSession> sync_session(SyncServer& server, std::shared_ptr<SyncUser> user, const std::string& path,
                                           FetchAccessToken&& fetch_access_token, ErrorHandler&& error_handler)

--- a/tests/sync/sync_test_utils.cpp
+++ b/tests/sync/sync_test_utils.cpp
@@ -26,7 +26,7 @@ bool create_dummy_realm(std::string path) {
     try {
         Realm::make_shared_realm(config);
         return true;
-    } catch(std::exception) {
+    } catch (std::exception&) {
         return false;
     }
 }

--- a/tests/sync/sync_test_utils.hpp
+++ b/tests/sync/sync_test_utils.hpp
@@ -33,20 +33,18 @@ bool results_contains_user(SyncUserMetadataResults& results, const std::string& 
 std::string tmp_dir();
 std::vector<char> make_test_encryption_key(const char start = 0);
 
-} // realm
+} // namespace realm
 
-#define REQUIRE_DIR_EXISTS(macro_path) \
-{ \
+#define REQUIRE_DIR_EXISTS(macro_path) do { \
     DIR *dir_listing = opendir((macro_path).c_str()); \
     CHECK(dir_listing); \
     if (dir_listing) closedir(dir_listing); \
-}
+} while (0)
 
-#define REQUIRE_DIR_DOES_NOT_EXIST(macro_path) \
-{ \
+#define REQUIRE_DIR_DOES_NOT_EXIST(macro_path) do { \
     DIR *dir_listing = opendir((macro_path).c_str()); \
     CHECK(dir_listing == NULL); \
     if (dir_listing) closedir(dir_listing); \
-}
+} while (0)
 
 #endif // REALM_SYNC_TEST_UTILS_HPP

--- a/tests/transaction_log_parsing.cpp
+++ b/tests/transaction_log_parsing.cpp
@@ -1258,7 +1258,8 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             fn();
             realm->commit_transaction();
 
-            _impl::transaction::advance(sg, &observer, SchemaMode::Automatic);
+            _impl::NotifierPackage notifiers;
+            _impl::transaction::advance(sg, &observer, SchemaMode::Automatic, notifiers);
             return observer;
         };
 
@@ -1282,7 +1283,6 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             REQUIRE_FALSE(changes.modified(0, 2));
         }
 
-#if REALM_MAJOR_VER >= 2
         SECTION("SetDefault does not mark as changed") {
             Row r = target->get(0);
             auto changes = observe({r}, [&] {
@@ -1292,7 +1292,6 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             REQUIRE_FALSE(changes.modified(0, 1));
             REQUIRE_FALSE(changes.modified(0, 2));
         }
-#endif
 
         SECTION("multiple properties on a single object are handled properly") {
             Row r = target->get(0);

--- a/tests/transaction_log_parsing.cpp
+++ b/tests/transaction_log_parsing.cpp
@@ -1240,7 +1240,7 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             }
 
             void did_change(std::vector<ObserverState> const& observers,
-                            std::vector<void*> const& invalidated) override
+                            std::vector<void*> const& invalidated, bool) override
             {
                 m_invalidated = invalidated;
                 m_result = observers;

--- a/tests/util/test_file.cpp
+++ b/tests/util/test_file.cpp
@@ -105,7 +105,7 @@ SyncServer::SyncServer()
             m_server.start("127.0.0.1", util::to_string(port));
             break;
         }
-        catch (std::runtime_error) {
+        catch (std::runtime_error const&) {
             continue;
         }
     }

--- a/tests/util/test_file.hpp
+++ b/tests/util/test_file.hpp
@@ -32,6 +32,9 @@ namespace realm {
 struct SyncConfig;
 }
 
+// {"identity":"test", "access": ["download", "upload"]}
+static const std::string s_test_token = "eyJpZGVudGl0eSI6InRlc3QiLCAiYWNjZXNzIjogWyJkb3dubG9hZCIsICJ1cGxvYWQiXX0=";
+
 #endif
 
 struct TestFile : realm::Realm::Config {
@@ -55,10 +58,6 @@ void advance_and_notify(realm::Realm& realm);
 
 #if REALM_ENABLE_SYNC
 
-struct SyncTestFile : TestFile {
-    SyncTestFile(const realm::SyncConfig&);
-};
-
 #define TEST_ENABLE_SYNC_LOGGING 0 // change to 1 to enable logging
 
 struct TestLogger : realm::util::Logger::LevelThreshold, realm::util::Logger {
@@ -71,8 +70,10 @@ struct TestLogger : realm::util::Logger::LevelThreshold, realm::util::Logger {
 
 class SyncServer {
 public:
-    SyncServer();
+    SyncServer(bool start_immediately=true);
     ~SyncServer();
+
+    void start();
 
     std::string url_for_realm(realm::StringData realm_name) const;
     std::string base_url() const { return m_url; }
@@ -81,6 +82,11 @@ private:
     realm::sync::Server m_server;
     std::thread m_thread;
     std::string m_url;
+};
+
+struct SyncTestFile : TestFile {
+    SyncTestFile(const realm::SyncConfig&);
+    SyncTestFile(SyncServer& server);
 };
 
 #endif // REALM_ENABLE_SYNC


### PR DESCRIPTION
This adds `NotificationToken::suppress_next()` which can be called within a write transaction to make the write transaction not produce a notification for that specific callback. All other callbacks (including others for the same collection) will still happen. The rest of the changes are support functionality to make this possible.

All methods of advancing the read transaction version will now send notifications, including beginning a write transaction and explicitly calling `Realm::refresh()`. If a hard refresh is required and the notifications for that version are not ready yet, it will block until they are. The two exceptions to this are advances due to importing handover objects (just not implemented yet), and advancements due to beginning a write transaction from within a notification callback (fundamentally not possible to do in any sensible way). This also fixes a lot of edge cases and race conditions along the way which could have resulted in notifications not being delivered when they should have been.
