### PR TITLE
Add support for an event notifications mechanism

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,6 +79,7 @@ if(REALM_ENABLE_SYNC)
     list(APPEND HEADERS
         sync/sync_config.hpp
         sync/sync_manager.hpp
+        sync/sync_notifier.hpp
         sync/sync_session.hpp
         sync/sync_user.hpp
         sync/impl/sync_client.hpp

--- a/src/sync/sync_notifier.hpp
+++ b/src/sync/sync_notifier.hpp
@@ -1,0 +1,81 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_OS_SYNC_NOTIFIER_HPP
+#define REALM_OS_SYNC_NOTIFIER_HPP
+
+#include "sync_config.hpp"
+#include "sync_session.hpp"
+#include "sync_user.hpp"
+
+#include <functional>
+#include <memory>
+
+namespace realm {
+
+class SyncNotifier;
+
+class SyncNotifierFactory {
+public:
+    virtual std::unique_ptr<SyncNotifier> make_notifier() = 0;
+};
+
+class SyncNotifier {
+public:
+	/// A user has successfully logged in.
+	/// Arguments: user
+	virtual void user_logged_in(std::shared_ptr<SyncUser>) const { }
+	
+	/// A user has successfully logged out.
+	/// Arguments: user
+	virtual void user_logged_out(std::shared_ptr<SyncUser>) const { }
+
+	/// A session has successfully been bound to the Realm Object Server.
+	/// Arguments: session
+	virtual void session_bound_to_server(std::shared_ptr<SyncSession>) const { }
+
+	/// A session has been destroyed.
+	/// Arguments: the config for the session, the path to the session's Realm file
+	virtual void session_destroyed(SyncConfig, const std::string&) const { }
+
+	// TODO: enable later
+	// /// A session might need to be reset.
+	// /// Arguments: session, a closure which should be called if the session should be reset.
+	// virtual void session_may_need_reset(std::shared_ptr<SyncSession>, std::function<void()>) const { }
+	//
+	// /// A session that needed to be reset was backed up.
+	// /// Arguments: the name of the backup Realm file, TODO
+	// virtual void session_reset_and_backed_up(const std::string&) const { }
+
+	/// The metadata Realm was reset.
+	/// Arguments: none
+	virtual void metadata_realm_reset() const { }
+
+	// TODO: enable later
+	// /// A synced Realm was deleted.
+	// /// Arguments: TODO
+	// virtual void realm_deleted() const { }
+
+	/// A user was deleted.
+	/// Arguments: the identity of the deleted user
+	virtual void user_deleted(const std::string&) const { }
+};
+
+}
+
+#endif // REALM_OS_SYNC_NOTIFIER_HPP

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -133,6 +133,8 @@ struct sync_session_states::WaitingForAccessToken : public SyncSession::State {
         if (session.m_deferred_close) {
             session.m_deferred_close = false;
             session.m_state->close(lock, session);
+        } else {
+            SyncManager::shared().fire_notification([&](const SyncNotifier& n) { n.session_bound_to_server(session.shared_from_this()); });
         }
     }
 
@@ -442,7 +444,7 @@ void SyncSession::unregister(std::unique_lock<std::mutex>& lock)
     REALM_ASSERT(m_state == &State::inactive); // Must stop an active session before unregistering.
 
     lock.unlock();
-    SyncManager::shared().unregister_session(m_realm_path);
+    SyncManager::shared().unregister_session(m_realm_path, m_config);
 }
 
 bool SyncSession::can_wait_for_network_completion() const

--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -103,6 +103,7 @@ void SyncUser::update_refresh_token(std::string token)
                     }
                 }
                 m_waiting_sessions.clear();
+                SyncManager::shared().fire_notification([this](const SyncNotifier& n) { n.user_logged_in(this->shared_from_this()); });
                 break;
             }
         }
@@ -149,6 +150,7 @@ void SyncUser::log_out()
             metadata.mark_for_removal();
         });
     }
