### PR TITLE
Fix a crash when calling SyncManager::reset_for_testing

### DIFF
--- a/src/sync/impl/sync_client.hpp
+++ b/src/sync/impl/sync_client.hpp
@@ -44,10 +44,16 @@ struct SyncClient {
     {
     }
 
-    ~SyncClient()
+    void stop()
     {
         client.stop();
-        m_thread.join();
+        if (m_thread.joinable())
+            m_thread.join();
+    }
+
+    ~SyncClient()
+    {
+        stop();
     }
 
 private:

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -141,12 +141,31 @@ void SyncManager::reset_for_testing()
         m_users.clear();
     }
     {
-        // Assert there are no active sessions remaining.
-        REALM_ASSERT(std::all_of(m_active_sessions.begin(), m_active_sessions.end(), [](auto& element){ return element.second.expired(); }));
-        // Destroy the client.
         std::lock_guard<std::mutex> lock(m_mutex);
+
+        // Stop the client. This will abort any uploads that inactive sessions are waiting for.
+        if (m_sync_client)
+            m_sync_client->stop();
+
+        {
+            std::lock_guard<std::mutex> lock(m_session_mutex);
+            // Callers of `SyncManager::reset_for_testing` should ensure there are no active sessions
+            // prior to calling `reset_for_testing`.
+            REALM_ASSERT(std::all_of(m_active_sessions.begin(), m_active_sessions.end(), [](auto& element){
+                return element.second.expired();
+            }));
+
+            // Destroy any remaining inactive sessions.
+            // FIXME: We shouldn't have any inactive sessions at this point! Sessions are expected to
+            // remain inactive until their final upload completes, at which point they are unregistered
+            // and destroyed. Our call to `sync::Client::stop` above aborts all uploads, so all sessions
+            // should have already been destroyed.
+            m_inactive_sessions.clear();
+        }
+
+        // Destroy the client now that we have no remaining sessions.
         m_sync_client = nullptr;
-        m_inactive_sessions.clear();
+
         // Reset even more state.
         // NOTE: these should always match the defaults.
         m_log_level = util::Logger::Level::info;
@@ -320,7 +339,7 @@ std::unique_ptr<SyncSession> SyncManager::get_existing_inactive_session_locked(c
 
 std::shared_ptr<SyncSession> SyncManager::get_session(const std::string& path, const SyncConfig& sync_config)
 {
-    auto client = get_sync_client(); // Throws
+    auto& client = get_sync_client(); // Throws
 
     // The session is declared outside the scope of the lock so that if an exception is thrown
     // it'll be destroyed after the lock has been dropped. This avoids deadlocking when
@@ -336,7 +355,7 @@ std::shared_ptr<SyncSession> SyncManager::get_session(const std::string& path, c
     bool session_is_new = false;
     if (!session) {
         session_is_new = true;
-        session.reset(new SyncSession(std::move(client), path, sync_config));
+        session.reset(new SyncSession(client, path, sync_config));
     }
 
     auto session_deleter = [this](SyncSession *session) { dropped_last_reference_to_session(session); };
@@ -372,15 +391,15 @@ void SyncManager::unregister_session(const std::string& path)
     m_inactive_sessions.erase(path);
 }
 
-std::shared_ptr<SyncClient> SyncManager::get_sync_client() const
+SyncClient& SyncManager::get_sync_client() const
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     if (!m_sync_client)
         m_sync_client = create_sync_client(); // Throws
-    return m_sync_client;
+    return *m_sync_client;
 }
 
-std::shared_ptr<SyncClient> SyncManager::create_sync_client() const
+std::unique_ptr<SyncClient> SyncManager::create_sync_client() const
 {
     REALM_ASSERT(!m_mutex.try_lock());
 
@@ -393,7 +412,7 @@ std::shared_ptr<SyncClient> SyncManager::create_sync_client() const
         stderr_logger->set_level_threshold(m_log_level);
         logger = std::move(stderr_logger);
     }
-    return std::make_shared<SyncClient>(std::move(logger),
+    return std::make_unique<SyncClient>(std::move(logger),
                                         std::move(m_error_handler),
                                         m_client_reconnect_mode,
                                         m_client_validate_ssl);

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -149,11 +149,15 @@ void SyncManager::reset_for_testing()
 
         {
             std::lock_guard<std::mutex> lock(m_session_mutex);
+
+#if REALM_ASSERTIONS_ENABLED
             // Callers of `SyncManager::reset_for_testing` should ensure there are no active sessions
             // prior to calling `reset_for_testing`.
-            REALM_ASSERT(std::all_of(m_active_sessions.begin(), m_active_sessions.end(), [](auto& element){
+            auto no_active_sessions = std::all_of(m_active_sessions.begin(), m_active_sessions.end(), [](auto& element){
                 return element.second.expired();
-            }));
+            });
+            REALM_ASSERT(no_active_sessions);
+#endif
 
             // Destroy any remaining inactive sessions.
             // FIXME: We shouldn't have any inactive sessions at this point! Sessions are expected to

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -120,8 +120,8 @@ private:
     SyncManager(const SyncManager&) = delete;
     SyncManager& operator=(const SyncManager&) = delete;
 
-    std::shared_ptr<_impl::SyncClient> get_sync_client() const;
-    std::shared_ptr<_impl::SyncClient> create_sync_client() const;
+    _impl::SyncClient& get_sync_client() const;
+    std::unique_ptr<_impl::SyncClient> create_sync_client() const;
 
     std::shared_ptr<SyncSession> get_existing_active_session_locked(const std::string& path) const;
     std::unique_ptr<SyncSession> get_existing_inactive_session_locked(const std::string& path);
@@ -141,7 +141,7 @@ private:
     // A map of user identities to (shared pointers to) SyncUser objects.
     std::unordered_map<std::string, std::shared_ptr<SyncUser>> m_users;
 
-    mutable std::shared_ptr<_impl::SyncClient> m_sync_client;
+    mutable std::unique_ptr<_impl::SyncClient> m_sync_client;
 
     // Protects m_active_sessions and m_inactive_sessions
     mutable std::mutex m_session_mutex;

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -138,7 +138,7 @@ private:
 
     friend class realm::SyncManager;
     // Called by SyncManager {
-    SyncSession(std::shared_ptr<_impl::SyncClient>, std::string realm_path, SyncConfig);
+    SyncSession(_impl::SyncClient&, std::string realm_path, SyncConfig);
     // }
 
     bool can_wait_for_network_completion() const;
@@ -163,7 +163,7 @@ private:
     SyncConfig m_config;
 
     std::string m_realm_path;
-    std::shared_ptr<_impl::SyncClient> m_client;
+    _impl::SyncClient& m_client;
     std::unique_ptr<sync::Session> m_session;
     util::Optional<int_fast64_t> m_deferred_commit_notification;
     bool m_deferred_close = false;


### PR DESCRIPTION
`SyncClient`'s lifetime was managed by a `shared_ptr`, resulting in `SyncManager::reset_for_testing` failing to destroy it when expected. This meant that its runloop was still running, and that it could continue to deliver callbacks to sessions that `reset_for_testing` was in the process of destroying.

To address this `SyncClient` is now owned by `SyncManager`, with `SyncSession`'s holding only a reference to their client. This is safe because sync asserts that all sessions have been destroyed when the client is destroyed.

/cc @austinzheng @alazier 

Fixes #269.