### PR TITLE
Fix a crash seen when running the sync tests on Linux

### DIFF
--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -415,7 +415,7 @@ void SyncSession::revive_if_needed(std::shared_ptr<SyncSession> session)
         }
     }
     if (handler) {
-        handler.value()(session->m_realm_path, session->m_config, std::move(session));
+        handler.value()(session->m_realm_path, session->m_config, session);
     }
 }
 


### PR DESCRIPTION
GCC on Linux evaluates function arguments in a different order to Clang on Apple platforms, as is its right. This was resulting in a null dereference due to dereferencing a moved-from `shared_ptr`.