### PR TITLE
[WIP] Allow sync file manager to act on “client reset” file actions

### DIFF
--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -184,16 +184,17 @@ std::string file_path_by_appending_extension(const std::string& path, const std:
 
 constexpr const char SyncFileManager::c_sync_directory[];
 constexpr const char SyncFileManager::c_utility_directory[];
+constexpr const char SyncFileManager::c_recovery_directory[];
 constexpr const char SyncFileManager::c_metadata_directory[];
 constexpr const char SyncFileManager::c_metadata_realm[];
 
-std::string SyncFileManager::get_utility_directory() const
+std::string SyncFileManager::get_special_directory(std::string directory_name) const
 {
-    auto util_path = file_path_by_appending_component(get_base_sync_directory(),
-                                                      c_utility_directory,
-                                                      util::FilePathType::Directory);
-    util::try_make_dir(util_path);
-    return util_path;
+    auto dir_path = file_path_by_appending_component(get_base_sync_directory(),
+                                                     directory_name,
+                                                     util::FilePathType::Directory);
+    util::try_make_dir(dir_path);
+    return dir_path;
 }
 
 std::string SyncFileManager::get_base_sync_directory() const
@@ -230,23 +231,17 @@ void SyncFileManager::remove_user_directory(const std::string& user_identity) co
     util::remove_nonempty_dir(user_path);
 }
 
-bool SyncFileManager::remove_realm(const std::string& user_identity, const std::string& raw_realm_path) const
+bool SyncFileManager::remove_realm(const std::string& absolute_path) const
 {
-    REALM_ASSERT(user_identity.length() > 0);
-    REALM_ASSERT(raw_realm_path.length() > 0);
-    if (filename_is_reserved(user_identity) || filename_is_reserved(raw_realm_path)) {
-        throw std::invalid_argument("A user or Realm can't have an identifier reserved by the filesystem.");
-    }
-    auto escaped = util::make_percent_encoded_string(raw_realm_path);
-    auto realm_path = util::file_path_by_appending_component(user_directory(user_identity), escaped);
+    REALM_ASSERT(absolute_path.length() > 0);
     bool success = true;
     // Remove the base Realm file (e.g. "example.realm").
-    success = File::try_remove(realm_path);
+    success = File::try_remove(absolute_path);
     // Remove the lock file (e.g. "example.realm.lock").
-    auto lock_path = util::file_path_by_appending_extension(realm_path, "lock");
+    auto lock_path = util::file_path_by_appending_extension(absolute_path, "lock");
     success = File::try_remove(lock_path);
     // Remove the management directory (e.g. "example.realm.management").
-    auto management_path = util::file_path_by_appending_extension(realm_path, "management");
+    auto management_path = util::file_path_by_appending_extension(absolute_path, "management");
     try {
         util::remove_nonempty_dir(management_path);
     }
@@ -256,6 +251,36 @@ bool SyncFileManager::remove_realm(const std::string& user_identity, const std::
         success = false;
     }
     return success;
+}
+
+bool SyncFileManager::copy_realm_file_to_recovery_directory(const std::string& absolute_path, const std::string& new_name) const
+{
+    REALM_ASSERT(absolute_path.length() > 0);
+    try {
+        auto new_path = util::file_path_by_appending_component(recovery_directory_path(), new_name);
+        if (File::exists(new_path)) {
+            return false;
+        }
+        File::copy(absolute_path, std::move(new_path));
+    } 
+    catch (File::NotFound const&) {
+    }
+    catch (File::AccessError const&) {
+        return false;
+    }
+    return true;
+}
+
+bool SyncFileManager::remove_realm(const std::string& user_identity, const std::string& raw_realm_path) const
+{
+    REALM_ASSERT(user_identity.length() > 0);
+    REALM_ASSERT(raw_realm_path.length() > 0);
+    if (filename_is_reserved(user_identity) || filename_is_reserved(raw_realm_path)) {
+        throw std::invalid_argument("A user or Realm can't have an identifier reserved by the filesystem.");
+    }
+    auto escaped = util::make_percent_encoded_string(raw_realm_path);
+    auto realm_path = util::file_path_by_appending_component(user_directory(user_identity), escaped);
+    return remove_realm(realm_path);
 }
 
 std::string SyncFileManager::path(const std::string& user_identity, const std::string& raw_realm_path) const

--- a/src/sync/impl/sync_file.hpp
+++ b/src/sync/impl/sync_file.hpp
@@ -66,14 +66,27 @@ public:
     /// Remove the Realm at a given path for a given user. Returns `true` if the remove operation fully succeeds.
     bool remove_realm(const std::string& user_identity, const std::string& raw_realm_path) const;
 
+    /// Remove the Realm whose primary Realm file is located at `absolute_path`. Returns `true` if the remove
+    /// operation fully succeeds.
+    bool remove_realm(const std::string& absolute_path) const;
+
+    /// Copy the Realm file at `absolute_path` to the recovery directory, with the specified `new_name`.
+    bool copy_realm_file_to_recovery_directory(const std::string& absolute_path, const std::string& new_name) const;
+
     /// Return the path for the metadata Realm files.
     std::string metadata_path() const;
 
     /// Remove the metadata Realm.
     bool remove_metadata_realm() const;
 
-    const std::string& base_path() const {
+    const std::string& base_path() const
+    {
         return m_base_path;
+    }
+
+    std::string recovery_directory_path() const
+    {
+        return get_special_directory(c_recovery_directory);
     }
 
 private:
@@ -81,10 +94,17 @@ private:
 
     static constexpr const char c_sync_directory[] = "realm-object-server";
     static constexpr const char c_utility_directory[] = "io.realm.object-server-utility";
+    static constexpr const char c_recovery_directory[] = "io.realm.object-server-recovered-realms";
     static constexpr const char c_metadata_directory[] = "metadata";
     static constexpr const char c_metadata_realm[] = "sync_metadata.realm";
 
-    std::string get_utility_directory() const;
+    std::string get_special_directory(std::string directory_name) const;
+
+    std::string get_utility_directory() const
+    {
+        return get_special_directory(c_utility_directory);
+    }
+
     std::string get_base_sync_directory() const;
 };
 

--- a/src/sync/impl/sync_metadata.cpp
+++ b/src/sync/impl/sync_metadata.cpp
@@ -43,7 +43,6 @@ static const char * const c_sync_original_name = "original_name";
 static const char * const c_sync_new_name = "new_name";
 static const char * const c_sync_action = "action";
 static const char * const c_sync_url = "url";
