### PR TITLE
Expose current user in sync_manager

### DIFF
--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -303,6 +303,26 @@ std::vector<std::shared_ptr<SyncUser>> SyncManager::all_logged_in_users() const
     return users;
 }
 
+std::shared_ptr<SyncUser> SyncManager::get_current_user() const
+{
+    std::lock_guard<std::mutex> lock(m_user_mutex);
+    
+    std::shared_ptr<SyncUser> result = nullptr;
+    for (auto& it : m_users) {
+        auto user = it.second;
+        if (user->state() == SyncUser::State::Active) {
+            if (result == nullptr) {
+                result = std::move(user);
+            }
+            else {
+                throw std::logic_error("get_current_user cannot be called if more that one valid, logged-in user exists.");
+            }
+        }
+    }
+    
+    return result;
+}
+
 std::string SyncManager::path_for_realm(const std::string& user_identity, const std::string& raw_realm_url) const
 {
     std::lock_guard<std::mutex> lock(m_file_system_mutex);

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -313,7 +313,7 @@ std::shared_ptr<SyncUser> SyncManager::get_current_user() const
         return nullptr;
     }
     if (std::find_if(std::next(it), m_users.end(), is_active_user) != m_users.end()) {
-        throw std::logic_error("get_current_user cannot be called if more that one valid, logged-in user exists.");
+        throw std::logic_error("Current user is not valid if more that one valid, logged-in user exists.");
     }
     return it->second;
 }

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -99,6 +99,8 @@ public:
     std::shared_ptr<SyncUser> get_existing_logged_in_user(const std::string& identity) const;
     // Get all the users that are logged in and not errored out.
     std::vector<std::shared_ptr<SyncUser>> all_logged_in_users() const;
+    // Gets the currently logged in user. If there are more than 1 users logged in, an exception is thrown.
+    std::shared_ptr<SyncUser> get_current_user() const;
 
     // Get the default path for a Realm for the given user and absolute unresolved URL.
     std::string path_for_realm(const std::string& user_identity, const std::string& raw_realm_url) const;

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -148,6 +148,18 @@ TEST_CASE("sync_manager: user state management", "[sync]") {
         CHECK(validate_user_in_vector(users, identity_2, url_2, token_2));
         CHECK(validate_user_in_vector(users, identity_3, none, token_3));
     }
+
+    SECTION("should return current user that was created during run time") {
+        auto u_null = SyncManager::shared().get_current_user();
+        REQUIRE(u_null == nullptr);
+
+        auto u1 = SyncManager::shared().get_user(identity_1, token_1, url_1);
+        auto u_current = SyncManager::shared().get_current_user();
+        REQUIRE(u_current == u1);
+
+        auto u2 = SyncManager::shared().get_user(identity_2, token_2, url_2);
+        REQUIRE_THROWS_AS(SyncManager::shared().get_current_user(), std::logic_error);
+    }
 }
 
 TEST_CASE("sync_manager: persistent user state management", "[sync]") {


### PR DESCRIPTION
With the API exposed in OS, bindings won't have to implement it themselves.