### PR TITLE
Add support for “file action” sync metadata

### DIFF
--- a/src/sync/impl/sync_metadata.cpp
+++ b/src/sync/impl/sync_metadata.cpp
@@ -38,31 +38,48 @@ static const char * const c_sync_identity = "identity";
 static const char * const c_sync_auth_server_url = "auth_server_url";
 static const char * const c_sync_user_token = "user_token";
 
+static const char * const c_sync_fileActionMetadata = "FileActionMetadata";
+static const char * const c_sync_original_name = "original_name";
+static const char * const c_sync_new_name = "new_name";
+static const char * const c_sync_action = "action";
+static const char * const c_sync_url = "url";
+
+
 SyncMetadataManager::SyncMetadataManager(std::string path,
                                          bool should_encrypt,
                                          util::Optional<std::vector<char>> encryption_key)
 {
     std::lock_guard<std::mutex> lock(m_metadata_lock);
 
-    auto nullable_string_property = [](const char *name) -> Property {
+    auto make_nullable_string_property = [](const char *name) -> Property {
         Property p = {name, PropertyType::String};
         p.is_nullable = true;
         return p;
     };
 
-    Property primary_key = {c_sync_identity, PropertyType::String};
-    primary_key.is_indexed = true;
-    primary_key.is_primary = true;
+    auto make_primary_key_property = [](const char *name) -> Property {
+        Property p = {name, PropertyType::String};
+        p.is_indexed = true;
+        p.is_primary = true;
+        return p;
+    };
 
     Realm::Config config;
     config.path = std::move(path);
     config.schema = Schema{
         {c_sync_userMetadata, {
-            primary_key,
+            make_primary_key_property(c_sync_identity),
             {c_sync_marked_for_removal, PropertyType::Bool},
-            nullable_string_property(c_sync_auth_server_url),
-            nullable_string_property(c_sync_user_token),
-        }}
+            make_nullable_string_property(c_sync_auth_server_url),
+            make_nullable_string_property(c_sync_user_token),
+        }},
+        {c_sync_fileActionMetadata, {
+            make_primary_key_property(c_sync_original_name),
+            {c_sync_action, PropertyType::Int},
+            make_nullable_string_property(c_sync_new_name),
+            {c_sync_url, PropertyType::String},
+            {c_sync_identity, PropertyType::String},
+        }},
     };
     config.schema_mode = SchemaMode::Additive;
     config.schema_version = 0;