-static const char * const c_sync_is_custom_file_path = "is_custom_file_path";
 
 
 SyncMetadataManager::SyncMetadataManager(std::string path,
@@ -78,7 +77,6 @@ SyncMetadataManager::SyncMetadataManager(std::string path,
             make_primary_key_property(c_sync_original_name),
             {c_sync_action, PropertyType::Int},
             make_nullable_string_property(c_sync_new_name),
-            {c_sync_is_custom_file_path, PropertyType::Bool},
             {c_sync_url, PropertyType::String},
             {c_sync_identity, PropertyType::String},
         }},
@@ -115,7 +113,6 @@ SyncMetadataManager::SyncMetadataManager(std::string path,
         descriptor->get_column_index(c_sync_original_name),
         descriptor->get_column_index(c_sync_new_name),
         descriptor->get_column_index(c_sync_action),
-        descriptor->get_column_index(c_sync_is_custom_file_path),
         descriptor->get_column_index(c_sync_url),
         descriptor->get_column_index(c_sync_identity)
     };
@@ -273,7 +270,6 @@ SyncFileActionMetadata::SyncFileActionMetadata(const SyncMetadataManager& manage
                                                std::string original_name,
                                                std::string url,
                                                std::string user_identity,
-                                               bool is_custom_file_path,
                                                util::Optional<std::string> new_name)
 : m_schema(manager.m_file_action_schema)
 {
@@ -294,7 +290,6 @@ SyncFileActionMetadata::SyncFileActionMetadata(const SyncMetadataManager& manage
     table->set_int(m_schema.idx_action, row_idx, raw_action);
     table->set_string(m_schema.idx_url, row_idx, url);
     table->set_string(m_schema.idx_user_identity, row_idx, user_identity);
-    table->set_bool(m_schema.idx_is_custom_file_path, row_idx, is_custom_file_path);
     m_realm->commit_transaction();
     m_row = table->get(row_idx);
 }
@@ -334,12 +329,6 @@ std::string SyncFileActionMetadata::user_identity() const
 {
     m_realm->verify_thread();
     return m_row.get_string(m_schema.idx_user_identity);
-}
-
-bool SyncFileActionMetadata::is_custom_file_path() const
-{
-    m_realm->verify_thread();
-    return m_row.get_bool(m_schema.idx_is_custom_file_path);
 }
 
 void SyncFileActionMetadata::remove()

--- a/src/sync/impl/sync_metadata.cpp
+++ b/src/sync/impl/sync_metadata.cpp
@@ -38,31 +38,50 @@ static const char * const c_sync_identity = "identity";
 static const char * const c_sync_auth_server_url = "auth_server_url";
 static const char * const c_sync_user_token = "user_token";
 
+static const char * const c_sync_fileActionMetadata = "FileActionMetadata";
+static const char * const c_sync_original_name = "original_name";
+static const char * const c_sync_new_name = "new_name";
+static const char * const c_sync_action = "action";
+static const char * const c_sync_url = "url";
+static const char * const c_sync_is_custom_file_path = "is_custom_file_path";
+
+
 SyncMetadataManager::SyncMetadataManager(std::string path,
                                          bool should_encrypt,
                                          util::Optional<std::vector<char>> encryption_key)
 {
     std::lock_guard<std::mutex> lock(m_metadata_lock);
 
-    auto nullable_string_property = [](const char *name) -> Property {
+    auto make_nullable_string_property = [](const char *name) -> Property {
         Property p = {name, PropertyType::String};
         p.is_nullable = true;
         return p;
     };
 
-    Property primary_key = {c_sync_identity, PropertyType::String};
-    primary_key.is_indexed = true;
-    primary_key.is_primary = true;
+    auto make_primary_key_property = [](const char *name) -> Property {
+        Property p = {name, PropertyType::String};
+        p.is_indexed = true;
+        p.is_primary = true;
+        return p;
+    };
 
     Realm::Config config;
     config.path = std::move(path);
     config.schema = Schema{
         {c_sync_userMetadata, {
-            primary_key,
+            make_primary_key_property(c_sync_identity),
             {c_sync_marked_for_removal, PropertyType::Bool},
-            nullable_string_property(c_sync_auth_server_url),
-            nullable_string_property(c_sync_user_token),
-        }}
+            make_nullable_string_property(c_sync_auth_server_url),
+            make_nullable_string_property(c_sync_user_token),
+        }},
+        {c_sync_fileActionMetadata, {
+            make_primary_key_property(c_sync_original_name),
+            {c_sync_action, PropertyType::Int},
+            make_nullable_string_property(c_sync_new_name),
+            {c_sync_is_custom_file_path, PropertyType::Bool},
+            {c_sync_url, PropertyType::String},
+            {c_sync_identity, PropertyType::String},
+        }},
     };
     config.schema_mode = SchemaMode::Additive;
     config.schema_version = 0;
@@ -81,14 +100,24 @@ SyncMetadataManager::SyncMetadataManager(std::string path,
     // Open the Realm.
     SharedRealm realm = Realm::get_shared_realm(config);
 
-    // Get data about the (hardcoded) schema.
+    // Get data about the (hardcoded) schemas.
     DescriptorRef descriptor = ObjectStore::table_for_object_type(realm->read_group(),
                                                                   c_sync_userMetadata)->get_descriptor();
-    m_schema = {
+    m_user_schema = {
         descriptor->get_column_index(c_sync_identity),
         descriptor->get_column_index(c_sync_marked_for_removal),
         descriptor->get_column_index(c_sync_user_token),
         descriptor->get_column_index(c_sync_auth_server_url)
+    };
+
+    descriptor = ObjectStore::table_for_object_type(realm->read_group(), c_sync_fileActionMetadata)->get_descriptor();
+    m_file_action_schema = {
+        descriptor->get_column_index(c_sync_original_name),
+        descriptor->get_column_index(c_sync_new_name),
+        descriptor->get_column_index(c_sync_action),
+        descriptor->get_column_index(c_sync_is_custom_file_path),
+        descriptor->get_column_index(c_sync_url),
+        descriptor->get_column_index(c_sync_identity)
     };
 
     m_metadata_config = std::move(config);
@@ -116,10 +145,18 @@ SyncUserMetadataResults SyncMetadataManager::get_users(bool marked) const
     SharedRealm realm = Realm::get_shared_realm(get_configuration());
 
     TableRef table = ObjectStore::table_for_object_type(realm->read_group(), c_sync_userMetadata);
-    Query query = table->where().equal(m_schema.idx_marked_for_removal, marked);
+    Query query = table->where().equal(m_user_schema.idx_marked_for_removal, marked);
 
     Results results(realm, std::move(query));
-    return SyncUserMetadataResults(std::move(results), std::move(realm), m_schema);
+    return SyncUserMetadataResults(std::move(results), std::move(realm), m_user_schema);
+}
+
+SyncFileActionMetadataResults SyncMetadataManager::all_pending_actions() const
+{
+    SharedRealm realm = Realm::get_shared_realm(get_configuration());
+    TableRef table = ObjectStore::table_for_object_type(realm->read_group(), c_sync_fileActionMetadata);
+    Results results(realm, table->where());
+    return SyncFileActionMetadataResults(std::move(results), std::move(realm), m_file_action_schema);
 }
 
 SyncUserMetadata::SyncUserMetadata(Schema schema, SharedRealm realm, RowExpr row)
@@ -130,7 +167,7 @@ SyncUserMetadata::SyncUserMetadata(Schema schema, SharedRealm realm, RowExpr row
 { }
 
 SyncUserMetadata::SyncUserMetadata(const SyncMetadataManager& manager, std::string identity, bool make_if_absent)
-: m_schema(manager.m_schema)
+: m_schema(manager.m_user_schema)
 {
     // Open the Realm.
     m_realm = Realm::get_shared_realm(manager.get_configuration());
@@ -225,6 +262,91 @@ void SyncUserMetadata::remove()
     m_invalid = true;
     m_realm->begin_transaction();
     TableRef table = ObjectStore::table_for_object_type(m_realm->read_group(), c_sync_userMetadata);
+    table->move_last_over(m_row.get_index());
+    m_realm->commit_transaction();
+    m_realm = nullptr;
+}
+
+
+SyncFileActionMetadata::SyncFileActionMetadata(const SyncMetadataManager& manager,
+                                               Action action,
+                                               std::string original_name,
+                                               std::string url,
+                                               std::string user_identity,
+                                               bool is_custom_file_path,
+                                               util::Optional<std::string> new_name)
+: m_schema(manager.m_file_action_schema)
+{
+    size_t raw_action = static_cast<size_t>(action);
+
+    // Open the Realm.
+    m_realm = Realm::get_shared_realm(manager.get_configuration());
+
+    // Retrieve or create the row for this object.
+    TableRef table = ObjectStore::table_for_object_type(m_realm->read_group(), c_sync_fileActionMetadata);
+    m_realm->begin_transaction();
+    size_t row_idx = table->find_first_string(m_schema.idx_original_name, original_name);
+    if (row_idx == not_found) {
+        row_idx = table->add_empty_row();
+        table->set_string(m_schema.idx_original_name, row_idx, original_name);
+    }
+    table->set_string(m_schema.idx_new_name, row_idx, new_name);
+    table->set_int(m_schema.idx_action, row_idx, raw_action);
+    table->set_string(m_schema.idx_url, row_idx, url);
+    table->set_string(m_schema.idx_user_identity, row_idx, user_identity);
+    table->set_bool(m_schema.idx_is_custom_file_path, row_idx, is_custom_file_path);
+    m_realm->commit_transaction();
+    m_row = table->get(row_idx);
+}
+
+SyncFileActionMetadata::SyncFileActionMetadata(Schema schema, SharedRealm realm, RowExpr row)
+: m_schema(std::move(schema))
+, m_realm(std::move(realm))
+, m_row(row)
+{ }
+
+std::string SyncFileActionMetadata::original_name() const
+{
+    m_realm->verify_thread();
+    return m_row.get_string(m_schema.idx_original_name);
+}
+
+util::Optional<std::string> SyncFileActionMetadata::new_name() const
+{
+    m_realm->verify_thread();
+    StringData result = m_row.get_string(m_schema.idx_new_name);
+    return result.is_null() ? util::none : util::make_optional(std::string(result));
+}
+
+SyncFileActionMetadata::Action SyncFileActionMetadata::action() const
+{
+    m_realm->verify_thread();
+    return static_cast<SyncFileActionMetadata::Action>(m_row.get_int(m_schema.idx_action));
+}
+
+std::string SyncFileActionMetadata::url() const
+{
+    m_realm->verify_thread();
+    return m_row.get_string(m_schema.idx_url);
+}
+
+std::string SyncFileActionMetadata::user_identity() const
+{
+    m_realm->verify_thread();
+    return m_row.get_string(m_schema.idx_user_identity);
+}
+
+bool SyncFileActionMetadata::is_custom_file_path() const
+{
+    m_realm->verify_thread();
+    return m_row.get_bool(m_schema.idx_is_custom_file_path);
+}
+
+void SyncFileActionMetadata::remove()
+{
+    m_realm->verify_thread();
+    m_realm->begin_transaction();
+    TableRef table = ObjectStore::table_for_object_type(m_realm->read_group(), c_sync_fileActionMetadata);
     table->move_last_over(m_row.get_index());
     m_realm->commit_transaction();
     m_realm = nullptr;

--- a/src/sync/impl/sync_metadata.hpp
+++ b/src/sync/impl/sync_metadata.hpp
@@ -76,6 +76,51 @@ private:
     Row m_row;
 };
 
+class SyncFileActionMetadata {
+public:
+    struct Schema {
+        size_t idx_original_name;
+        size_t idx_new_name;
+        size_t idx_action;
+        size_t idx_is_custom_file_path;
+        size_t idx_url;
+        size_t idx_user_identity;
+    };
+
+    enum class Action {
+        // The Realm files at the given directory will be deleted.
+        DeleteRealm,
+        // The primary Realm file will be copied to a 'recovery' directory, and the original Realm files will be deleted.
+        HandleRealmForClientReset
+    };
+
+    // The absolute path to the file in question (if this is a Realm, this is the "primary" Realm file).
+    std::string original_name() const;
+    // The meaning of this parameter depends on the `Action` specified.
+    util::Optional<std::string> new_name() const;
+    Action action() const;
+    std::string url() const;
+    std::string user_identity() const;
+    bool is_custom_file_path() const;
+
+    // Remove the action from the metadata database, because it was completed or is now invalid.
+    void remove();
+
+    SyncFileActionMetadata(const SyncMetadataManager& manager,
+                           Action action,
+                           std::string original_name,
+                           std::string url,
+                           std::string user_identity,
+                           bool is_custom_file_path=false,
+                           util::Optional<std::string> new_name=none);
+
+    SyncFileActionMetadata(Schema schema, SharedRealm realm, RowExpr row);
+private:
+    Schema m_schema;
+    SharedRealm m_realm;
+    Row m_row;
+};
+
 template<class T>
 class SyncMetadataResults {
 public:
@@ -102,9 +147,11 @@ private:
     mutable Results m_results;
 };
 using SyncUserMetadataResults = SyncMetadataResults<SyncUserMetadata>;
+using SyncFileActionMetadataResults = SyncMetadataResults<SyncFileActionMetadata>;
 
 class SyncMetadataManager {
 friend class SyncUserMetadata;
+friend class SyncFileActionMetadata;
 public:
     // Return a Results object containing all users not marked for removal.
     SyncUserMetadataResults all_unmarked_users() const;
@@ -113,6 +160,9 @@ public:
     // `remove()` on each user to actually remove it from the database. (This is so that already-open Realm files can be
     // safely cleaned up the next time the host is launched.)
     SyncUserMetadataResults all_users_marked_for_removal() const;
+
+    // Return a Results object containing all pending actions.
+    SyncFileActionMetadataResults all_pending_actions() const;
 
     Realm::Config get_configuration() const;
 
@@ -131,7 +181,8 @@ private:
 
     Realm::Config m_metadata_config;
 
-    SyncUserMetadata::Schema m_schema;
+    SyncUserMetadata::Schema m_user_schema;
+    SyncFileActionMetadata::Schema m_file_action_schema;
     mutable std::mutex m_metadata_lock;
 };
 

--- a/src/sync/impl/sync_metadata.hpp
+++ b/src/sync/impl/sync_metadata.hpp
@@ -82,7 +82,6 @@ public:
         size_t idx_original_name;
         size_t idx_new_name;
         size_t idx_action;
-        size_t idx_is_custom_file_path;
         size_t idx_url;
         size_t idx_user_identity;
     };
@@ -101,7 +100,6 @@ public:
     Action action() const;
     std::string url() const;
     std::string user_identity() const;
-    bool is_custom_file_path() const;
 
     // Remove the action from the metadata database, because it was completed or is now invalid.
     void remove();
@@ -111,7 +109,6 @@ public:
                            std::string original_name,
                            std::string url,
                            std::string user_identity,
-                           bool is_custom_file_path=false,
                            util::Optional<std::string> new_name=none);
 
     SyncFileActionMetadata(Schema schema, SharedRealm realm, RowExpr row);

--- a/src/sync/sync_config.hpp
+++ b/src/sync/sync_config.hpp
@@ -28,6 +28,8 @@
 #include <string>
 #include <system_error>
 
+#include <realm/util/optional.hpp>
+
 namespace realm {
 
 class SyncUser;
@@ -82,6 +84,7 @@ struct SyncConfig {
     SyncSessionStopPolicy stop_policy;
     std::function<SyncBindSessionHandler> bind_session_handler;
     std::function<SyncSessionErrorHandler> error_handler;
+    util::Optional<std::string> custom_realm_path=none;
 };
 
 } // namespace realm

--- a/src/sync/sync_config.hpp
+++ b/src/sync/sync_config.hpp
@@ -28,8 +28,6 @@
 #include <string>
 #include <system_error>
 
-#include <realm/util/optional.hpp>
-
 namespace realm {
 
 class SyncUser;
@@ -76,6 +74,18 @@ struct SyncError {
         }
         return realm::sync::is_session_level_error(static_cast<ProtocolError>(error_code.value()));
     }
+
+    /// The error indicates a client reset situation.
+    bool is_client_reset_requested() const
+    {
+        if (error_code.category() != realm::sync::protocol_error_category()) {
+            return false;
+        }
+        // TODO: any other error codes that indicate client reset?
+        return (error_code == ProtocolError::bad_server_file_ident
+                || error_code == ProtocolError::bad_server_version
+                || error_code == ProtocolError::diverging_histories);
+    }
 };
 
 struct SyncConfig {
@@ -84,7 +94,6 @@ struct SyncConfig {
     SyncSessionStopPolicy stop_policy;
     std::function<SyncBindSessionHandler> bind_session_handler;
     std::function<SyncSessionErrorHandler> error_handler;
-    util::Optional<std::string> custom_realm_path=none;
 };
 
 } // namespace realm

