### PR TITLE
Reset metadata if metadata.realm could not be opened

### DIFF
--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -45,7 +45,8 @@ SyncManager& SyncManager::shared()
 
 void SyncManager::configure_file_system(const std::string& base_file_path,
                                         MetadataMode metadata_mode,
-                                        util::Optional<std::vector<char>> custom_encryption_key)
+                                        util::Optional<std::vector<char>> custom_encryption_key,
+                                        bool reset_metadata_on_error)
 {
     std::vector<UserCreationData> users_to_add;
     {
@@ -68,9 +69,19 @@ void SyncManager::configure_file_system(const std::string& base_file_path,
                                                                            false);
                 break;
             case MetadataMode::Encryption:
-                m_metadata_manager = std::make_unique<SyncMetadataManager>(m_file_manager->metadata_path(),
-                                                                           true,
-                                                                           std::move(custom_encryption_key));
+                try {
+                    m_metadata_manager = std::make_unique<SyncMetadataManager>(m_file_manager->metadata_path(),
+                                                                               true,
+                                                                               std::move(custom_encryption_key));
+                } catch (RealmFileException const& ex) {
+                    if (reset_metadata_on_error && m_file_manager->remove_metadata_realm()) {
+                        m_metadata_manager = std::make_unique<SyncMetadataManager>(m_file_manager->metadata_path(),
+                                                                                   true,
+                                                                                   std::move(custom_encryption_key));
+                    } else {
+                        throw;
+                    }
+                }
                 break;
             case MetadataMode::NoMetadata:
                 return;

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -66,7 +66,8 @@ public:
     // Configure the metadata and file management subsystems. This MUST be called upon startup.
     void configure_file_system(const std::string& base_file_path,
                                MetadataMode metadata_mode=MetadataMode::Encryption,
-                               util::Optional<std::vector<char>> custom_encryption_key=none);
+                               util::Optional<std::vector<char>> custom_encryption_key=none,
+                               bool reset_metadata_on_error=false);
 
     void set_log_level(util::Logger::Level) noexcept;
     void set_logger_factory(SyncLoggerFactory&) noexcept;

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -172,3 +172,21 @@ TEST_CASE("sync_manager: persistent user state management") {
         }
     }
 }
+
+TEST_CASE("sync_manager: metadata") {
+    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
+    reset_test_directory(base_path);
+
+    SECTION("should be reset in case of decryption error") {
+        const size_t key_size = 64;
+        std::vector<char> encryption_key(key_size);
+
+        arc4random_buf(encryption_key.data(), key_size);
+        SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::Encryption, encryption_key);
+
+        SyncManager::shared().reset_for_testing();
+
+        arc4random_buf(encryption_key.data(), key_size);
+        SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::Encryption, encryption_key, true);
+    }
+}

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -178,15 +178,15 @@ TEST_CASE("sync_manager: metadata") {
     reset_test_directory(base_path);
 
     SECTION("should be reset in case of decryption error") {
-        const size_t key_size = 64;
-        std::vector<char> encryption_key(key_size);
+		SyncManager::shared().configure_file_system(base_path,
+                                                    SyncManager::MetadataMode::Encryption,
+                                                    make_test_encryption_key());
 
-        arc4random_buf(encryption_key.data(), key_size);
-        SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::Encryption, encryption_key);
+		SyncManager::shared().reset_for_testing();
 
-        SyncManager::shared().reset_for_testing();
-
-        arc4random_buf(encryption_key.data(), key_size);
-        SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::Encryption, encryption_key, true);
+		SyncManager::shared().configure_file_system(base_path,
+                                                    SyncManager::MetadataMode::Encryption,
+                                                    make_test_encryption_key(),
+                                                    true);
     }
 }

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -178,13 +178,13 @@ TEST_CASE("sync_manager: metadata") {
     reset_test_directory(base_path);
 
     SECTION("should be reset in case of decryption error") {
-		SyncManager::shared().configure_file_system(base_path,
+        SyncManager::shared().configure_file_system(base_path,
                                                     SyncManager::MetadataMode::Encryption,
                                                     make_test_encryption_key());
 
-		SyncManager::shared().reset_for_testing();
+        SyncManager::shared().reset_for_testing();
 
-		SyncManager::shared().configure_file_system(base_path,
+        SyncManager::shared().configure_file_system(base_path,
                                                     SyncManager::MetadataMode::Encryption,
                                                     make_test_encryption_key(),
                                                     true);

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -186,7 +186,7 @@ TEST_CASE("sync_manager: metadata") {
 
         SyncManager::shared().configure_file_system(base_path,
                                                     SyncManager::MetadataMode::Encryption,
-                                                    make_test_encryption_key(),
+                                                    make_test_encryption_key(1),
                                                     true);
     }
 }


### PR DESCRIPTION
This PR is related to https://github.com/realm/realm-cocoa/issues/4264, it allows to reset metadata in case of error, most likely in case of invalid encryption key. Other related issues: https://github.com/realm/realm-browser-osx/issues/228 and https://github.com/realm/realm-browser-osx-private/issues/141.

Any existing users directories should probably be deleted at least until we have an API to handle this as was suggested in https://github.com/realm/realm-cocoa/issues/4264.

/cc @austinzheng, @jpsim, @bdash 