### PR TITLE
Replace blocking upload/download waiters with async versions

### DIFF
--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -141,9 +141,12 @@ void SyncManager::reset_for_testing()
         m_users.clear();
     }
     {
+        // Assert there are no active sessions remaining.
+        REALM_ASSERT(std::all_of(m_active_sessions.begin(), m_active_sessions.end(), [](auto& element){ return element.second.expired(); }));
         // Destroy the client.
         std::lock_guard<std::mutex> lock(m_mutex);
         m_sync_client = nullptr;
+        m_inactive_sessions.clear();
         // Reset even more state.
         // NOTE: these should always match the defaults.
         m_log_level = util::Logger::Level::info;
@@ -366,8 +369,7 @@ void SyncManager::unregister_session(const std::string& path)
         return;
     auto it = m_inactive_sessions.find(path);
     REALM_ASSERT(it != m_inactive_sessions.end());
-    if (it->second->can_be_safely_destroyed())
-        m_inactive_sessions.erase(path);
+    m_inactive_sessions.erase(path);
 }
 
 std::shared_ptr<SyncClient> SyncManager::get_sync_client() const

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -103,7 +103,9 @@ public:
     // Get the default path for a Realm for the given user and absolute unresolved URL.
     std::string path_for_realm(const std::string& user_identity, const std::string& raw_realm_url) const;
 
-    // Reset part of the singleton state for testing purposes. DO NOT CALL OUTSIDE OF TESTING CODE.
+    // Reset the singleton state for testing purposes. DO NOT CALL OUTSIDE OF TESTING CODE.
+    // Precondition: any synced Realms or `SyncSession`s must be closed or rendered inactive prior to
+    // calling this method.
     void reset_for_testing();
 
 private:

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -210,24 +210,21 @@ struct sync_session_states::Active : public SyncSession::State {
 struct sync_session_states::Dying : public SyncSession::State {
     void enter_state(std::unique_lock<std::mutex>&, SyncSession& session) const override
     {
-        ++session.m_pending_upload_threads;
-        std::thread([session=&session] {
+        size_t current_death_count = ++session.m_death_count;
+        session.m_session->async_wait_for_upload_completion([session=&session, current_death_count](std::error_code error_code) {
+            if (error_code == util::error::operation_aborted) {
+                // Session was killed beneath us. Don't do anything.
+                return;
+            }
+            // FIXME: It's possible for the session to be destroyed while the callback is running,
+            // which is something we should address in the future. It is only possible when 
+            // SyncManager::reset_for_testing() is called.
+            // c.f. https://github.com/realm/realm-object-store/issues/269
             std::unique_lock<std::mutex> lock(session->m_state_mutex);
-            if (session->m_pending_upload_threads != 1) {
-                --session->m_pending_upload_threads;
-                return;
+            if (session->m_state == &State::dying && session->m_death_count == current_death_count) {
+                session->advance_state(lock, inactive);
             }
-
-            if (session->m_state != &State::dying) {
-                // The session was revived. Don't kill it.
-                --session->m_pending_upload_threads;
-                return;
-            }
-
-            session->m_session->wait_for_upload_complete_or_client_stopped();
-            --session->m_pending_upload_threads;
-            session->advance_state(lock, inactive);
-        }).detach();
+        });
     }
 
     bool revive_if_needed(std::unique_lock<std::mutex>& lock, SyncSession& session) const override
@@ -461,44 +458,41 @@ bool SyncSession::can_wait_for_network_completion() const
     return m_state == &State::active || m_state == &State::dying;
 }
 
-void SyncSession::wait_for_upload_completion()
+bool SyncSession::wait_for_upload_completion(std::function<void(std::error_code)> callback)
+{
+    std::unique_lock<std::mutex> lock(m_state_mutex);
+    // FIXME: instead of dropping the callback if we haven't yet `bind()`ed,
+    // save it and register it when the session `bind()`s.
+    if (can_wait_for_network_completion()) {
+        REALM_ASSERT(m_session);
+        m_session->async_wait_for_upload_completion(std::move(callback));
+        return true;
+    }
+    return false;
+}
+
+bool SyncSession::wait_for_download_completion(std::function<void(std::error_code)> callback)
+{
+    std::unique_lock<std::mutex> lock(m_state_mutex);
+    // FIXME: instead of dropping the callback if we haven't yet `bind()`ed,
+    // save it and register it when the session `bind()`s.
+    if (can_wait_for_network_completion()) {
+        REALM_ASSERT(m_session);
+        m_session->async_wait_for_download_completion(std::move(callback));
+        return true;
+    }
+    return false;
+}
+
+bool SyncSession::wait_for_upload_completion_blocking()
 {
     std::unique_lock<std::mutex> lock(m_state_mutex);
     if (can_wait_for_network_completion()) {
         REALM_ASSERT(m_session);
         m_session->wait_for_upload_complete_or_client_stopped();
+        return true;
     }
-}
-
-void SyncSession::wait_for_download_completion()
-{
-    std::unique_lock<std::mutex> lock(m_state_mutex);
-    if (can_wait_for_network_completion()) {
-        REALM_ASSERT(m_session);
-        m_session->wait_for_download_complete_or_client_stopped();
-    }
-}
-
-void SyncSession::wait_for_upload_completion(std::function<void()> callback)
-{
-    // FIXME: If the session is waiting for a token, the `wait_for_upload` should be deferred until the `bind()`
-    // instead of just calling the callback immediately.
-    REALM_ASSERT(shared_from_this());
-    std::thread([callback=std::move(callback), self=shared_from_this()]() {
-        self->wait_for_upload_completion();
-        callback();
-    }).detach();
-}
-
-void SyncSession::wait_for_download_completion(std::function<void()> callback)
-{
-    // FIXME: If the session is waiting for a token, the `wait_for_upload` should be deferred until the `bind()`
-    // instead of just calling the callback immediately.
-    REALM_ASSERT(shared_from_this());
-    std::thread([callback=std::move(callback), self=shared_from_this()]() {
-        self->wait_for_download_completion();
-        callback();
-    }).detach();
+    return false;
 }
 
 void SyncSession::refresh_access_token(std::string access_token, util::Optional<std::string> server_url)
@@ -532,10 +526,4 @@ SyncSession::PublicState SyncSession::state() const
         return PublicState::Error;
     }
     REALM_UNREACHABLE();
-}
-
-bool SyncSession::can_be_safely_destroyed() const
-{
-    std::unique_lock<std::mutex> lock(m_state_mutex);
-    return m_state == &State::inactive && m_pending_upload_threads == 0;
 }

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -60,9 +60,6 @@ public:
         Error,
     };
     PublicState state() const;