--- a/src/sync/sync_config.hpp
+++ b/src/sync/sync_config.hpp
@@ -27,6 +27,7 @@
 #include <memory>
 #include <string>
 #include <system_error>
+#include <unordered_map>
 
 namespace realm {
 
@@ -50,6 +51,10 @@ struct SyncError {
     std::error_code error_code;
     std::string message;
     bool is_fatal;
+    std::unordered_map<std::string, std::string> user_info;
+
+    static constexpr const char c_original_file_path_key[] = "ORIGINAL_FILE_PATH";
+    static constexpr const char c_recovery_file_path_key[] = "RECOVERY_FILE_PATH";
 
     /// The error is a client error, which applies to the client and all its sessions.
     bool is_client_error() const

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -154,6 +154,34 @@ void SyncManager::configure_file_system(const std::string& base_file_path,
     }
 }
 
+bool SyncManager::immediately_run_file_actions(const std::string& realm_path)
+{
+    SyncFileActionMetadataResults file_actions = m_metadata_manager->all_pending_actions();
+    for (size_t i = 0; i < file_actions.size(); i++) {
+        SyncFileActionMetadata file_action = file_actions.get(i);
+        if (file_action.original_name() != realm_path) {
+            continue;
+        }
+        switch (file_action.action()) {
+            case SyncFileActionMetadata::Action::DeleteRealm:
+                // Delete all the files for the given Realm.
+                m_file_manager->remove_realm(file_action.original_name());
+                file_action.remove();
+                return true;
+            case SyncFileActionMetadata::Action::HandleRealmForClientReset:
+                // Copy the primary Realm file to the recovery dir, and then delete the Realm.
+                auto new_name = file_action.new_name();
+                if (new_name && m_file_manager->copy_realm_file_to_recovery_directory(file_action.original_name(), *new_name)) {
+                    m_file_manager->remove_realm(file_action.original_name());
+                    file_action.remove();
+                    return true;
+                }
+                break;
+        }
+    }
+    return false;
+}
+
 void SyncManager::reset_for_testing()
 {
     std::lock_guard<std::mutex> lock(m_file_system_mutex);

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -69,6 +69,12 @@ public:
                                util::Optional<std::vector<char>> custom_encryption_key=none,
                                bool reset_metadata_on_error=false);
 
+    // Immediately run file actions for a single Realm at a given original path.
+    // Returns whether or not a file action was successfully executed for the specified Realm.
+    // Preconditions: all references to the Realm at the given path must have already been invalidated.
+    // The metadata and file management subsystems must also have already been configured.
+    bool immediately_run_file_actions(const std::string& original_name);
+
     void set_log_level(util::Logger::Level) noexcept;
     void set_logger_factory(SyncLoggerFactory&) noexcept;
 

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -19,11 +19,15 @@
 #include "sync/sync_session.hpp"
 
 #include "sync/impl/sync_client.hpp"
+#include "sync/impl/sync_file.hpp"
+#include "sync/impl/sync_metadata.hpp"
 #include "sync/sync_manager.hpp"
 #include "sync/sync_user.hpp"
 
 #include <realm/sync/client.hpp>
 #include <realm/sync/protocol.hpp>
+
+#include <chrono>
 
 using namespace realm;
 using namespace realm::_impl;
@@ -288,9 +292,17 @@ void SyncSession::create_sync_session()
     REALM_ASSERT(!m_session);
     m_session = std::make_unique<sync::Session>(m_client.client, m_realm_path);
 
+    // Constants for client reset error case.
+    const std::string user_identity = m_config.user->identity();
+    const std::string new_path = util::make_percent_encoded_string(user_identity + "_" + m_config.realm_url + "_");
+
     // Set up the wrapped handler
     std::weak_ptr<SyncSession> weak_self = shared_from_this();
-    auto wrapped_handler = [this, weak_self](std::error_code error_code, bool is_fatal, std::string message) {
+    auto wrapped_handler = [this, weak_self,
+                            custom_realm_path=m_config.custom_realm_path,
+                            realm_url=m_config.realm_url,
+                            user_identity=std::move(user_identity),
+                            new_path=std::move(new_path)](std::error_code error_code, bool is_fatal, std::string message) {
         auto self = weak_self.lock();
         if (!self) {
             // An error was delivered after the session it relates to was destroyed. There's nothing useful
@@ -351,7 +363,26 @@ void SyncSession::create_sync_session()
                 case ProtocolError::bad_client_file_ident:
                 case ProtocolError::bad_server_version:
                 case ProtocolError::bad_client_version:
+                    break;
                 case ProtocolError::diverging_histories:
+                    // TODO: need to handle this for other errors, not just this one
+                    // TODO: need to prompt user for recovery, not just do it automatically
+                    // Add a SyncFileActionMetadata marking the Realm as needing to be deleted on next app launch.
+                    error_type = SyncSessionError::ClientReset;
+                    SyncManager::shared().perform_metadata_update([this, custom_realm_path=std::move(custom_realm_path),
+                                                                   user_identity=std::move(user_identity),
+                                                                   realm_url=std::move(realm_url),
+                                                                   new_path=std::move(new_path)](const SyncMetadataManager& manager) {
+                        auto full_name = new_path + to_string(std::chrono::duration_cast<std::chrono::seconds>(std::chrono::system_clock::now().time_since_epoch()).count());
+                        SyncFileActionMetadata(manager,
+                                               SyncFileActionMetadata::Action::HandleRealmForClientReset,
+                                               custom_realm_path.value_or(SyncManager::shared().path_for_realm(user_identity, realm_url)),
+                                               m_config.realm_url,
+                                               m_config.user->identity(),
+                                               bool(custom_realm_path),
+                                               util::Optional<std::string>(std::move(full_name)));
+                    });
+                    break;
                 case ProtocolError::bad_changeset:
                     break;
             }

--- a/tests/sync/metadata.cpp
+++ b/tests/sync/metadata.cpp
@@ -24,6 +24,7 @@
 using namespace realm;
 using namespace realm::util;
 using File = realm::util::File;
+using SyncAction = SyncFileActionMetadata::Action;
 
 static const std::string base_path = tmp_dir() + "/realm_objectstore_sync_metadata/";
 static const std::string metadata_path = base_path + "/metadata.realm";
@@ -155,6 +156,73 @@ TEST_CASE("sync_metadata: user metadata APIs", "[sync]") {
         REQUIRE(marked_users.size() == 2);
         REQUIRE(results_contains_user(marked_users, identity1));
         REQUIRE(results_contains_user(marked_users, identity3));
+    }
+}
+
+TEST_CASE("sync_metadata: file action metadata", "[sync]") {
+    reset_test_directory(base_path);
+    SyncMetadataManager manager(metadata_path, false);
+
+    const std::string identity_1 = "asdfg";
+    const std::string identity_2 = "qwerty";
+    const std::string url_1 = "realm://realm.example.com/1";
+    const std::string url_2 = "realm://realm.example.com/2";
+
+    SECTION("can be properly constructed") {
+        const auto original_name = "/tmp/foobar/test1";
+        auto user_metadata = SyncFileActionMetadata(manager, SyncAction::HandleRealmForClientReset, original_name, url_1, identity_1, true);
+        REQUIRE(user_metadata.original_name() == original_name);
+        REQUIRE(user_metadata.new_name() == none);
+        REQUIRE(user_metadata.action() == SyncAction::HandleRealmForClientReset);
+        REQUIRE(user_metadata.url() == url_1);
+        REQUIRE(user_metadata.user_identity() == identity_1);
+        REQUIRE(user_metadata.is_custom_file_path());
+    }
+
+    SECTION("properly reflects updating state, across multiple instances") {
+        const auto original_name = "/tmp/foobar/test2a";
+        const std::string new_name_1 = "/tmp/foobar/test2b";
+        const std::string new_name_2 = "/tmp/foobar/test2c";
+        auto user_metadata_1 = SyncFileActionMetadata(manager, SyncAction::HandleRealmForClientReset, original_name, url_1, identity_1, true, new_name_1);
+        REQUIRE(user_metadata_1.original_name() == original_name);
+        REQUIRE(user_metadata_1.new_name() == new_name_1);
+        REQUIRE(user_metadata_1.action() == SyncAction::HandleRealmForClientReset);
+        REQUIRE(user_metadata_1.url() == url_1);
+        REQUIRE(user_metadata_1.user_identity() == identity_1);
+        REQUIRE(user_metadata_1.is_custom_file_path());
+
+        auto user_metadata_2 = SyncFileActionMetadata(manager, SyncAction::DeleteRealm, original_name, url_2, identity_2, false,  new_name_2);
+        REQUIRE(user_metadata_1.original_name() == original_name);
+        REQUIRE(user_metadata_1.new_name() == new_name_2);
+        REQUIRE(user_metadata_1.action() == SyncAction::DeleteRealm);
+        REQUIRE(user_metadata_2.original_name() == original_name);
+        REQUIRE(user_metadata_2.new_name() == new_name_2);
+        REQUIRE(user_metadata_2.action() == SyncAction::DeleteRealm);
+        REQUIRE(user_metadata_1.url() == url_2);
+        REQUIRE(user_metadata_1.user_identity() == identity_2);
+        REQUIRE(!user_metadata_1.is_custom_file_path());
+    }
+}
+
+TEST_CASE("sync_metadata: file action metadata APIs", "[sync]") {
+    reset_test_directory(base_path);
+    SyncMetadataManager manager(metadata_path, false);
+    SECTION("properly list all pending actions, reflecting their deletion") {
+        const auto filename1 = "/tmp/foobar/file1";
+        const auto filename2 = "/tmp/foobar/file2";
+        const auto filename3 = "/tmp/foobar/file3";
+        auto first = SyncFileActionMetadata(manager, SyncAction::HandleRealmForClientReset, filename1, "asdf", "realm://realm.example.com/1");
+        auto second = SyncFileActionMetadata(manager, SyncAction::HandleRealmForClientReset, filename2, "asdf", "realm://realm.example.com/2");
+        auto third = SyncFileActionMetadata(manager, SyncAction::HandleRealmForClientReset, filename3, "asdf", "realm://realm.example.com/3");
+        auto actions = manager.all_pending_actions();
+        REQUIRE(actions.size() == 3);
+        REQUIRE(results_contains_original_name(actions, filename1));
+        REQUIRE(results_contains_original_name(actions, filename2));
+        REQUIRE(results_contains_original_name(actions, filename3));
+        first.remove();
+        second.remove();
+        third.remove();
+        REQUIRE(actions.size() == 0);
     }
 }
 

--- a/tests/sync/metadata.cpp
+++ b/tests/sync/metadata.cpp
@@ -170,28 +170,26 @@ TEST_CASE("sync_metadata: file action metadata", "[sync]") {
 
     SECTION("can be properly constructed") {
         const auto original_name = "/tmp/foobar/test1";
-        auto user_metadata = SyncFileActionMetadata(manager, SyncAction::HandleRealmForClientReset, original_name, url_1, identity_1, true);
+        auto user_metadata = SyncFileActionMetadata(manager, SyncAction::HandleRealmForClientReset, original_name, url_1, identity_1);
         REQUIRE(user_metadata.original_name() == original_name);
         REQUIRE(user_metadata.new_name() == none);
         REQUIRE(user_metadata.action() == SyncAction::HandleRealmForClientReset);
         REQUIRE(user_metadata.url() == url_1);
         REQUIRE(user_metadata.user_identity() == identity_1);
-        REQUIRE(user_metadata.is_custom_file_path());
     }
 
     SECTION("properly reflects updating state, across multiple instances") {
         const auto original_name = "/tmp/foobar/test2a";
         const std::string new_name_1 = "/tmp/foobar/test2b";
         const std::string new_name_2 = "/tmp/foobar/test2c";
-        auto user_metadata_1 = SyncFileActionMetadata(manager, SyncAction::HandleRealmForClientReset, original_name, url_1, identity_1, true, new_name_1);
+        auto user_metadata_1 = SyncFileActionMetadata(manager, SyncAction::HandleRealmForClientReset, original_name, url_1, identity_1, new_name_1);
         REQUIRE(user_metadata_1.original_name() == original_name);
         REQUIRE(user_metadata_1.new_name() == new_name_1);
         REQUIRE(user_metadata_1.action() == SyncAction::HandleRealmForClientReset);
         REQUIRE(user_metadata_1.url() == url_1);
         REQUIRE(user_metadata_1.user_identity() == identity_1);
-        REQUIRE(user_metadata_1.is_custom_file_path());
 
-        auto user_metadata_2 = SyncFileActionMetadata(manager, SyncAction::DeleteRealm, original_name, url_2, identity_2, false,  new_name_2);
+        auto user_metadata_2 = SyncFileActionMetadata(manager, SyncAction::DeleteRealm, original_name, url_2, identity_2, new_name_2);
         REQUIRE(user_metadata_1.original_name() == original_name);
         REQUIRE(user_metadata_1.new_name() == new_name_2);
         REQUIRE(user_metadata_1.action() == SyncAction::DeleteRealm);
@@ -200,7 +198,6 @@ TEST_CASE("sync_metadata: file action metadata", "[sync]") {
         REQUIRE(user_metadata_2.action() == SyncAction::DeleteRealm);
         REQUIRE(user_metadata_1.url() == url_2);
         REQUIRE(user_metadata_1.user_identity() == identity_2);
-        REQUIRE(!user_metadata_1.is_custom_file_path());
     }
 }
 

--- a/tests/sync/session.cpp
+++ b/tests/sync/session.cpp
@@ -270,4 +270,5 @@ TEST_CASE("sync: log-in", "[sync]") {
     }
 
     // TODO: write a test that logs out a Realm with multiple sessions, then logs it back in?
+    // TODO: write tests that check that a Session properly handles various types of errors reported via its callback.
 }

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -248,6 +248,154 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
     }
 }
 
