### PR TITLE
Delete the uv_async_t through the correct pointer type

### DIFF
--- a/src/util/uv/event_loop_signal.hpp
+++ b/src/util/uv/event_loop_signal.hpp
@@ -37,7 +37,7 @@ public:
     {
         uv_close((uv_handle_t*)m_handle, [](uv_handle_t* handle) {
             delete static_cast<Callback*>(handle->data);
-            delete handle;
+            delete reinterpret_cast<uv_async_t*>(handle);
         });
     }
 


### PR DESCRIPTION
Deleting an object through a different pointer type gives undefined behavior, and elicits a complaint from address sanitizer.

/cc @alazier 