### PR TITLE
Copy property values when migrating from optional to required property

### DIFF
--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -182,6 +182,7 @@ void make_property_required(Group& group, Table& table, Property property)
 {
     property.is_nullable = false;
     insert_column(group, table, property, property.table_column);
+    copy_property_values(property, table);
     table.remove_column(property.table_column + 1);
 }
 

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -455,7 +455,7 @@ TEST_CASE("migration: Automatic") {
                 REQUIRE(table->get_int(0, i) == i);
         }
 
-        SECTION("values for nullable properties are discarded when converitng to required") {
+        SECTION("non-null values for nullable properties are not discarded when converitng to required") {
             Schema schema = {
                 {"object", {
                     {"value", PropertyType::Int, "", "", false, false, true},
@@ -473,7 +473,7 @@ TEST_CASE("migration: Automatic") {
 
             realm->update_schema(set_optional(schema, "object", "value", false), 2);
             for (size_t i = 0; i < 10; ++i)
-                REQUIRE(table->get_int(0, i) == 0);
+                REQUIRE(table->get_int(0, i) == i);
         }
 
         SECTION("deleting table removed from the schema deletes it") {


### PR DESCRIPTION
This PR is addressed to the first issue in https://github.com/realm/realm-cocoa/issues/4370.

To me it seems that `non-null` values could be copied automatically while migrating from optional to required property. It allows users to not specify the migration block for this type of migrations in case if no `null` values exist in a table.

In case if there are any `null` values before the migration the `Attempted to insert null into non-nullable column` exception is generated, that will cause the user to setup migration block manually.

Another improvement that can be done here is addressed in https://github.com/realm/realm-cocoa/issues/1793, but it's not a part of this PR.

The test that checks that an exception is thrown when copying `null` value shout be added here as well.

/cc @jpsim, @bdash, @tgoyne 