### PR TITLE
Add more validation for Realm Config parameters

### DIFF
--- a/src/sync/impl/sync_metadata.cpp
+++ b/src/sync/impl/sync_metadata.cpp
@@ -44,30 +44,28 @@ SyncMetadataManager::SyncMetadataManager(std::string path,
 {
     std::lock_guard<std::mutex> lock(m_metadata_lock);
 
-    auto nullable_string_property = [](std::string name)->Property {
-        Property p = { name, PropertyType::String };
+    auto nullable_string_property = [](const char *name) -> Property {
+        Property p = {name, PropertyType::String};
         p.is_nullable = true;
         return p;
     };
 
-    Property primary_key = { c_sync_identity, PropertyType::String };
+    Property primary_key = {c_sync_identity, PropertyType::String};
     primary_key.is_indexed = true;
     primary_key.is_primary = true;
 
     Realm::Config config;
     config.path = std::move(path);
-    Schema schema = {
-        { c_sync_userMetadata,
-            {
-                primary_key,
-                { c_sync_marked_for_removal, PropertyType::Bool },
-                nullable_string_property(c_sync_auth_server_url),
-                nullable_string_property(c_sync_user_token),
-            }
-        }
+    config.schema = Schema{
+        {c_sync_userMetadata, {
+            primary_key,
+            {c_sync_marked_for_removal, PropertyType::Bool},
+            nullable_string_property(c_sync_auth_server_url),
+            nullable_string_property(c_sync_user_token),
+        }}
     };
-    config.schema = std::move(schema);
     config.schema_mode = SchemaMode::Additive;
+    config.schema_version = 0;
 #if REALM_PLATFORM_APPLE
     if (should_encrypt && !encryption_key) {
         encryption_key = keychain::metadata_realm_encryption_key();

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -55,6 +55,30 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
         REQUIRE(realm1.get() != realm2.get());
     }
 
+    SECTION("should validate that the config is sensible") {
+        SECTION("bad encryption key") {
+            config.encryption_key = std::vector<char>(2, 0);
+            REQUIRE_THROWS(Realm::get_shared_realm(config));
+        }
+
+        SECTION("schema without schema version") {
+            config.schema_version = ObjectStore::NotVersioned;
+            REQUIRE_THROWS(Realm::get_shared_realm(config));
+        }
+
+        SECTION("migration function for read-only") {
+            config.schema_mode = SchemaMode::ReadOnly;
+            config.migration_function = [](auto, auto, auto) { };
+            REQUIRE_THROWS(Realm::get_shared_realm(config));
+        }
+
+        SECTION("migration function for additive-only") {
+            config.schema_mode = SchemaMode::Additive;
+            config.migration_function = [](auto, auto, auto) { };
+            REQUIRE_THROWS(Realm::get_shared_realm(config));
+        }
+    }
+
     SECTION("should reject mismatched config") {
         config.cache = false;
 
@@ -62,6 +86,8 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
             auto realm = Realm::get_shared_realm(config);
             config.schema_version = 2;
             REQUIRE_THROWS(Realm::get_shared_realm(config));
+
+            config.schema = util::none;
             config.schema_version = ObjectStore::NotVersioned;
             REQUIRE_NOTHROW(Realm::get_shared_realm(config));
         }

--- a/tests/util/test_file.cpp
+++ b/tests/util/test_file.cpp
@@ -56,6 +56,8 @@ TestFile::TestFile()
     path = tmpdir + "/realm.XXXXXX";
     mktemp(&path[0]);
     unlink(path.c_str());
+
+    schema_version = 0;
 }
 
 TestFile::~TestFile()


### PR DESCRIPTION
Reject a few more cases such as supplying a schema without a schema version or a migration function in a schema mode that doesn't do migrations.

Closes #249.