### PR TITLE
Fix property change migration involving LinkingObjects

### DIFF
--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -107,12 +107,8 @@ const Property *ObjectSchema::property_for_name(StringData name) const {
 }
 
 bool ObjectSchema::property_is_computed(Property const& property) const {
-    for (auto& prop : computed_properties) {
-        if (prop == property) {
-            return true;
-        }
-    }
-    return false;
+    auto end = computed_properties.end();
+    return std::find(computed_properties.begin(), end, property) != end;
 }
 
 void ObjectSchema::set_primary_key_property()

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -106,6 +106,15 @@ const Property *ObjectSchema::property_for_name(StringData name) const {
     return const_cast<ObjectSchema *>(this)->property_for_name(name);
 }
 
+bool ObjectSchema::property_is_computed(Property const& property) const {
+    for (auto& prop : computed_properties) {
+        if (prop == property) {
+            return true;
+        }
+    }
+    return false;
+}
+
 void ObjectSchema::set_primary_key_property()
 {
     if (primary_key.length()) {

--- a/src/object_schema.hpp
+++ b/src/object_schema.hpp
@@ -53,6 +53,7 @@ public:
     const Property *primary_key_property() const {
         return property_for_name(primary_key);
     }
+    bool property_is_computed(Property const& property) const;
 
     void validate(Schema const& schema, std::vector<ObjectSchemaValidationException>& exceptions) const;
 

--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -93,9 +93,10 @@ void add_index(Table& table, size_t col)
 
 void insert_column(Group& group, Table& table, Property const& property, size_t col_ndx)
 {
-    if (property.type == PropertyType::LinkingObjects) {
-        throw std::logic_error("Cannot directly insert a LinkingObject column, it must be an artifact of an existing link column.");
-    }
+    // Cannot directly insert a LinkingObjects column (a computed property).
+    // LinkingObjects must be an artifact of an existing link column.
+    REALM_ASSERT(property.type != PropertyType::LinkingObjects);
+
     if (property.type == PropertyType::Object || property.type == PropertyType::Array) {
         auto target_name = ObjectStore::table_name_for_object_type(property.object_type);
         TableRef link_table = group.get_or_add_table(target_name);

--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -467,8 +467,7 @@ static void create_initial_tables(Group& group, std::vector<SchemaChange> const&
 
         void operator()(ChangePropertyType op)
         {
-            insert_column(group, table(op.object), *op.new_property, op.old_property->table_column);
-            table(op.object).remove_column(op.old_property->table_column + 1);
+            replace_column(group, table(op.object), *op.old_property, *op.new_property);
         }
     } applier{group};
 

--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -115,12 +115,8 @@ void add_column(Group& group, Table& table, Property const& property)
 
 void replace_column(Group& group, Table& table, Property const& old_property, Property const& new_property)
 {
-    size_t col_offset = 0;
-    if (new_property.type != PropertyType::LinkingObjects) {
-        insert_column(group, table, new_property, old_property.table_column);
-        col_offset = 1;
-    }
-    table.remove_column(old_property.table_column + col_offset);
+    insert_column(group, table, new_property, old_property.table_column);
+    table.remove_column(old_property.table_column + 1);
 }
 
 TableRef create_table(Group& group, ObjectSchema const& object_schema)

--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -112,6 +112,10 @@ static void compare(ObjectSchema const& existing_schema,
             changes.emplace_back(schema_change::RemoveProperty{&existing_schema, &current_prop});
             continue;
         }
+        if (target_schema.property_is_computed(*target_prop)) {
+            changes.emplace_back(schema_change::RemoveProperty{&existing_schema, &current_prop});
+            continue;
+        }
         if (current_prop.type != target_prop->type || current_prop.object_type != target_prop->object_type) {
             changes.emplace_back(schema_change::ChangePropertyType{&existing_schema, &current_prop, target_prop});
             continue;

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -101,6 +101,16 @@ Schema remove_property(Schema schema, StringData object_name, StringData propert
     return schema;
 }
 
+Schema replace_property(Schema schema, StringData object_name, StringData old_property_name, Property new_property)
+{
+    auto& properties = schema.find(object_name)->persisted_properties;
+    auto pos = find_if(begin(properties), end(properties),
+                        [&](auto&& prop) { return prop.name == old_property_name; });
+    properties.erase(pos);
+    properties.insert(pos, new_property);
+    return schema;
+}
+
 Schema set_indexed(Schema schema, StringData object_name, StringData property_name, bool value)
 {
     schema.find(object_name)->property_for_name(property_name)->is_indexed = value;
@@ -239,6 +249,30 @@ TEST_CASE("migration: Automatic") {
                 }},
             };
             REQUIRE_MIGRATION_NEEDED(*realm, schema, remove_property(schema, "object", "col2"));
+        }
+
+        SECTION("replace property from existing object schema") {
+            auto realm = Realm::get_shared_realm(config);
+            Schema schema1 = {
+                {"object", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                    {"link", PropertyType::Object, "object2", "", false, false, true},
+                }},
+                {"object2", {
+                    {"value", PropertyType::Int, "", "", false, false, false},
+                    {"inverse", PropertyType::Object, "object", "", false, false, true},
+                }},
+            };
+            Property new_property{"link", PropertyType::LinkingObjects, "object2", "inverse", false, false, false};
+            Schema schema2 = replace_property(schema1, "object", "link", new_property);
+
+            REQUIRE_UPDATE_SUCCEEDS(*realm, schema1, 0);
+            REQUIRE_THROWS((*realm).update_schema(schema2));
+            REQUIRE((*realm).schema() == schema1);
+            REQUIRE_NOTHROW((*realm).update_schema(schema2, 1,
+                            [](SharedRealm, SharedRealm, Schema&) { /* empty but present migration handler */ }));
+            //VERIFY_SCHEMA(*realm); //FIXME: why is the column index of object.link now npos?
+            REQUIRE((*realm).schema() == schema2);
         }
 
         SECTION("change property type") {


### PR DESCRIPTION
Backlink columns should not be inserted directly to tables. This happens automatically when the corresponding Link or LinkList column is inserted in the linked table. This caused the stack trace in realm core [2291](https://github.com/realm/realm-core/issues/2291). The added test in this PR can produce the same stack trace.

@bdash @tgoyne please review