### PR TITLE
Change `all_users` to `all_logged_in_users`

### DIFF
--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -263,14 +263,14 @@ std::shared_ptr<SyncUser> SyncManager::get_existing_logged_in_user(const std::st
     return (ptr->state() == SyncUser::State::Active ? ptr : nullptr);
 }
 
-std::vector<std::shared_ptr<SyncUser>> SyncManager::all_users() const
+std::vector<std::shared_ptr<SyncUser>> SyncManager::all_logged_in_users() const
 {
     std::lock_guard<std::mutex> lock(m_user_mutex);
     std::vector<std::shared_ptr<SyncUser>> users;
     users.reserve(m_users.size());
     for (auto& it : m_users) {
         auto user = it.second;
-        if (user->state() != SyncUser::State::Error) {
+        if (user->state() == SyncUser::State::Active) {
             users.emplace_back(std::move(user));
         }
     }

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -97,8 +97,8 @@ public:
                                        bool is_admin=false);
     // Get an existing user for a given identity, if one exists and is logged in.
     std::shared_ptr<SyncUser> get_existing_logged_in_user(const std::string& identity) const;
-    // Get all the users.
-    std::vector<std::shared_ptr<SyncUser>> all_users() const;
+    // Get all the users that are logged in and not errored out.
+    std::vector<std::shared_ptr<SyncUser>> all_logged_in_users() const;
 
     // Get the default path for a Realm for the given user and absolute unresolved URL.
     std::string path_for_realm(const std::string& user_identity, const std::string& raw_realm_url) const;


### PR DESCRIPTION
@jpsim @bdash @tgoyne 

Related to: https://github.com/realm/realm-object-store/issues/231

Changes:
- `SyncManager` now only returns logged-in, non-errored users
- Added more tests