### PR TITLE
Support multiple SyncSessions per URL

### DIFF
--- a/src/sync/sync_user.hpp
+++ b/src/sync/sync_user.hpp
@@ -51,8 +51,11 @@ public:
     // Return a list of all sessions belonging to this user.
     std::vector<std::shared_ptr<SyncSession>> all_sessions();
 
-    // Return a session for a given URL.
-    std::shared_ptr<SyncSession> session_for_url(const std::string& url);
+    // Return a session for a given on disk path.
+    // In most cases, bindings shouldn't expose this to consumers, since the on-disk
+    // path for a synced Realm is an opaque implementation detail. This API is retained
+    // for testing purposes, and for bindings for consumers that are servers or tools.
+    std::shared_ptr<SyncSession> session_for_on_disk_path(const std::string& path);
 
     // Update the user's refresh token. If the user is logged out, it will log itself back in.
     // Note that this is called by the SyncManager, and should not be directly called.


### PR DESCRIPTION
Replaces #270. @bdash @simonask 

Fixes #243.

Changes:
- ~~`Realm::Config` now has a method to properly configure itself with a `SyncConfig`~~
- Sync users now index sessions by their on-disk paths, allowing multiple sessions per URL (as long as their file paths are distinct)
- The `session_for_url()` API has been removed
- Updated tests