+TEST_CASE("sync_manager: file actions", "[sync]") {
+    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
+    reset_test_directory(base_path);
+    auto file_manager = SyncFileManager(base_path);
+    // Open the metadata separately, so we can investigate it ourselves.
+    SyncMetadataManager manager(file_manager.metadata_path(), false);
+
+    const std::string realm_url = "https://example.realm.com/~/1";
+    const std::string identity_1 = "foo-1";
+    const std::string identity_2 = "bar-1";
+    const std::string identity_3 = "baz-1";
+
+    // Realm paths
+    const std::string realm_path_1 = file_manager.path(identity_1, realm_url);
+    const std::string realm_path_2 = file_manager.path(identity_2, realm_url);
+    const std::string realm_path_3 = file_manager.path(identity_3, realm_url);
+
+    SECTION("Action::DeleteRealm") {
+        // Create some file actions
+        auto a1 = SyncFileActionMetadata(manager, SyncFileActionMetadata::Action::DeleteRealm, realm_path_1, "user1", realm_url, false);
+        auto a2 = SyncFileActionMetadata(manager, SyncFileActionMetadata::Action::DeleteRealm, realm_path_2, "user2", realm_url, false);
+        auto a3 = SyncFileActionMetadata(manager, SyncFileActionMetadata::Action::DeleteRealm, realm_path_3, "user3", realm_url, false);
+
+        SECTION("should properly delete the Realm") {
+            // Create some Realms
+            create_dummy_realm(realm_path_1);
+            create_dummy_realm(realm_path_2);
+            create_dummy_realm(realm_path_3);
+            SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoEncryption);
+            // File actions should be cleared.
+            auto pending_actions = manager.all_pending_actions();
+            CHECK(pending_actions.size() == 0);
+            // All Realms should be deleted.
+            REQUIRE_REALM_DOES_NOT_EXIST(realm_path_1);
+            REQUIRE_REALM_DOES_NOT_EXIST(realm_path_2);
+            REQUIRE_REALM_DOES_NOT_EXIST(realm_path_3);
+        }
+
+        SECTION("should fail gracefully if the Realm is missing") {
+            // Don't actually create the Realm files
+            REQUIRE_REALM_DOES_NOT_EXIST(realm_path_1);
+            REQUIRE_REALM_DOES_NOT_EXIST(realm_path_2);
+            REQUIRE_REALM_DOES_NOT_EXIST(realm_path_3);
+            SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoEncryption);
+            auto pending_actions = manager.all_pending_actions();
+            CHECK(pending_actions.size() == 0);
+        }
+
+        SECTION("should do nothing if metadata is disabled") {
+            // Create some Realms
+            create_dummy_realm(realm_path_1);
+            create_dummy_realm(realm_path_2);
+            create_dummy_realm(realm_path_3);
+            SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoMetadata);
+            // All file actions should still be present.
+            auto pending_actions = manager.all_pending_actions();
+            CHECK(pending_actions.size() == 3);
+            // All Realms should still be present.
+            REQUIRE_REALM_EXISTS(realm_path_1);
+            REQUIRE_REALM_EXISTS(realm_path_2);
+            REQUIRE_REALM_EXISTS(realm_path_3);
+        }
+    }
+
+    SECTION("Action::HandleRealmForClientReset") {
+        // Create some file actions
+        const std::string recovery_1 = "recovery-1";
+        const std::string recovery_2 = "recovery-2";
+        const std::string recovery_3 = "recovery-3";
+        auto a1 = SyncFileActionMetadata(manager, SyncFileActionMetadata::Action::HandleRealmForClientReset, realm_path_1, "user1", realm_url, false, recovery_1);
+        auto a2 = SyncFileActionMetadata(manager, SyncFileActionMetadata::Action::HandleRealmForClientReset, realm_path_2, "user2", realm_url, false, recovery_2);
+        auto a3 = SyncFileActionMetadata(manager, SyncFileActionMetadata::Action::HandleRealmForClientReset, realm_path_3, "user3", realm_url, false, recovery_3);
+        const std::string recovery_dir = file_manager.recovery_directory_path();
+
+        SECTION("should properly copy the Realm file and delete the Realm") {
+            // Create some Realms
+            create_dummy_realm(realm_path_1);
+            create_dummy_realm(realm_path_2);
+            create_dummy_realm(realm_path_3);
+            SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoEncryption);
+            // File actions should be cleared.
+            auto pending_actions = manager.all_pending_actions();
+            CHECK(pending_actions.size() == 0);
+            // All Realms should be deleted.
+            REQUIRE_REALM_DOES_NOT_EXIST(realm_path_1);
+            REQUIRE_REALM_DOES_NOT_EXIST(realm_path_2);
+            REQUIRE_REALM_DOES_NOT_EXIST(realm_path_3);
+            // There should be recovery files.
+            CHECK(File::exists(util::file_path_by_appending_component(recovery_dir, recovery_1)));
+            CHECK(File::exists(util::file_path_by_appending_component(recovery_dir, recovery_2)));
+            CHECK(File::exists(util::file_path_by_appending_component(recovery_dir, recovery_3)));
+        }
+
+        SECTION("should fail gracefully if the Realm is missing") {
+            // Don't actually create the Realm files
+            REQUIRE_REALM_DOES_NOT_EXIST(realm_path_1);
+            REQUIRE_REALM_DOES_NOT_EXIST(realm_path_2);
+            REQUIRE_REALM_DOES_NOT_EXIST(realm_path_3);
+            SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoEncryption);
+            // File actions should be cleared.
+            auto pending_actions = manager.all_pending_actions();
+            CHECK(pending_actions.size() == 0);
+            // There should not be recovery files.
+            CHECK(!File::exists(util::file_path_by_appending_component(recovery_dir, recovery_1)));
+            CHECK(!File::exists(util::file_path_by_appending_component(recovery_dir, recovery_2)));
+            CHECK(!File::exists(util::file_path_by_appending_component(recovery_dir, recovery_3)));
+        }
+
+        SECTION("should fail gracefully if there is already a file at the destination") {
+            // Create some Realms
+            create_dummy_realm(realm_path_1);
+            create_dummy_realm(realm_path_2);
+            create_dummy_realm(realm_path_3);
+            create_dummy_realm(util::file_path_by_appending_component(recovery_dir, recovery_1));
+            SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoEncryption);
+            // Most file actions should be cleared.
+            auto pending_actions = manager.all_pending_actions();
+            CHECK(pending_actions.size() == 1);
+            // Realms should be deleted.
+            REQUIRE_REALM_EXISTS(realm_path_1);
+            REQUIRE_REALM_DOES_NOT_EXIST(realm_path_2);
+            REQUIRE_REALM_DOES_NOT_EXIST(realm_path_3);
+            // There should be recovery files.
+            CHECK(File::exists(util::file_path_by_appending_component(recovery_dir, recovery_2)));
+            CHECK(File::exists(util::file_path_by_appending_component(recovery_dir, recovery_3)));
+        }
+
+        SECTION("should do nothing if metadata is disabled") {
+            // Create some Realms
+            create_dummy_realm(realm_path_1);
+            create_dummy_realm(realm_path_2);
+            create_dummy_realm(realm_path_3);
+            SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoMetadata);
+            // All file actions should still be present.
+            auto pending_actions = manager.all_pending_actions();
+            CHECK(pending_actions.size() == 3);
+            // All Realms should still be present.
+            REQUIRE_REALM_EXISTS(realm_path_1);
+            REQUIRE_REALM_EXISTS(realm_path_2);
+            REQUIRE_REALM_EXISTS(realm_path_3);
+            // There should not be recovery files.
+            CHECK(!File::exists(util::file_path_by_appending_component(recovery_dir, recovery_1)));
+            CHECK(!File::exists(util::file_path_by_appending_component(recovery_dir, recovery_2)));
+            CHECK(!File::exists(util::file_path_by_appending_component(recovery_dir, recovery_3)));
+        }
+    }
+}
+
 TEST_CASE("sync_manager: metadata") {
     auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     reset_test_directory(base_path);

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -259,17 +259,19 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
     const std::string identity_1 = "foo-1";
     const std::string identity_2 = "bar-1";
     const std::string identity_3 = "baz-1";
+    const std::string identity_4 = "baz-2";
 
     // Realm paths
     const std::string realm_path_1 = file_manager.path(identity_1, realm_url);
     const std::string realm_path_2 = file_manager.path(identity_2, realm_url);
     const std::string realm_path_3 = file_manager.path(identity_3, realm_url);
+    const std::string realm_path_4 = file_manager.path(identity_4, realm_url);
 
     SECTION("Action::DeleteRealm") {
         // Create some file actions
-        auto a1 = SyncFileActionMetadata(manager, SyncFileActionMetadata::Action::DeleteRealm, realm_path_1, "user1", realm_url, false);
-        auto a2 = SyncFileActionMetadata(manager, SyncFileActionMetadata::Action::DeleteRealm, realm_path_2, "user2", realm_url, false);
-        auto a3 = SyncFileActionMetadata(manager, SyncFileActionMetadata::Action::DeleteRealm, realm_path_3, "user3", realm_url, false);
+        auto a1 = SyncFileActionMetadata(manager, SyncFileActionMetadata::Action::DeleteRealm, realm_path_1, "user1", realm_url);
+        auto a2 = SyncFileActionMetadata(manager, SyncFileActionMetadata::Action::DeleteRealm, realm_path_2, "user2", realm_url);
+        auto a3 = SyncFileActionMetadata(manager, SyncFileActionMetadata::Action::DeleteRealm, realm_path_3, "user3", realm_url);
 
         SECTION("should properly delete the Realm") {
             // Create some Realms
@@ -317,9 +319,9 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
         const std::string recovery_1 = "recovery-1";
         const std::string recovery_2 = "recovery-2";
         const std::string recovery_3 = "recovery-3";
-        auto a1 = SyncFileActionMetadata(manager, SyncFileActionMetadata::Action::HandleRealmForClientReset, realm_path_1, "user1", realm_url, false, recovery_1);
-        auto a2 = SyncFileActionMetadata(manager, SyncFileActionMetadata::Action::HandleRealmForClientReset, realm_path_2, "user2", realm_url, false, recovery_2);
-        auto a3 = SyncFileActionMetadata(manager, SyncFileActionMetadata::Action::HandleRealmForClientReset, realm_path_3, "user3", realm_url, false, recovery_3);
+        auto a1 = SyncFileActionMetadata(manager, SyncFileActionMetadata::Action::HandleRealmForClientReset, realm_path_1, "user1", realm_url, recovery_1);
+        auto a2 = SyncFileActionMetadata(manager, SyncFileActionMetadata::Action::HandleRealmForClientReset, realm_path_2, "user2", realm_url, recovery_2);
+        auto a3 = SyncFileActionMetadata(manager, SyncFileActionMetadata::Action::HandleRealmForClientReset, realm_path_3, "user3", realm_url, recovery_3);
         const std::string recovery_dir = file_manager.recovery_directory_path();
 
         SECTION("should properly copy the Realm file and delete the Realm") {
@@ -354,6 +356,25 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
             CHECK(!File::exists(util::file_path_by_appending_component(recovery_dir, recovery_1)));
             CHECK(!File::exists(util::file_path_by_appending_component(recovery_dir, recovery_2)));
             CHECK(!File::exists(util::file_path_by_appending_component(recovery_dir, recovery_3)));
+        }
+
+        SECTION("should work properly when manually driven") {
+            // Create a Realm file
+            create_dummy_realm(realm_path_4);
+            // Configure the system
+            SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoEncryption);
+            // Add a file action after the system is configured.
+            REQUIRE_REALM_EXISTS(realm_path_4);
+            auto a4 = SyncFileActionMetadata(manager, SyncFileActionMetadata::Action::HandleRealmForClientReset, realm_path_4, "user4", realm_url, recovery_1);
+            auto pending_actions = manager.all_pending_actions();
+            CHECK(pending_actions.size() == 1);
+            // Force the recovery. (In a real application, the user would have closed the files by now.)
+            REQUIRE(SyncManager::shared().immediately_run_file_actions(realm_path_4));
+            // There should be recovery files.
+            REQUIRE_REALM_DOES_NOT_EXIST(realm_path_4);
+            CHECK(File::exists(util::file_path_by_appending_component(recovery_dir, recovery_1)));
+            pending_actions = manager.all_pending_actions();
+            CHECK(pending_actions.size() == 0);
         }
 
         SECTION("should fail gracefully if there is already a file at the destination") {

--- a/tests/sync/sync_test_utils.cpp
+++ b/tests/sync/sync_test_utils.cpp
@@ -22,9 +22,10 @@ namespace realm {
 
 bool create_dummy_realm(std::string path) {
     Realm::Config config;
-    config.path = std::move(path);
+    config.path = path;
     try {
         Realm::make_shared_realm(config);
+        REQUIRE_REALM_EXISTS(path);
         return true;
     } catch (std::exception&) {
         return false;

--- a/tests/sync/sync_test_utils.cpp
+++ b/tests/sync/sync_test_utils.cpp
@@ -45,6 +45,15 @@ bool results_contains_user(SyncUserMetadataResults& results, const std::string& 
     return false;
 }
 
+bool results_contains_original_name(SyncFileActionMetadataResults& results, const std::string& original_name) {
+    for (size_t i = 0; i < results.size(); i++) {
+        if (results.get(i).original_name() == original_name) {
+            return true;
+        }
+    }
+    return false;
+}
+
 std::string tmp_dir() {
     const char* dir = getenv("TMPDIR");
     if (dir && *dir)

--- a/tests/sync/sync_test_utils.hpp
+++ b/tests/sync/sync_test_utils.hpp
@@ -48,4 +48,16 @@ std::vector<char> make_test_encryption_key(const char start = 0);
     if (dir_listing) closedir(dir_listing); \
 } while (0)
 
+#define REQUIRE_REALM_EXISTS(macro_path) do { \
+	REQUIRE(realm::util::File::exists(macro_path)); \
+	REQUIRE(realm::util::File::exists((macro_path) + ".lock")); \
+	REQUIRE_DIR_EXISTS((macro_path) + ".management"); \
+} while (0)
+
+#define REQUIRE_REALM_DOES_NOT_EXIST(macro_path) do { \
+	REQUIRE(!realm::util::File::exists(macro_path)); \
+	REQUIRE(!realm::util::File::exists((macro_path) + ".lock")); \
+	REQUIRE_DIR_DOES_NOT_EXIST((macro_path) + ".management"); \
+} while (0)
+
 #endif // REALM_SYNC_TEST_UTILS_HPP

--- a/tests/sync/sync_test_utils.hpp
+++ b/tests/sync/sync_test_utils.hpp
@@ -30,6 +30,7 @@ namespace realm {
 bool create_dummy_realm(std::string path);
 void reset_test_directory(const std::string& base_path);
 bool results_contains_user(SyncUserMetadataResults& results, const std::string& identity);
+bool results_contains_original_name(SyncFileActionMetadataResults& results, const std::string& original_name);
 std::string tmp_dir();
 std::vector<char> make_test_encryption_key(const char start = 0);
 


### PR DESCRIPTION
Depends upon https://github.com/realm/realm-object-store/pull/233

I'm hoping for an API to force `sync` to emit a particular error, which would make writing additional tests possible.

Changes:
- `SyncConfig` now has another field for specifying an optional custom on-disk file path
- A 'diverging histories' error now generates a `ClientReset` error kind
- When receiving a 'diverging histories' error, a client reset file action is generated
- `SyncManager` now acts on file reset actions
- Added more tests