### PR TITLE
fix check for already-registered sessions in SyncUser::register_session

### DIFF
--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -173,7 +173,11 @@ void SyncUser::register_session(std::shared_ptr<SyncSession> session)
 {
     const std::string& url = session->config().realm_url;
     std::unique_lock<std::mutex> lock(m_mutex);
-    if (m_sessions.find(url) != m_sessions.end() || m_waiting_sessions.find(url) != m_waiting_sessions.end()) {
+    auto has_session = [&] (const auto& sessions) {
+        auto it = sessions.find(url);
+        return it != sessions.end() && !it->second.expired();
+    };
+    if (has_session(m_sessions) || has_session(m_waiting_sessions)) {
         throw std::invalid_argument("Can only register sessions that haven't previously been registered.");
     }
     switch (m_state) {


### PR DESCRIPTION
due to `m_sessions`/`m_waiting_sessions` being a map to `weak_ptr`, there could be a key entry with no corresponding `SyncSession`.

Thanks @bdash for finding this.