### PR TITLE
Handover for distinct Results

### DIFF
--- a/src/impl/handover.cpp
+++ b/src/impl/handover.cpp
@@ -36,6 +36,8 @@ AnyHandover::AnyHandover(AnyHandover&& handover)
         case AnyThreadConfined::Type::Results:
             new (&m_results.query_handover) QueryHandover(std::move(handover.m_results.query_handover));
             new (&m_results.sort_order) SortDescriptor::HandoverPatch(std::move(handover.m_results.sort_order));
+            new (&m_results.distinct_descriptor) SortDescriptor::HandoverPatch(
+                    std::move(handover.m_results.distinct_descriptor));
             break;
     }
     new (&m_type) AnyThreadConfined::Type(handover.m_type);
@@ -62,6 +64,7 @@ AnyHandover::~AnyHandover()
         case AnyThreadConfined::Type::Results:
             m_results.query_handover.~unique_ptr();
             m_results.sort_order.~unique_ptr();
+            m_results.distinct_descriptor.~unique_ptr();
             break;
     }
 }
@@ -84,7 +87,8 @@ AnyThreadConfined AnyHandover::import_from_handover(SharedRealm realm) &&
             auto query = shared_group.import_from_handover(std::move(m_results.query_handover));
             auto& table = *query->get_table();
             return AnyThreadConfined(Results(std::move(realm), std::move(*query),
-                                             SortDescriptor::create_from_and_consume_patch(m_results.sort_order, table)));
+                        SortDescriptor::create_from_and_consume_patch(m_results.sort_order, table),
+                        SortDescriptor::create_from_and_consume_patch(m_results.distinct_descriptor, table)));
         }
     }
     REALM_UNREACHABLE();

--- a/src/impl/handover.hpp
+++ b/src/impl/handover.hpp
@@ -66,6 +66,7 @@ private:
         struct {
             QueryHandover query_handover;
             SortDescriptor::HandoverPatch sort_order;
+            SortDescriptor::HandoverPatch distinct_descriptor;
         } m_results;
     };
 
@@ -75,8 +76,11 @@ private:
     AnyHandover(LinkViewHandover link_view)
     : m_type(AnyThreadConfined::Type::List), m_list({std::move(link_view)}) {}
 
-    AnyHandover(QueryHandover query_handover, SortDescriptor::HandoverPatch sort_order)
-    : m_type(AnyThreadConfined::Type::Results), m_results({std::move(query_handover), std::move(sort_order)}) {}
+    AnyHandover(QueryHandover query_handover,
+            SortDescriptor::HandoverPatch sort_order, SortDescriptor::HandoverPatch distinct_descriptor)
+    : m_type(AnyThreadConfined::Type::Results),
+      m_results({std::move(query_handover), std::move(sort_order), std::move(distinct_descriptor)}) {}
+
 };
 }
 }

--- a/src/impl/results_notifier.hpp
+++ b/src/impl/results_notifier.hpp
@@ -43,6 +43,8 @@ private:
 
     SortDescriptor::HandoverPatch m_sort_handover;
     SortDescriptor m_sort;
+    SortDescriptor::HandoverPatch m_distinct_handover;
+    SortDescriptor m_distinct;
     bool m_target_is_in_table_order;
 
     // The TableView resulting from running the query. Will be detached unless

--- a/src/thread_confined.cpp
+++ b/src/thread_confined.cpp
@@ -118,8 +118,10 @@ _impl::AnyHandover AnyThreadConfined::export_for_handover() const
         case AnyThreadConfined::Type::Results: {
             SortDescriptor::HandoverPatch sort_order;
             SortDescriptor::generate_patch(m_results.get_sort(), sort_order);
+            SortDescriptor::HandoverPatch distinct_descriptor;
+            SortDescriptor::generate_patch(m_results.get_distinct(), distinct_descriptor);
             return _impl::AnyHandover(shared_group.export_for_handover(m_results.get_query(), ConstSourcePayload::Copy),
-                                      std::move(sort_order));
+                                      std::move(sort_order), std::move(distinct_descriptor));
         }
     }
     REALM_UNREACHABLE();


### PR DESCRIPTION
- Handover patch for Results.m_distinct
- Add tests

async distinct is supported by current java implementation, and for https://github.com/realm/realm-java/pull/3834 , it needs to be supported in OS level as well.

I am not quite sure if it is possible to make the fine grained notification work for the distinct results. Any suggestions? @bdash @tgoyne @JadenGeller 