### PR TITLE
Disable deprecation warnings for ASL

### DIFF
--- a/src/impl/apple/external_commit_helper.cpp
+++ b/src/impl/apple/external_commit_helper.cpp
@@ -158,6 +158,8 @@ ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent)
         try {
             listen();
         }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         catch (std::exception const& e) {
             fprintf(stderr, "uncaught exception in notifier thread: %s: %s\n", typeid(e).name(), e.what());
             asl_log(nullptr, nullptr, ASL_LEVEL_ERR, "uncaught exception in notifier thread: %s: %s", typeid(e).name(), e.what());
@@ -168,6 +170,7 @@ ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent)
             asl_log(nullptr, nullptr, ASL_LEVEL_ERR, "uncaught exception in notifier thread");
             throw;
         }
+#pragma clang diagnostic pop
     });
 }
 


### PR DESCRIPTION
It's deprecated in favor of os_log, but os_log is only available when targeting macOS 10.12/iOS 10 so it'll be a very long time before we can switch to it.