@@ -81,14 +98,23 @@ SyncMetadataManager::SyncMetadataManager(std::string path,
     // Open the Realm.
     SharedRealm realm = Realm::get_shared_realm(config);
 
-    // Get data about the (hardcoded) schema.
+    // Get data about the (hardcoded) schemas.
     DescriptorRef descriptor = ObjectStore::table_for_object_type(realm->read_group(),
                                                                   c_sync_userMetadata)->get_descriptor();
-    m_schema = {
+    m_user_schema = {
         descriptor->get_column_index(c_sync_identity),
         descriptor->get_column_index(c_sync_marked_for_removal),
         descriptor->get_column_index(c_sync_user_token),
         descriptor->get_column_index(c_sync_auth_server_url)
+    };
+
+    descriptor = ObjectStore::table_for_object_type(realm->read_group(), c_sync_fileActionMetadata)->get_descriptor();
+    m_file_action_schema = {
+        descriptor->get_column_index(c_sync_original_name),
+        descriptor->get_column_index(c_sync_new_name),
+        descriptor->get_column_index(c_sync_action),
+        descriptor->get_column_index(c_sync_url),
+        descriptor->get_column_index(c_sync_identity)
     };
 
     m_metadata_config = std::move(config);
@@ -116,10 +142,18 @@ SyncUserMetadataResults SyncMetadataManager::get_users(bool marked) const
     SharedRealm realm = Realm::get_shared_realm(get_configuration());
 
     TableRef table = ObjectStore::table_for_object_type(realm->read_group(), c_sync_userMetadata);
-    Query query = table->where().equal(m_schema.idx_marked_for_removal, marked);
+    Query query = table->where().equal(m_user_schema.idx_marked_for_removal, marked);
 
     Results results(realm, std::move(query));
-    return SyncUserMetadataResults(std::move(results), std::move(realm), m_schema);
+    return SyncUserMetadataResults(std::move(results), std::move(realm), m_user_schema);
+}
+
+SyncFileActionMetadataResults SyncMetadataManager::all_pending_actions() const
+{
+    SharedRealm realm = Realm::get_shared_realm(get_configuration());
+    TableRef table = ObjectStore::table_for_object_type(realm->read_group(), c_sync_fileActionMetadata);
+    Results results(realm, table->where());
+    return SyncFileActionMetadataResults(std::move(results), std::move(realm), m_file_action_schema);
 }
 
 SyncUserMetadata::SyncUserMetadata(Schema schema, SharedRealm realm, RowExpr row)
@@ -130,7 +164,7 @@ SyncUserMetadata::SyncUserMetadata(Schema schema, SharedRealm realm, RowExpr row
 { }
 
 SyncUserMetadata::SyncUserMetadata(const SyncMetadataManager& manager, std::string identity, bool make_if_absent)
-: m_schema(manager.m_schema)
+: m_schema(manager.m_user_schema)
 {
     // Open the Realm.
     m_realm = Realm::get_shared_realm(manager.get_configuration());
@@ -225,6 +259,83 @@ void SyncUserMetadata::remove()
     m_invalid = true;
     m_realm->begin_transaction();
     TableRef table = ObjectStore::table_for_object_type(m_realm->read_group(), c_sync_userMetadata);
+    table->move_last_over(m_row.get_index());
+    m_realm->commit_transaction();
+    m_realm = nullptr;
+}
+
+
+SyncFileActionMetadata::SyncFileActionMetadata(const SyncMetadataManager& manager,
+                                               Action action,
+                                               const std::string& original_name,
+                                               const std::string& url,
+                                               const std::string& user_identity,
+                                               util::Optional<std::string> new_name)
+: m_schema(manager.m_file_action_schema)
+{
+    size_t raw_action = static_cast<size_t>(action);
+
+    // Open the Realm.
+    m_realm = Realm::get_shared_realm(manager.get_configuration());
+
+    // Retrieve or create the row for this object.
+    TableRef table = ObjectStore::table_for_object_type(m_realm->read_group(), c_sync_fileActionMetadata);
+    m_realm->begin_transaction();
+    size_t row_idx = table->find_first_string(m_schema.idx_original_name, original_name);
+    if (row_idx == not_found) {
+        row_idx = table->add_empty_row();
+        table->set_string(m_schema.idx_original_name, row_idx, original_name);
+    }
+    table->set_string(m_schema.idx_new_name, row_idx, new_name);
+    table->set_int(m_schema.idx_action, row_idx, raw_action);
+    table->set_string(m_schema.idx_url, row_idx, url);
+    table->set_string(m_schema.idx_user_identity, row_idx, user_identity);
+    m_realm->commit_transaction();
+    m_row = table->get(row_idx);
+}
+
+SyncFileActionMetadata::SyncFileActionMetadata(Schema schema, SharedRealm realm, RowExpr row)
+: m_schema(std::move(schema))
+, m_realm(std::move(realm))
+, m_row(row)
+{ }
+
+std::string SyncFileActionMetadata::original_name() const
+{
+    m_realm->verify_thread();
+    return m_row.get_string(m_schema.idx_original_name);
+}
+
+util::Optional<std::string> SyncFileActionMetadata::new_name() const
+{
+    m_realm->verify_thread();
+    StringData result = m_row.get_string(m_schema.idx_new_name);
+    return result.is_null() ? util::none : util::make_optional(std::string(result));
+}
+
+SyncFileActionMetadata::Action SyncFileActionMetadata::action() const
+{
+    m_realm->verify_thread();
+    return static_cast<SyncFileActionMetadata::Action>(m_row.get_int(m_schema.idx_action));
+}
+
+std::string SyncFileActionMetadata::url() const
+{
+    m_realm->verify_thread();
+    return m_row.get_string(m_schema.idx_url);
+}
+
+std::string SyncFileActionMetadata::user_identity() const
+{
+    m_realm->verify_thread();
+    return m_row.get_string(m_schema.idx_user_identity);
+}
+
+void SyncFileActionMetadata::remove()
+{
+    m_realm->verify_thread();
+    m_realm->begin_transaction();
+    TableRef table = ObjectStore::table_for_object_type(m_realm->read_group(), c_sync_fileActionMetadata);
     table->move_last_over(m_row.get_index());
     m_realm->commit_transaction();
     m_realm = nullptr;

--- a/src/sync/impl/sync_metadata.hpp
+++ b/src/sync/impl/sync_metadata.hpp
@@ -76,6 +76,53 @@ private:
     Row m_row;
 };
 
+class SyncFileActionMetadata {
+public:
+    struct Schema {
+        size_t idx_original_name;
+        size_t idx_new_name;
+        size_t idx_action;
+        size_t idx_url;
+        size_t idx_user_identity;
+    };
+
+    enum class Action {
+        // The Realm files at the given directory will be deleted.
+        DeleteRealm,
+        // The Realm file will be copied to a 'recovery' directory, and the original Realm files will be deleted.
+        HandleRealmForClientReset
+    };
+
+    // The absolute path to the Realm file in question.
+    std::string original_name() const;
+
+    // The meaning of this parameter depends on the `Action` specified.
+    // For `HandleRealmForClientReset`, it is the absolute path where the backup copy 
+    // of the Realm file found at `original_name()` will be placed. 
+    // For all other `Action`s, it is ignored.
+    util::Optional<std::string> new_name() const;
+
+    Action action() const;
+    std::string url() const;
+    std::string user_identity() const;
+
+    // Remove the action from the metadata database, because it was completed or is now invalid.
+    void remove();
+
+    SyncFileActionMetadata(const SyncMetadataManager& manager,
+                           Action action,
+                           const std::string& original_name,
+                           const std::string& url,
+                           const std::string& user_identity,
+                           util::Optional<std::string> new_name=none);
+
+    SyncFileActionMetadata(Schema schema, SharedRealm realm, RowExpr row);
+private:
+    Schema m_schema;
+    SharedRealm m_realm;
+    Row m_row;
+};
+
 template<class T>
 class SyncMetadataResults {
 public:
@@ -102,9 +149,11 @@ private:
     mutable Results m_results;
 };
 using SyncUserMetadataResults = SyncMetadataResults<SyncUserMetadata>;
+using SyncFileActionMetadataResults = SyncMetadataResults<SyncFileActionMetadata>;
 
 class SyncMetadataManager {
 friend class SyncUserMetadata;
+friend class SyncFileActionMetadata;
 public:
     // Return a Results object containing all users not marked for removal.
     SyncUserMetadataResults all_unmarked_users() const;
@@ -113,6 +162,9 @@ public:
     // `remove()` on each user to actually remove it from the database. (This is so that already-open Realm files can be
     // safely cleaned up the next time the host is launched.)
     SyncUserMetadataResults all_users_marked_for_removal() const;
+
+    // Return a Results object containing all pending actions.
+    SyncFileActionMetadataResults all_pending_actions() const;
 
     Realm::Config get_configuration() const;
 
@@ -131,7 +183,8 @@ private:
 
     Realm::Config m_metadata_config;
 
-    SyncUserMetadata::Schema m_schema;
+    SyncUserMetadata::Schema m_user_schema;
+    SyncFileActionMetadata::Schema m_file_action_schema;
     mutable std::mutex m_metadata_lock;
 };
 

--- a/tests/sync/sync_test_utils.cpp
+++ b/tests/sync/sync_test_utils.cpp
@@ -45,6 +45,15 @@ bool results_contains_user(SyncUserMetadataResults& results, const std::string& 
     return false;
 }
 
+bool results_contains_original_name(SyncFileActionMetadataResults& results, const std::string& original_name) {
+    for (size_t i = 0; i < results.size(); i++) {
+        if (results.get(i).original_name() == original_name) {
+            return true;
+        }
+    }
+    return false;
+}
+
 std::string tmp_dir() {
     const char* dir = getenv("TMPDIR");
     if (dir && *dir)

--- a/tests/sync/sync_test_utils.hpp
+++ b/tests/sync/sync_test_utils.hpp
@@ -30,6 +30,7 @@ namespace realm {
 bool create_dummy_realm(std::string path);
 void reset_test_directory(const std::string& base_path);
 bool results_contains_user(SyncUserMetadataResults& results, const std::string& identity);
+bool results_contains_original_name(SyncFileActionMetadataResults& results, const std::string& original_name);
 std::string tmp_dir();
 std::vector<char> make_test_encryption_key(const char start = 0);
 


### PR DESCRIPTION
Changes
- Added `SyncFileActionMetadata`, which represents an action the file subsystem should take on a sync’ed Realm the next time the app launches
- Added tests

Part of client support for client reset.