### PR TITLE
store table name in object schema

### DIFF
--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -51,6 +51,7 @@ ObjectSchema::ObjectSchema(std::string name, std::initializer_list<Property> per
 : name(std::move(name))
 , persisted_properties(persisted_properties)
 {
+    table_name = ObjectStore::table_name_for_object_type(this->name);
     for (auto const& prop : persisted_properties) {
         if (prop.is_primary) {
             primary_key = prop.name;
@@ -62,9 +63,11 @@ ObjectSchema::ObjectSchema(Group const& group, StringData name, size_t index) : 
     ConstTableRef table;
     if (index < group.size()) {
         table = group.get_table(index);
+        table_name = std::string(table.get()->get_name());
     }
     else {
-        table = ObjectStore::table_for_object_type(group, name);
+        table_name = ObjectStore::table_name_for_object_type(this->name);
+        table = group.get_table(table_name);
     }
 
     size_t count = table->get_column_count();

--- a/src/object_schema.hpp
+++ b/src/object_schema.hpp
@@ -41,6 +41,7 @@ public:
     ObjectSchema(Group const& group, StringData name, size_t index=-1);
 
     std::string name;
+    std::string table_name;
     std::vector<Property> persisted_properties;
     std::vector<Property> computed_properties;
     std::string primary_key;

--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -75,7 +75,7 @@ void set_schema_version(Group& group, uint64_t version) {
 template<typename Group>
 auto table_for_object_schema(Group& group, ObjectSchema const& object_schema)
 {
-    return ObjectStore::table_for_object_type(group, object_schema.name);
+    return group.get_table(object_schema.table_name);
 }
 
 void add_index(Table& table, size_t col)
@@ -118,8 +118,7 @@ void replace_column(Group& group, Table& table, Property const& old_property, Pr
 
 TableRef create_table(Group& group, ObjectSchema const& object_schema)
 {
-    auto name = ObjectStore::table_name_for_object_type(object_schema.name);
-    auto table = group.get_or_add_table(name);
+    auto table = group.get_or_add_table(object_schema.table_name);
     if (table->get_column_count() > 0) {
         return table;
     }


### PR DESCRIPTION
To allow having binding-level classes which map to a non-standard table name. This is especially useful for sync, where different clients may have different naming conventions. This is already in use in realm/realm-cocoa#4324.

This implementation does require `table_name` to be explicitly set by the caller if the default constructor is used. /cc @bdash 