### PR TITLE
Fix issue where default value could be moved

### DIFF
--- a/src/sync/impl/sync_metadata.hpp
+++ b/src/sync/impl/sync_metadata.hpp
@@ -122,9 +122,7 @@ public:
     /// If the platform supports it, setting `should_encrypt` to `true` and not specifying an encryption key will make
     /// the object store handle generating and persisting an encryption key for the metadata database. Otherwise, an
     /// exception will be thrown.
-    SyncMetadataManager(std::string path,
-                        bool should_encrypt,
-                        util::Optional<std::vector<char>> encryption_key=none);
+    SyncMetadataManager(std::string path, bool should_encrypt, util::Optional<std::vector<char>> encryption_key);
 
 private:
     SyncUserMetadataResults get_users(bool marked) const;

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -65,12 +65,15 @@ void SyncManager::configure_file_system(const std::string& base_file_path,
         switch (metadata_mode) {
             case MetadataMode::NoEncryption:
                 m_metadata_manager = std::make_unique<SyncMetadataManager>(m_file_manager->metadata_path(),
-                                                                           false);
+                                                                           false,
+                                                                           none);
                 break;
             case MetadataMode::Encryption:
                 m_metadata_manager = std::make_unique<SyncMetadataManager>(m_file_manager->metadata_path(),
                                                                            true,
-                                                                           std::move(custom_encryption_key));
+                                                                           (custom_encryption_key
+                                                                            ? std::move(custom_encryption_key)
+                                                                            : none));
                 break;
             case MetadataMode::NoMetadata:
                 return;

--- a/tests/sync/metadata.cpp
+++ b/tests/sync/metadata.cpp
@@ -30,7 +30,7 @@ static const std::string metadata_path = base_path + "/metadata.realm";
 
 TEST_CASE("sync_metadata: user metadata") {
     reset_test_directory(base_path);
-    SyncMetadataManager manager(metadata_path, false);
+    SyncMetadataManager manager(metadata_path, false, none);
 
     SECTION("can be properly constructed") {
         const auto identity = "testcase1a";
@@ -129,7 +129,7 @@ TEST_CASE("sync_metadata: user metadata") {
 
 TEST_CASE("sync_metadata: user metadata APIs") {
     reset_test_directory(base_path);
-    SyncMetadataManager manager(metadata_path, false);
+    SyncMetadataManager manager(metadata_path, false, none);
 
     SECTION("properly list all marked and unmarked users") {
         const auto identity1 = "testcase2a1";
@@ -160,7 +160,7 @@ TEST_CASE("sync_metadata: user metadata APIs") {
 
 TEST_CASE("sync_metadata: results") {
     reset_test_directory(base_path);
-    SyncMetadataManager manager(metadata_path, false);
+    SyncMetadataManager manager(metadata_path, false, none);
 
     SECTION("properly update as underlying items are added") {
         const auto identity1 = "testcase3a1";
@@ -211,13 +211,13 @@ TEST_CASE("sync_metadata: persistence across metadata manager instances") {
         const auto identity = "testcase4a";
         const std::string sample_url = "https://realm.example.org";
         const std::string sample_token = "this_is_a_user_token";
-        SyncMetadataManager first_manager(metadata_path, false);
+        SyncMetadataManager first_manager(metadata_path, false, none);
         auto first = SyncUserMetadata(first_manager, identity);
         first.set_state(sample_url, sample_token);
         REQUIRE(first.identity() == identity);
         REQUIRE(first.server_url() == sample_url);
         REQUIRE(first.user_token() == sample_token);
-        SyncMetadataManager second_manager(metadata_path, false);
+        SyncMetadataManager second_manager(metadata_path, false, none);
         auto second = SyncUserMetadata(second_manager, identity);
         REQUIRE(second.identity() == identity);
         REQUIRE(second.server_url() == sample_url);
@@ -235,7 +235,7 @@ TEST_CASE("sync_metadata: encryption") {
         }
         SECTION("different encryption settings") {
             SyncMetadataManager first_manager(metadata_path, true, make_test_encryption_key(10));
-            REQUIRE_THROWS(SyncMetadataManager(metadata_path, false));
+            REQUIRE_THROWS(SyncMetadataManager(metadata_path, false, none));
         }
     }
 

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -92,7 +92,7 @@ TEST_CASE("sync_manager: persistent user state management") {
     reset_test_directory(base_path);
     auto file_manager = SyncFileManager(base_path);
     // Open the metadata separately, so we can investigate it ourselves.
-    SyncMetadataManager manager(file_manager.metadata_path(), false);
+    SyncMetadataManager manager(file_manager.metadata_path(), false, none);
 
     const std::string url_1 = "https://example.realm.com/1/";
     const std::string url_2 = "https://example.realm.com/2/";
@@ -100,6 +100,13 @@ TEST_CASE("sync_manager: persistent user state management") {
     const std::string token_1 = "foo_token";
     const std::string token_2 = "bar_token";
     const std::string token_3 = "baz_token";
+
+    SECTION("configure_file_system should allow configuration with no encryption multiple times") {
+        // Ensure a bug does not occur where default `none`s are improperly `std::move()`d
+        SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoEncryption);
+        SyncManager::shared().reset_for_testing();
+        SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoEncryption);
+    }
 
     SECTION("when users are persisted") {
         const std::string identity_1 = "foo-1";

--- a/tests/sync/user.cpp
+++ b/tests/sync/user.cpp
@@ -151,7 +151,7 @@ TEST_CASE("sync_user: user persistence") {
     SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoEncryption);
     auto file_manager = SyncFileManager(base_path);
     // Open the metadata separately, so we can investigate it ourselves.
-    SyncMetadataManager manager(file_manager.metadata_path(), false);
+    SyncMetadataManager manager(file_manager.metadata_path(), false, none);
 
     SECTION("properly persists a user's information upon creation") {
         const std::string identity = "test_identity_1";


### PR DESCRIPTION
Waiting for tests to run, since apparently `make` can't find Foundation on my machine anymore.

Changes:
- Fixed issue where default value could be erroneously moved in `SyncManager::configure_file_system()`
- `SyncMetadataManager` no longer has a default value for `encryption_key`
- Added a test and updated existing tests