### PR TITLE
Close the file descriptor returned by mkstemp

### DIFF
--- a/tests/util/test_file.cpp
+++ b/tests/util/test_file.cpp
@@ -58,7 +58,12 @@ TestFile::TestFile()
 #endif
     }();
     path = tmpdir + "/realm.XXXXXX";
-    mkstemp(&path[0]);
+    int fd = mkstemp(&path[0]);
+    if (fd < 0) {
+        int err = errno;
+        throw std::system_error(err, std::system_category());
+    }
+    close(fd);
     unlink(path.c_str());
 
     schema_version = 0;


### PR DESCRIPTION
Failing to close this file descriptor results in many tests failing on macOS Sierra due to running out of available file descriptors.

/cc @kneth @austinzheng 