### PR TITLE
Fix errors for sync beta 5.0

### DIFF
--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -305,41 +305,41 @@ void SyncSession::create_sync_session()
             return;
         }
 
-        using Error = realm::sync::Error;
+        using ProtocolError = realm::sync::ProtocolError;
 
         SyncSessionError error_type = SyncSessionError::Debug;
         // Precondition: error_code is a valid realm::sync::Error raw value.
-        Error strong_code = static_cast<Error>(error_code);
+        ProtocolError strong_code = static_cast<ProtocolError>(error_code);
 
         switch (strong_code) {
             // Client errors; all ignored (for now)
-            case Error::invalid_error:
-            case Error::connection_closed:
-            case Error::other_error:
-            case Error::unknown_message:
-            case Error::bad_syntax:
-            case Error::limits_exceeded:
-            case Error::wrong_protocol_version:
-            case Error::bad_session_ident:
-            case Error::reuse_of_session_ident:
-            case Error::bound_in_other_session:
-            case Error::bad_message_order:
+            case ProtocolError::invalid_error:
+            case ProtocolError::connection_closed:
+            case ProtocolError::other_error:
+            case ProtocolError::unknown_message:
+            case ProtocolError::bad_syntax:
+            case ProtocolError::limits_exceeded:
+            case ProtocolError::wrong_protocol_version:
+            case ProtocolError::bad_session_ident:
+            case ProtocolError::reuse_of_session_ident:
+            case ProtocolError::bound_in_other_session:
+            case ProtocolError::bad_message_order:
                 return;
             // Session errors
-            case Error::disabled_session:
-            case Error::session_closed:
-            case Error::other_session_error:
+            case ProtocolError::disabled_session:
+            case ProtocolError::session_closed:
+            case ProtocolError::other_session_error:
                 // The binding doesn't need to be aware of these because they are strictly informational, and do not
                 // represent actual errors.
                 return;
-            case Error::token_expired: {
+            case ProtocolError::token_expired: {
                 std::unique_lock<std::mutex> lock(m_state_mutex);
                 // This isn't an error from the binding's point of view. If we're connected we'll
                 // simply ask the binding to log in again.
                 m_state->access_token_expired(lock, *this);
                 return;
             }
-            case Error::bad_authentication: {
+            case ProtocolError::bad_authentication: {
                 std::shared_ptr<SyncUser> user_to_invalidate;
                 {
                     std::unique_lock<std::mutex> lock(m_state_mutex);
@@ -351,22 +351,22 @@ void SyncSession::create_sync_session()
                     user_to_invalidate->invalidate();
                 break;
             }
-            case Error::illegal_realm_path:
-            case Error::no_such_realm:
-            case Error::bad_server_file_ident:
-            case Error::diverging_histories:
-            case Error::bad_changeset: {
+            case ProtocolError::illegal_realm_path:
+            case ProtocolError::no_such_realm:
+            case ProtocolError::bad_server_file_ident:
+            case ProtocolError::diverging_histories:
+            case ProtocolError::bad_changeset: {
                 std::unique_lock<std::mutex> lock(m_state_mutex);
                 error_type = SyncSessionError::SessionFatal;
                 advance_state(lock, State::error);
                 break;
             }
-            case Error::permission_denied:
+            case ProtocolError::permission_denied:
                 error_type = SyncSessionError::AccessDenied;
                 break;
-            case Error::bad_client_file_ident:
-            case Error::bad_server_version:
-            case Error::bad_client_version:
+            case ProtocolError::bad_client_file_ident:
+            case ProtocolError::bad_server_version:
+            case ProtocolError::bad_client_version:
                 error_type = SyncSessionError::Debug;
                 break;
         }


### PR DESCRIPTION
Seems like `realm::sync::Error` was renamed to `ProtocolError`, so building OS against latest sync fails.