-    // FIXME: Sessions should be safely destroyable at any time; the fact that they aren't is a bug
-    // (https://github.com/realm/realm-sync/issues/986)
-    bool can_be_safely_destroyed() const;
 
     bool is_in_error_state() const {
         return state() == PublicState::Error;
@@ -70,11 +67,13 @@ public:
 
     std::string const& path() const { return m_realm_path; }
 
-    void wait_for_upload_completion();
-    void wait_for_download_completion();
+    bool wait_for_upload_completion(std::function<void(std::error_code)> callback);
+    bool wait_for_download_completion(std::function<void(std::error_code)> callback);
 
-    void wait_for_upload_completion(std::function<void()> callback);
-    void wait_for_download_completion(std::function<void()> callback);
+    // Wait for any pending uploads to complete, blocking the calling thread.
+    // Returns `false` if the method did not attempt to wait, either because the
+    // session is in an error state or because it hasn't yet been `bind()`ed.
+    bool wait_for_upload_completion_blocking();
 
     // If the sync session is currently `Dying`, ask it to stay alive instead.
     // If the sync session is currently `Inactive`, recreate it. Otherwise, a no-op.
@@ -159,7 +158,7 @@ private:
     mutable std::mutex m_state_mutex;
 
     const State* m_state = nullptr;
-    size_t m_pending_upload_threads = 0;
+    size_t m_death_count = 0;
 
     SyncConfig m_config;
 

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -18,6 +18,7 @@
 
 #include "catch.hpp"
 
+#include "util/event_loop.hpp"
 #include "util/index_helpers.hpp"
 #include "util/test_file.hpp"
 #include "util/format.hpp"
@@ -933,8 +934,7 @@ TEST_CASE("notifications: sync") {
         // Start the server and wait for the Realm to be uploaded so that sync
         // makes some writes to the Realm and bumps the version
         server.start();
-        SyncManager::shared().get_session(config.path, *config.sync_config)->wait_for_upload_completion();
-
+        SyncManager::shared().get_session(config.path, *config.sync_config)->wait_for_upload_completion_blocking();
         // Make sure that the notifications still get delivered rather than
         // waiting forever due to that we don't get a commit notification from
         // the commits sync makes to store the upload progress

--- a/tests/sync/session.cpp
+++ b/tests/sync/session.cpp
@@ -228,7 +228,7 @@ TEST_CASE("sync: log-in", "[sync]") {
                                     [&](auto, int, std::string, SyncSessionError) { ++error_count; });
 
         std::atomic<bool> download_did_complete(false);
-        session->wait_for_download_completion([&] { download_did_complete = true; });
+        session->wait_for_download_completion([&](auto) { download_did_complete = true; });
         EventLoop::main().run_until([&] { return download_did_complete.load() || error_count > 0; });
         CHECK(!session->is_in_error_state());
         CHECK(error_count == 0);
@@ -244,7 +244,6 @@ TEST_CASE("sync: log-in", "[sync]") {
         CHECK(session->is_in_error_state());
     }
 
-#if 0
     // FIXME: This test currently deadlocks when SyncSession's error handler attempts to change the
     // session's state. Should be fixed by https://github.com/realm/realm-object-store/pull/181.
 
@@ -255,7 +254,7 @@ TEST_CASE("sync: log-in", "[sync]") {
                                     [&](auto, int, std::string, SyncSessionError) { ++error_count; });
 
         EventLoop::main().perform([&] {
-            session->wait_for_download_completion([] {
+            session->wait_for_download_completion([](auto) {
                 fprintf(stderr, "Download completed.\n");
             });
         });
@@ -263,7 +262,6 @@ TEST_CASE("sync: log-in", "[sync]") {
         EventLoop::main().run_until([&] { return error_count > 0; });
         CHECK(session->is_in_error_state());
     }
-#endif
 
     // TODO: write a test that logs out a Realm with multiple sessions, then logs it back in?
 }


### PR DESCRIPTION
Fixes #178, fixes #244
Depends upon: #241 (otherwise the tests will still sporadically fail)
@bdash 

Changes:
- Replaced use of blocking waiter APIs with their new async variants
- Updated tests
- Test resetter now clears sessions between test runs