### PR TITLE
Validate primary column uniqueness if migration function is not specified

### DIFF
--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -647,6 +647,7 @@ void ObjectStore::apply_schema_changes(Group& group, Schema& schema, uint64_t& s
     }
     else {
         apply_post_migration_changes(group, changes, {});
+        validate_primary_column_uniqueness(group);
     }
 
     set_schema_version(group, target_schema_version);


### PR DESCRIPTION
This PR is related to the second issue in https://github.com/realm/realm-cocoa/issues/4370: in case if the migration function is not specified the validation of the primary column should still be performed.

/cc @bdash, @jpsim 