+    SyncManager::shared().fire_notification([this](const SyncNotifier& n) { n.user_logged_out(this->shared_from_this()); });
 }
 
 void SyncUser::invalidate()

--- a/src/sync/sync_user.hpp
+++ b/src/sync/sync_user.hpp
@@ -33,7 +33,7 @@ class SyncSession;
 
 // A `SyncUser` represents a single user account. Each user manages the sessions that
 // are associated with it.
-class SyncUser {
+class SyncUser : public std::enable_shared_from_this<SyncUser> {
 friend class SyncSession;
 public:
     enum class State {

--- a/tests/sync/sync_test_utils.cpp
+++ b/tests/sync/sync_test_utils.cpp
@@ -20,6 +20,16 @@
 
 namespace realm {
 
+bool session_is_active(const SyncSession& session)
+{
+    return session.state() == SyncSession::PublicState::Active;
+}
+
+bool session_is_inactive(const SyncSession& session)
+{
+    return session.state() == SyncSession::PublicState::Inactive;
+}
+
 bool create_dummy_realm(std::string path) {
     Realm::Config config;
     config.path = std::move(path);

--- a/tests/sync/sync_test_utils.hpp
+++ b/tests/sync/sync_test_utils.hpp
@@ -21,6 +21,10 @@
 
 #include "catch.hpp"
 
+#include "util/test_file.hpp"
+
+#include "sync/sync_manager.hpp"
+#include "sync/sync_session.hpp"
 #include "sync/impl/sync_file.hpp"
 #include "sync/impl/sync_metadata.hpp"
 
@@ -32,6 +36,33 @@ void reset_test_directory(const std::string& base_path);
 bool results_contains_user(SyncUserMetadataResults& results, const std::string& identity);
 std::string tmp_dir();
 std::vector<char> make_test_encryption_key(const char start = 0);
+bool session_is_active(const SyncSession& session);
+bool session_is_inactive(const SyncSession& session);
+
+/// Create a properly configured `SyncSession` for test purposes.
+template <typename FetchAccessToken, typename ErrorHandler>
+std::shared_ptr<SyncSession> sync_session(SyncServer& server, std::shared_ptr<SyncUser> user, const std::string& path,
+                                          FetchAccessToken&& fetch_access_token, ErrorHandler&& error_handler,
+                                          SyncSessionStopPolicy stop_policy=SyncSessionStopPolicy::AfterChangesUploaded,
+                                          std::string* on_disk_path=nullptr)
+{
+    std::string url = server.base_url() + path;
+    SyncTestFile config({user, url, std::move(stop_policy),
+        [&](const std::string& path, const SyncConfig& config, std::shared_ptr<SyncSession> session) {
+            auto token = fetch_access_token(path, config.realm_url);
+            session->refresh_access_token(std::move(token), config.realm_url);
+        }, std::forward<ErrorHandler>(error_handler)});
+    if (on_disk_path) {
+        *on_disk_path = config.path;
+    }
+
+    std::shared_ptr<SyncSession> session;
+    {
+        auto realm = Realm::get_shared_realm(config);
+        session = SyncManager::shared().get_session(config.path, *config.sync_config);
+    }
+    return session;
+}
 
 } // namespace realm
 

--- a/tests/sync/user.cpp
+++ b/tests/sync/user.cpp
@@ -18,7 +18,6 @@
 
 #include "sync_test_utils.hpp"
 
-#include "sync/sync_manager.hpp"
 #include "sync/sync_user.hpp"
 #include <realm/util/file.hpp>
 #include <realm/util/scope_exit.hpp>


### PR DESCRIPTION
Replaces #262, which I accidentally merged and then backed out. @bdash 

Changes:
- Implemented a notifier that bindings can override to get sync-wide event notifications
- A few internal API changes to facilitate this new feature
- Object store sync test infrastructure slightly overhauled to facilitate testing
- Added tests to exercise the new functionality