### PR TITLE
Fix compilation in Xcode with sync enabled

### DIFF
--- a/CMake/RealmCore.cmake
+++ b/CMake/RealmCore.cmake
@@ -18,6 +18,7 @@
 
 include(ExternalProject)
 include(ProcessorCount)
+find_package(PkgConfig)
 
 if(${CMAKE_GENERATOR} STREQUAL "Unix Makefiles")
     set(MAKE_EQUAL_MAKE "MAKE=$(MAKE)")
@@ -236,10 +237,12 @@ function(build_realm_sync sync_directory)
     set_property(TARGET realm-sync-server PROPERTY IMPORTED_LOCATION_COVERAGE ${sync_server_library_debug})
     set_property(TARGET realm-sync-server PROPERTY IMPORTED_LOCATION_RELEASE ${sync_server_library_release})
     set_property(TARGET realm-sync-server PROPERTY IMPORTED_LOCATION ${sync_server_library_release})
+
+    pkg_check_modules(YAML QUIET yaml-cpp)
     if(APPLE)
-        set_property(TARGET realm-sync-server PROPERTY INTERFACE_LINK_LIBRARIES ${FOUNDATION} ${SECURITY} -lyaml-cpp)
+        set_property(TARGET realm-sync-server PROPERTY INTERFACE_LINK_LIBRARIES ${FOUNDATION} ${SECURITY} ${YAML_LDFLAGS})
     else()
-        set_property(TARGET realm-sync-server PROPERTY INTERFACE_LINK_LIBRARIES -lcrypto -lssl -lyaml-cpp) 
+        set_property(TARGET realm-sync-server PROPERTY INTERFACE_LINK_LIBRARIES -lcrypto -lssl  ${YAML_LDFLAGS})
     endif()
 
     set(REALM_SYNC_INCLUDE_DIR ${sync_directory}/src PARENT_SCOPE)


### PR DESCRIPTION
/usr/local is not on the default search path when building via Xcode, so a simple `-lyaml-cpp` doesn't work when it's installed via homebrew. Fix this by using pkg-config to get the correct ldflags.