### PR TITLE
Fix a LogicError(bad_version) error on refresh()

### DIFF
--- a/src/impl/collection_notifier.cpp
+++ b/src/impl/collection_notifier.cpp
@@ -429,8 +429,10 @@ void NotifierPackage::package_and_wait(util::Optional<VersionID::version_type> t
         return true;
     };
     m_notifiers.erase(std::remove_if(begin(m_notifiers), end(m_notifiers), package), end(m_notifiers));
-    if (m_version && target_version && m_version->version < *target_version)
+    if (m_version && target_version && m_version->version < *target_version) {
         m_notifiers.clear();
+        m_version = util::none;
+    }
     REALM_ASSERT(m_version || m_notifiers.empty());
 
     m_coordinator = nullptr;


### PR DESCRIPTION
refresh() and begin_write() don't block for notifiers if the notifiers exist only for implict async queries and there are no callbacks, which means that the Realm can get ahead of the notifier version. When this happened, it was still trying to advance to the notifier version even though nothing from that notifier would be delivered and the advance would fail due to it being an older version.

Probably is the issue reported at https://github.com/realm/realm-cocoa/issues/4345.