### PR TITLE
Add a test for sync session re-registration

### DIFF
--- a/tests/sync/user.cpp
+++ b/tests/sync/user.cpp
@@ -39,7 +39,7 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
 
     SECTION("properly creates a new normal user") {
         auto user = SyncManager::shared().get_user(identity, token, server_url);
-        REQUIRE(user != nullptr);
+        REQUIRE(user);
         // The expected state for a newly created user:
         REQUIRE(!user->is_admin());
         REQUIRE(user->identity() == identity);
@@ -50,7 +50,7 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
 
     SECTION("properly creates a new admin user") {
         auto user = SyncManager::shared().get_user(identity, token, server_url, true);
-        REQUIRE(user != nullptr);
+        REQUIRE(user);
         // The expected state for a newly created user:
         REQUIRE(user->is_admin());
         REQUIRE(user->identity() == identity);
@@ -62,7 +62,7 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
     SECTION("properly retrieves a previously created user, updating fields as necessary") {
         const std::string second_token = "0987654321-fake-token";
         auto first = SyncManager::shared().get_user(identity, token, server_url);
-        REQUIRE(first != nullptr);
+        REQUIRE(first);
         REQUIRE(first->identity() == identity);
         REQUIRE(first->refresh_token() == token);
         // Get the user again, but with a different token.
@@ -106,7 +106,7 @@ TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API", "[sync]"
 
     SECTION("properly returns a null pointer when called for a non-existent user") {
         std::shared_ptr<SyncUser> user = SyncManager::shared().get_existing_logged_in_user(identity);
-        REQUIRE(user == nullptr);
+        REQUIRE(!user);
     }
 
     SECTION("properly returns an existing logged-in user") {
@@ -126,7 +126,7 @@ TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API", "[sync]"
         REQUIRE(first->state() == SyncUser::State::LoggedOut);
         // Get that user using the 'existing user' API.
         auto second = SyncManager::shared().get_existing_logged_in_user(identity);
-        REQUIRE(second == nullptr);
+        REQUIRE(!second);
     }
 }
 


### PR DESCRIPTION
Tests fix in https://github.com/realm/realm-object-store/pull/219

Before the fix, this test never completes. After the fix, it works.

There's probably a more idiomatic way to pass a second value out of a function...

@bdash @jpsim @tgoyne 