### PR TITLE
Improve object server test suite

### DIFF
--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -350,7 +350,7 @@ void SyncManager::unregister_session(const std::string& path)
         return;
     auto it = m_inactive_sessions.find(path);
     REALM_ASSERT(it != m_inactive_sessions.end());
-    if (it->second->is_inactive())
+    if (it->second->can_be_safely_destroyed())
         m_inactive_sessions.erase(path);
 }
 

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -52,8 +52,21 @@ using SyncSessionTransactCallback = void(VersionID old_version, VersionID new_ve
 
 class SyncSession : public std::enable_shared_from_this<SyncSession> {
 public:
-    bool is_valid() const;
-    bool is_inactive() const;
+    enum class PublicState {
+        WaitingForAccessToken,
+        Active,
+        Dying,
+        Inactive,
+        Error,
+    };
+    PublicState state() const;
+    // FIXME: Sessions should be safely destroyable at any time; the fact that they aren't is a bug
+    // (https://github.com/realm/realm-sync/issues/986)
+    bool can_be_safely_destroyed() const;
+
+    bool is_in_error_state() const {
+        return state() == PublicState::Error;
+    }
 
     std::string const& path() const { return m_realm_path; }
 

--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -50,9 +50,9 @@ std::vector<std::shared_ptr<SyncSession>> SyncUser::all_sessions()
         return sessions;
     }
     for (auto it = m_sessions.begin(); it != m_sessions.end();) {
-        if (auto ptr = it->second.lock()) {
-            if (ptr->is_valid()) {
-                sessions.emplace_back(std::move(ptr));
+        if (auto ptr_to_session = it->second.lock()) {
+            if (!ptr_to_session->is_in_error_state()) {
+                sessions.emplace_back(std::move(ptr_to_session));
                 it++;
                 continue;
             }

--- a/src/sync/sync_user.hpp
+++ b/src/sync/sync_user.hpp
@@ -55,6 +55,7 @@ public:
     std::shared_ptr<SyncSession> session_for_url(const std::string& url);
 
     // Update the user's refresh token. If the user is logged out, it will log itself back in.
+    // Note that this is called by the SyncManager, and should not be directly called.
     void update_refresh_token(std::string token);
 
     // Log the user out and mark it as such. This will also close its associated Sessions.
@@ -84,6 +85,7 @@ public:
     // Register a session to this user.
     // A registered session will be bound at the earliest opportunity: either
     // immediately, or upon the user becoming Active.
+    // Note that this is called by the SyncManager, and should not be directly called.
     void register_session(std::shared_ptr<SyncSession> session);
 
 private:

--- a/tests/sync/file.cpp
+++ b/tests/sync/file.cpp
@@ -35,7 +35,7 @@ static void prepare_sync_manager_test(void) {
     util::make_dir(manager_path);
 }
 
-TEST_CASE("sync_file: percent-encoding APIs") {
+TEST_CASE("sync_file: percent-encoding APIs", "[sync]") {
     SECTION("does not encode a string that has no restricted characters") {
         const std::string expected = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_-";
         auto actual = make_percent_encoded_string(expected);
@@ -57,7 +57,7 @@ TEST_CASE("sync_file: percent-encoding APIs") {
     }
 }
 
-TEST_CASE("sync_file: URL manipulation APIs") {
+TEST_CASE("sync_file: URL manipulation APIs", "[sync]") {
     SECTION("properly concatenates a path when the path has a trailing slash") {
         const std::string expected = "/foo/bar";
         const std::string path = "/foo/";
@@ -123,7 +123,7 @@ TEST_CASE("sync_file: URL manipulation APIs") {
     }
 }
 
-TEST_CASE("sync_file: SyncFileManager APIs") {
+TEST_CASE("sync_file: SyncFileManager APIs", "[sync]") {
     const std::string identity = "123456789";
     const std::string manager_path = base_path + "syncmanager/";
     prepare_sync_manager_test();

--- a/tests/sync/metadata.cpp
+++ b/tests/sync/metadata.cpp
@@ -28,7 +28,7 @@ using File = realm::util::File;
 static const std::string base_path = tmp_dir() + "/realm_objectstore_sync_metadata/";
 static const std::string metadata_path = base_path + "/metadata.realm";
 
-TEST_CASE("sync_metadata: user metadata") {
+TEST_CASE("sync_metadata: user metadata", "[sync]") {
     reset_test_directory(base_path);
     SyncMetadataManager manager(metadata_path, false);
 
@@ -127,7 +127,7 @@ TEST_CASE("sync_metadata: user metadata") {
     }
 }
 
-TEST_CASE("sync_metadata: user metadata APIs") {
+TEST_CASE("sync_metadata: user metadata APIs", "[sync]") {
     reset_test_directory(base_path);
     SyncMetadataManager manager(metadata_path, false);
 
@@ -158,7 +158,7 @@ TEST_CASE("sync_metadata: user metadata APIs") {
     }
 }
 
-TEST_CASE("sync_metadata: results") {
+TEST_CASE("sync_metadata: results", "[sync]") {
     reset_test_directory(base_path);
     SyncMetadataManager manager(metadata_path, false);
 
@@ -204,7 +204,7 @@ TEST_CASE("sync_metadata: results") {
     }
 }
 
-TEST_CASE("sync_metadata: persistence across metadata manager instances") {
+TEST_CASE("sync_metadata: persistence across metadata manager instances", "[sync]") {
     reset_test_directory(base_path);
 
     SECTION("works for the basic case") {
@@ -225,7 +225,7 @@ TEST_CASE("sync_metadata: persistence across metadata manager instances") {
     }
 }
 
-TEST_CASE("sync_metadata: encryption") {
+TEST_CASE("sync_metadata: encryption", "[sync]") {
     reset_test_directory(base_path);
 
     SECTION("prohibits opening the metadata Realm with different keys") {

--- a/tests/sync/session.cpp
+++ b/tests/sync/session.cpp
@@ -24,6 +24,9 @@
 #include "sync/sync_config.hpp"
 #include "sync/sync_manager.hpp"
 #include "sync/sync_session.hpp"
+#include "sync/sync_user.hpp"
+
+#include <realm/util/scope_exit.hpp>
 
 #include <atomic>
 #include <chrono>
@@ -34,10 +37,11 @@ using namespace realm::util;
 
 template <typename FetchAccessToken, typename ErrorHandler>
 std::shared_ptr<SyncSession> sync_session(SyncServer& server, std::shared_ptr<SyncUser> user, const std::string& path,
-                                          FetchAccessToken&& fetch_access_token, ErrorHandler&& error_handler)
+                                          FetchAccessToken&& fetch_access_token, ErrorHandler&& error_handler,
+                                          SyncSessionStopPolicy stop_policy=SyncSessionStopPolicy::AfterChangesUploaded)
 {
     std::string url = server.base_url() + path;
-    SyncTestFile config({user, url, SyncSessionStopPolicy::AfterChangesUploaded,
+    SyncTestFile config({user, url, std::move(stop_policy),
         [&](const std::string& path, const SyncConfig& config, std::shared_ptr<SyncSession> session) {
             auto token = fetch_access_token(path, config.realm_url);
             session->refresh_access_token(std::move(token), config.realm_url);
@@ -51,7 +55,116 @@ std::shared_ptr<SyncSession> sync_session(SyncServer& server, std::shared_ptr<Sy
     return session;
 }
 
+namespace {
+
+bool session_is_active(const SyncSession& session)
+{
+    return session.state() == SyncSession::PublicState::Active;
+}
+
+bool session_is_inactive(const SyncSession& session)
+{
+    return session.state() == SyncSession::PublicState::Inactive;
+}
+
+}
+
+TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
+    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
+    SyncServer server;
+    SyncManager::shared().configure_file_system("/tmp/", SyncManager::MetadataMode::NoMetadata);
+    const std::string realm_base_url = server.base_url();
+
+    SECTION("a SyncUser can properly retrieve its owned sessions") {
+        auto user = SyncManager::shared().get_user("user1a", "not_a_real_token");
+        auto session1 = sync_session(server, user, "/test1a-1",
+                                     [&](auto...) { return s_test_token; },
+                                     [&](auto...) { });
+        auto session2 = sync_session(server, user, "/test1a-2",
+                                     [&](auto...) { return s_test_token; },
+                                     [&](auto...) { });
+        EventLoop::main().run_until([&] { return session_is_active(*session1) && session_is_active(*session2); });
+
+        // Check the sessions on the SyncUser.
+        REQUIRE(user->all_sessions().size() == 2);
+        auto s1 = user->session_for_url(realm_base_url + "/test1a-1");
+        REQUIRE(s1);
+        CHECK(s1->config().realm_url == realm_base_url + "/test1a-1");
+        auto s2 = user->session_for_url(realm_base_url + "/test1a-2");
+        REQUIRE(s2);
+        CHECK(s2->config().realm_url == realm_base_url + "/test1a-2");
+    }
+
+    SECTION("a SyncUser properly unbinds its sessions upon logging out") {
+        auto user = SyncManager::shared().get_user("user1b", "not_a_real_token");
+        auto session1 = sync_session(server, user, "/test1b-1",
+                                     [&](auto...) { return s_test_token; },
+                                     [&](auto...) { });
+        auto session2 = sync_session(server, user, "/test1b-2",
+                                     [&](auto...) { return s_test_token; },
+                                     [&](auto...) { });
+        EventLoop::main().run_until([&] { return session_is_active(*session1) && session_is_active(*session2); });
+
+        // Log the user out.
+        user->log_out();
+        // The sessions should log themselves out.
+        EventLoop::main().run_until([&] { return session_is_inactive(*session1) && session_is_inactive(*session2); });
+        CHECK(user->all_sessions().size() == 0);
+    }
+
+    SECTION("a SyncUser defers binding new sessions until it is logged in") {
+        const std::string user_id = "user1c";
+        auto user = SyncManager::shared().get_user(user_id, "not_a_real_token");
+        user->log_out();
+        REQUIRE(user->state() == SyncUser::State::LoggedOut);
+        auto session1 = sync_session(server, user, "/test1b-1",
+                                     [&](auto...) { return s_test_token; },
+                                     [&](auto...) { });
+        auto session2 = sync_session(server, user, "/test1b-2",
+                                     [&](auto...) { return s_test_token; },
+                                     [&](auto...) { });
+        // Run the runloop many iterations to see if the sessions spuriously bind.
+        std::atomic<int> run_count(0);
+        EventLoop::main().run_until([&] { run_count++; return run_count >= 100; });
+        REQUIRE(session_is_inactive(*session1));
+        REQUIRE(session_is_inactive(*session2));
+        REQUIRE(user->all_sessions().size() == 0);
+        // Log the user back in via the sync manager.
+        user = SyncManager::shared().get_user(user_id, "not_a_real_token_either");
+        EventLoop::main().run_until([&] { return session_is_active(*session1) && session_is_active(*session2); });
+        REQUIRE(user->all_sessions().size() == 2);
+    }
+
+    SECTION("a SyncUser properly rebinds existing sessions upon logging back in") {
+        const std::string user_id = "user1d";
+        auto user = SyncManager::shared().get_user(user_id, "not_a_real_token");
+        auto session1 = sync_session(server, user, "/test1b-1",
+                                     [&](auto...) { return s_test_token; },
+                                     [&](auto...) { });
+        auto session2 = sync_session(server, user, "/test1b-2",
+                                     [&](auto...) { return s_test_token; },
+                                     [&](auto...) { });
+        // Make sure the sessions are bound.
+        EventLoop::main().run_until([&] { return session_is_active(*session1) && session_is_active(*session2); });
+        REQUIRE(user->all_sessions().size() == 2);
+        // Log the user out.
+        user->log_out();
+        REQUIRE(user->state() == SyncUser::State::LoggedOut);
+        // Run the runloop many iterations to see if the sessions spuriously rebind.
+        std::atomic<int> run_count(0);
+        EventLoop::main().run_until([&] { run_count++; return run_count >= 100; });
+        REQUIRE(session_is_inactive(*session1));
+        REQUIRE(session_is_inactive(*session2));
+        REQUIRE(user->all_sessions().size() == 0);
+        // Log the user back in via the sync manager.
+        user = SyncManager::shared().get_user(user_id, "not_a_real_token_either");
+        EventLoop::main().run_until([&] { return session_is_active(*session1) && session_is_active(*session2); });
+        REQUIRE(user->all_sessions().size() == 2);
+    }
+}
+
 TEST_CASE("sync: log-in", "[sync]") {
+    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
     // Disable file-related functionality and metadata functionality for testing purposes.
     SyncManager::shared().configure_file_system("/tmp/", SyncManager::MetadataMode::NoMetadata);
@@ -65,8 +178,7 @@ TEST_CASE("sync: log-in", "[sync]") {
         std::atomic<bool> download_did_complete(false);
         session->wait_for_download_completion([&] { download_did_complete = true; });
         EventLoop::main().run_until([&] { return download_did_complete.load() || error_count > 0; });
-        CHECK(session->is_valid());
-        CHECK(download_did_complete.load());
+        CHECK(!session->is_in_error_state());
         CHECK(error_count == 0);
     }
 
@@ -77,7 +189,7 @@ TEST_CASE("sync: log-in", "[sync]") {
                                     [&](int, std::string, SyncSessionError) { ++error_count; });
 
         EventLoop::main().run_until([&] { return error_count > 0; });
-        CHECK(!session->is_valid());
+        CHECK(session->is_in_error_state());
     }
 
 #if 0
@@ -97,14 +209,9 @@ TEST_CASE("sync: log-in", "[sync]") {
         });
 
         EventLoop::main().run_until([&] { return error_count > 0; });
-        CHECK(!session->is_valid());
+        CHECK(session->is_in_error_state());
     }
 #endif
 
     // TODO: write a test that logs out a Realm with multiple sessions, then logs it back in?
-
-    // Cleanup
-    SyncManager::shared().reset_for_testing();
 }
-
-// TODO: tests investigating the interaction of SyncUser and SyncSession

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -45,7 +45,7 @@ bool validate_user_in_vector(std::vector<std::shared_ptr<SyncUser>> vector,
 
 }
 
-TEST_CASE("sync_manager: basic property APIs") {
+TEST_CASE("sync_manager: basic property APIs", "[sync]") {
     auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     reset_test_directory(base_path);
     SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoMetadata);
@@ -72,7 +72,7 @@ TEST_CASE("sync_manager: basic property APIs") {
     }
 }
 
-TEST_CASE("sync_manager: `path_for_realm` API") {
+TEST_CASE("sync_manager: `path_for_realm` API", "[sync]") {
     auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     reset_test_directory(base_path);
     SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoMetadata);
@@ -87,7 +87,7 @@ TEST_CASE("sync_manager: `path_for_realm` API") {
     }
 }
 
-TEST_CASE("sync_manager: persistent user state management") {
+TEST_CASE("sync_manager: persistent user state management", "[sync]") {
     auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     reset_test_directory(base_path);
     auto file_manager = SyncFileManager(base_path);

--- a/tests/sync/user.cpp
+++ b/tests/sync/user.cpp
@@ -29,7 +29,7 @@ using File = realm::util::File;
 
 static const std::string base_path = tmp_dir() + "/realm_objectstore_sync_user/";
 
-TEST_CASE("sync_user: SyncManager `get_user()` API") {
+TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
     auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     reset_test_directory(base_path);
     SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoEncryption);
@@ -96,7 +96,7 @@ TEST_CASE("sync_user: SyncManager `get_user()` API") {
     }
 }
 
-TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API") {
+TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API", "[sync]") {
     auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     reset_test_directory(base_path);
     SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoEncryption);
@@ -130,7 +130,7 @@ TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API") {
     }
 }
 
-TEST_CASE("sync_user: logout") {
+TEST_CASE("sync_user: logout", "[sync]") {
     reset_test_directory(base_path);
     SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoEncryption);
     const std::string identity = "sync_test_identity";
@@ -145,7 +145,7 @@ TEST_CASE("sync_user: logout") {
     }
 }
 
-TEST_CASE("sync_user: user persistence") {
+TEST_CASE("sync_user: user persistence", "[sync]") {
     auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     reset_test_directory(base_path);
     SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoEncryption);


### PR DESCRIPTION
@alazier @bdash @tgoyne 

This PR doesn't fix any bugs, it just adds some more sync-related tests and improves a few peripheral things. So there's no rush to get it reviewed.

Changes:
- Added more tests examining the interaction between `SyncUser` and `SyncSession`
- Renamed `SyncSession`'s `is_inactive()` API to `can_be_safely_destroyed()` to better reflect its purpose
- Added a `SyncSession` API to examine the current state, and removed the `is_valid()` API
- Tagged existing sync-related tests with the `[sync]` tag
