### PR TITLE
Support multiple on-disk files per logical synced Realm

### DIFF
--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -131,6 +131,8 @@ public:
     using MigrationFunction = std::function<void (SharedRealm old_realm, SharedRealm realm, Schema&)>;
 
     struct Config {
+        friend class Realm;
+
         std::string path;
         // User-supplied encryption key. Must be either empty or 64 bytes.
         std::vector<char> encryption_key;
@@ -166,8 +168,19 @@ public:
         // speeds up tests that don't need notifications.
         bool automatic_change_notifications = true;
 
+        /// Set a `SyncConfig` on this `Config`, properly configuring `path` at the same time.
+        /// Precondition: `configure_file_system()` must have already been called on the `SyncManager`
+        /// singleton, if setting this to a non-null value.
+        void set_sync_config(std::shared_ptr<SyncConfig> config);
+
+        inline std::shared_ptr<SyncConfig> sync_config() const
+        {
+            return m_sync_config;
+        }
+
+private:
         /// A data structure storing data used to configure the Realm for sync support.
-        std::shared_ptr<SyncConfig> sync_config;
+        std::shared_ptr<SyncConfig> m_sync_config;
     };
 
     // Get a cached Realm or create a new one if no cached copies exists

--- a/src/sync/sync_config.hpp
+++ b/src/sync/sync_config.hpp
@@ -23,6 +23,8 @@
 #include <memory>
 #include <string>
 
+#include <realm/util/optional.hpp>
+
 namespace realm {
 
 class SyncUser;
@@ -51,6 +53,7 @@ struct SyncConfig {
     SyncSessionStopPolicy stop_policy;
     std::function<SyncBindSessionHandler> bind_session_handler;
     std::function<SyncSessionErrorHandler> error_handler;
+    util::Optional<std::string> custom_file_path=none;
 };
 
 } // namespace realm

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -306,7 +306,9 @@ std::vector<std::shared_ptr<SyncUser>> SyncManager::all_logged_in_users() const
 std::string SyncManager::path_for_realm(const std::string& user_identity, const std::string& raw_realm_url) const
 {
     std::lock_guard<std::mutex> lock(m_file_system_mutex);
-    REALM_ASSERT(m_file_manager);
+    if (!m_file_manager) {
+        throw std::runtime_error("The file management subsystem isn't yet initialized. Please invoke configure_file_system() before calling this method.");
+    }
     return m_file_manager->path(user_identity, raw_realm_url);
 }
 

--- a/src/sync/sync_user.hpp
+++ b/src/sync/sync_user.hpp
@@ -125,8 +125,8 @@ private:
     SyncSessionMap m_waiting_custom_sessions;
 
     // Private helper methods.
-    void register_custom_path_session(std::shared_ptr<SyncSession>, const std::string&, std::unique_lock<std::mutex>);
-    void register_default_path_session(std::shared_ptr<SyncSession>, std::unique_lock<std::mutex>);
+    bool register_custom_path_session(std::shared_ptr<SyncSession>, const std::string&);
+    bool register_default_path_session(std::shared_ptr<SyncSession>);
     std::shared_ptr<SyncSession> session_for_key(const std::string&, SyncSessionMap&);
 };
 

--- a/src/sync/sync_user.hpp
+++ b/src/sync/sync_user.hpp
@@ -30,6 +30,7 @@
 namespace realm {
 
 class SyncSession;
+using SyncSessionMap = std::unordered_map<std::string, std::weak_ptr<SyncSession>>;
 
 // A `SyncUser` represents a single user account. Each user manages the sessions that
 // are associated with it.
@@ -51,8 +52,11 @@ public:
     // Return a list of all sessions belonging to this user.
     std::vector<std::shared_ptr<SyncSession>> all_sessions();
 
-    // Return a session for a given URL.
+    // Return a session with the default file path for a given URL, if one exists.
     std::shared_ptr<SyncSession> session_for_url(const std::string& url);
+
+    // Return a session for a given custom file path, if one exists.
+    std::shared_ptr<SyncSession> session_for_custom_file_path(const std::string& url);
 
     // Update the user's refresh token. If the user is logged out, it will log itself back in.
     // Note that this is called by the SyncManager, and should not be directly called.
@@ -111,10 +115,19 @@ private:
 
     // Sessions are owned by the SyncManager, but the user keeps a map of weak references
     // to them.
-    std::unordered_map<std::string, std::weak_ptr<SyncSession>> m_sessions;
+    // This map maps URLs --> weak pointers to sessions (for sessions with default file paths).
+    SyncSessionMap m_sessions;
+    // This map maps on-disk paths --> weak pointers to sessions (for sessions with custom file paths).
+    SyncSessionMap m_custom_sessions;
 
     // Waiting sessions are those that should be asked to connect once this user is logged in.
-    std::unordered_map<std::string, std::weak_ptr<SyncSession>> m_waiting_sessions;
+    SyncSessionMap m_waiting_sessions;
+    SyncSessionMap m_waiting_custom_sessions;
+
+    // Private helper methods.
+    void register_custom_path_session(std::shared_ptr<SyncSession>, const std::string&, std::unique_lock<std::mutex>);
+    void register_default_path_session(std::shared_ptr<SyncSession>, std::unique_lock<std::mutex>);
+    std::shared_ptr<SyncSession> session_for_key(const std::string&, SyncSessionMap&);
 };
 
 }

--- a/tests/sync/session.cpp
+++ b/tests/sync/session.cpp
@@ -43,7 +43,7 @@ std::shared_ptr<SyncSession> sync_session(SyncServer& server, std::shared_ptr<Sy
                                           std::string* on_disk_path=nullptr)
 {
     std::string url = server.base_url() + path;
-    SyncConfig sync_config = {user, url, std::move(stop_policy),
+    SyncConfig sync_config{user, url, std::move(stop_policy),
         [&](const std::string& path, const SyncConfig& config, std::shared_ptr<SyncSession> session) {
             auto token = fetch_access_token(path, config.realm_url);
             session->refresh_access_token(std::move(token), config.realm_url);

--- a/tests/util/test_file.hpp
+++ b/tests/util/test_file.hpp
@@ -85,7 +85,7 @@ private:
 };
 
 struct SyncTestFile : TestFile {
-    SyncTestFile(const realm::SyncConfig&);
+    SyncTestFile(realm::SyncConfig&, bool treat_path_as_custom=false);
     SyncTestFile(SyncServer& server);
 };
 


### PR DESCRIPTION
@jpsim @tgoyne @bdash @alazier 

Fixes https://github.com/realm/realm-object-store/issues/243

Changes:
- `SyncConfig` now has an optional custom-path property
- `Realm::Config` now has a method to properly configure itself with a `SyncConfig`
- Users now track "default-path" Realms (indexed by URL, used by clients) separately from "custom-path" Realms
- Minor API changes to allow default-path and custom-path Realms to be created properly
- Added and upgraded tests