### PR TITLE
Remove some transaction log validation for schema changes

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -419,9 +419,8 @@ namespace {
 class IncrementalChangeInfo {
 public:
     IncrementalChangeInfo(SharedGroup& sg,
-                          SchemaMode schema_mode,
                           std::vector<std::shared_ptr<_impl::CollectionNotifier>>& notifiers)
-    : m_sg(sg), m_schema_mode(schema_mode)
+    : m_sg(sg)
     {
         if (notifiers.empty())
             return;
@@ -465,7 +464,7 @@ public:
     void advance_to_final(VersionID version)
     {
         if (!m_current) {
-            transaction::advance(m_sg, nullptr, m_schema_mode, version);
+            transaction::advance(m_sg, nullptr, version);
             return;
         }
 
@@ -508,7 +507,6 @@ private:
     std::vector<TransactionChangeInfo> m_info;
     TransactionChangeInfo* m_current = nullptr;
     SharedGroup& m_sg;
-    SchemaMode m_schema_mode;
 };
 } // anonymous namespace
 
@@ -536,7 +534,7 @@ void RealmCoordinator::run_async_notifiers()
 
     // Advance all of the new notifiers to the most recent version, if any
     auto new_notifiers = std::move(m_new_notifiers);
-    IncrementalChangeInfo new_notifier_change_info(*m_advancer_sg, m_config.schema_mode, new_notifiers);
+    IncrementalChangeInfo new_notifier_change_info(*m_advancer_sg, new_notifiers);
 
     if (!new_notifiers.empty()) {
         REALM_ASSERT_3(m_advancer_sg->get_transact_stage(), ==, SharedGroup::transact_Reading);
@@ -546,7 +544,7 @@ void RealmCoordinator::run_async_notifiers()
         // The advancer SG can be at an older version than the oldest new notifier
         // if a notifier was added and then removed before it ever got the chance
         // to run, as we don't move the pin forward when removing dead notifiers
-        transaction::advance(*m_advancer_sg, nullptr, m_config.schema_mode, new_notifiers.front()->version());
+        transaction::advance(*m_advancer_sg, nullptr, new_notifiers.front()->version());
 
         // Advance each of the new notifiers to the latest version, attaching them
         // to the SG at their handover version. This requires a unique
@@ -581,7 +579,7 @@ void RealmCoordinator::run_async_notifiers()
 
     if (skip_version.version) {
         REALM_ASSERT(version >= skip_version);
-        IncrementalChangeInfo change_info(*m_notifier_sg, m_config.schema_mode, notifiers);
+        IncrementalChangeInfo change_info(*m_notifier_sg, notifiers);
         for (auto& notifier : notifiers)
             notifier->add_required_change_info(change_info.current());
         change_info.advance_to_final(skip_version);
@@ -597,7 +595,7 @@ void RealmCoordinator::run_async_notifiers()
 
     // Advance the non-new notifiers to the same version as we advanced the new
     // ones to (or the latest if there were no new ones)
-    IncrementalChangeInfo change_info(*m_notifier_sg, m_config.schema_mode, notifiers);
+    IncrementalChangeInfo change_info(*m_notifier_sg, notifiers);
     for (auto& notifier : notifiers) {
         notifier->add_required_change_info(change_info.current());
     }
@@ -658,15 +656,11 @@ void RealmCoordinator::advance_to_ready(Realm& realm)
 
     auto& sg = Realm::Internal::get_shared_group(realm);
     if (!notifiers) {
-        transaction::advance(sg, realm.m_binding_context.get(), m_config.schema_mode, VersionID{});
+        transaction::advance(sg, realm.m_binding_context.get(), VersionID{});
         return;
     }
 
-    auto version = notifiers.version();
-    if (version && *version <= sg.get_version_of_current_transaction())
-        return;
-
-    transaction::advance(sg, realm.m_binding_context.get(), m_config.schema_mode, notifiers);
+    transaction::advance(sg, realm.m_binding_context.get(), notifiers);
 }
 
 std::vector<std::shared_ptr<_impl::CollectionNotifier>> RealmCoordinator::notifiers_for_realm(Realm& realm)
@@ -694,7 +688,7 @@ bool RealmCoordinator::advance_to_latest(Realm& realm)
     notifiers.package_and_wait(sgf::get_version_of_latest_snapshot(sg));
 
     auto version = sg.get_version_of_current_transaction();
-    transaction::advance(sg, realm.m_binding_context.get(), m_config.schema_mode, notifiers);
+    transaction::advance(sg, realm.m_binding_context.get(), notifiers);
     return version != sg.get_version_of_current_transaction();
 }
 
@@ -707,7 +701,7 @@ void RealmCoordinator::promote_to_write(Realm& realm)
     lock.unlock();
 
     auto& sg = Realm::Internal::get_shared_group(realm);
-    transaction::begin(sg, realm.m_binding_context.get(), m_config.schema_mode, notifiers);
+    transaction::begin(sg, realm.m_binding_context.get(), notifiers);
 }
 
 void RealmCoordinator::process_available_async(Realm& realm)

--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -68,10 +68,6 @@ class TransactLogValidationMixin {
     // Index of currently selected table
     size_t m_current_table = 0;
 
-    // Tables which were created during the transaction being processed, which
-    // can have columns inserted without a schema version bump
-    std::vector<size_t> m_new_tables;
-
     REALM_NORETURN
     REALM_NOINLINE
     void schema_error()
@@ -79,57 +75,10 @@ class TransactLogValidationMixin {
         throw std::logic_error("Schema mismatch detected: another process has modified the Realm file's schema in an incompatible way");
     }
 
-    // Throw an exception if the currently modified table already existed before
-    // the current set of modifications
-    bool schema_error_unless_new_table()
-    {
-        if (schema_mode == SchemaMode::Additive) {
-            return true;
-        }
-        if (std::find(begin(m_new_tables), end(m_new_tables), m_current_table) != end(m_new_tables)) {
-            return true;
-        }
-        schema_error();
-    }
-
 protected:
     size_t current_table() const noexcept { return m_current_table; }
 
 public:
-    SchemaMode schema_mode;
-
-    // Schema changes which don't involve a change in the schema version are
-    // allowed
-    bool add_search_index(size_t) { return true; }
-    bool remove_search_index(size_t) { return true; }
-
-    // Creating entirely new tables without a schema version bump is allowed, so
-    // we need to track if new columns are being added to a new table or an
-    // existing one
-    bool insert_group_level_table(size_t table_ndx, size_t, StringData)
-    {
-        // Shift any previously added tables after the new one
-        for (auto& table : m_new_tables) {
-            if (table >= table_ndx)
-                ++table;
-        }
-        m_new_tables.push_back(table_ndx);
-        m_current_table = table_ndx;
-        return true;
-    }
-    bool insert_column(size_t, DataType, StringData, bool) { return schema_error_unless_new_table(); }
-    bool insert_link_column(size_t, DataType, StringData, size_t, size_t) { return schema_error_unless_new_table(); }
-    bool set_link_type(size_t, LinkType) { return schema_error_unless_new_table(); }
-    bool move_column(size_t, size_t) { return schema_error_unless_new_table(); }
-    bool move_group_level_table(size_t, size_t) { return schema_error_unless_new_table(); }
-
-    // Removing or renaming things while a Realm is open is never supported
-    bool erase_group_level_table(size_t, size_t) { schema_error(); }
-    bool rename_group_level_table(size_t, StringData) { schema_error(); }
-    bool erase_column(size_t) { schema_error(); }
-    bool erase_link_column(size_t, size_t, size_t) { schema_error(); }
-    bool rename_column(size_t, StringData) { schema_error(); }
-
     bool select_descriptor(int levels, const size_t*)
     {
         // subtables not supported
@@ -142,10 +91,29 @@ public:
         return true;
     }
 
-    bool select_link_list(size_t, size_t, size_t) { return true; }
+    // Removing or renaming things while a Realm is open is never supported
+    bool erase_group_level_table(size_t, size_t) { schema_error(); }
+    bool rename_group_level_table(size_t, StringData) { schema_error(); }
+    bool erase_column(size_t) { schema_error(); }
+    bool erase_link_column(size_t, size_t, size_t) { schema_error(); }
+    bool rename_column(size_t, StringData) { schema_error(); }
+
+    // Schema changes which don't involve a change in the schema version are
+    // allowed
+    bool add_search_index(size_t) { return true; }
+    bool remove_search_index(size_t) { return true; }
+
+    // Additive changes and reorderings are supported
+    bool insert_group_level_table(size_t, size_t, StringData) { return true; }
+    bool insert_column(size_t, DataType, StringData, bool) { return true; }
+    bool insert_link_column(size_t, DataType, StringData, size_t, size_t) { return true; }
+    bool set_link_type(size_t, LinkType) { return true; }
+    bool move_column(size_t, size_t) { return true; }
+    bool move_group_level_table(size_t, size_t) { return true; }
 
     // Non-schema changes are all allowed
     void parse_complete() { }
+    bool select_link_list(size_t, size_t, size_t) { return true; }
     bool insert_empty_rows(size_t, size_t, size_t, bool) { return true; }
     bool erase_rows(size_t, size_t, size_t, bool) { return true; }
     bool swap_rows(size_t, size_t) { return true; }
@@ -159,14 +127,12 @@ public:
     bool link_list_swap(size_t, size_t) { return true; }
     bool merge_rows(size_t, size_t) { return true; }
     bool optimize_table() { return true; }
-
 };
 
 
 // A transaction log handler that just validates that all operations made are
 // ones supported by the object store
 struct TransactLogValidator : public TransactLogValidationMixin, public MarkDirtyMixin<TransactLogValidator> {
-    TransactLogValidator(SchemaMode schema_mode) { this->schema_mode = schema_mode; }
     void mark_dirty(size_t, size_t) { }
 };
 
@@ -254,8 +220,7 @@ class TransactLogObserver : public TransactLogValidationMixin, public MarkDirtyM
 public:
     template<typename Func>
     TransactLogObserver(BindingContext* context, SharedGroup& sg, Func&& func,
-                        util::Optional<SchemaMode> schema_mode,
-                        _impl::NotifierPackage& notifiers)
+                        _impl::NotifierPackage& notifiers, bool validate=true)
     : m_context(context)
     , m_notifiers(notifiers)
     , m_sg(sg)
@@ -270,12 +235,10 @@ public:
         // target version is, despite not otherwise needing to observe anything
         if (m_observers.empty() && (!m_notifiers || m_notifiers.version())) {
             m_notifiers.before_advance();
-            if (schema_mode) {
-                func(TransactLogValidator(*schema_mode));
-            }
-            else {
+            if (validate)
+                func(TransactLogValidator());
+            else
                 func();
-            }
             if (context && old_version != sg.get_version_of_current_transaction()) {
                 context->did_change({}, {});
             }
@@ -816,19 +779,19 @@ namespace realm {
 namespace _impl {
 
 namespace transaction {
-void advance(SharedGroup& sg, BindingContext* context, SchemaMode schema_mode, VersionID version)
+void advance(SharedGroup& sg, BindingContext* context, VersionID version)
 {
     _impl::NotifierPackage notifiers;
     TransactLogObserver(context, sg, [&](auto&&... args) {
         LangBindHelper::advance_read(sg, std::move(args)..., version);
-    }, schema_mode, notifiers);
+    }, notifiers);
 }
 
-void advance(SharedGroup& sg, BindingContext* context, SchemaMode schema_mode, NotifierPackage& notifiers)
+void advance(SharedGroup& sg, BindingContext* context, NotifierPackage& notifiers)
 {
     TransactLogObserver(context, sg, [&](auto&&... args) {
         LangBindHelper::advance_read(sg, std::move(args)..., notifiers.version().value_or(VersionID{}));
-    }, schema_mode, notifiers);
+    }, notifiers);
 }
 
 void begin_without_validation(SharedGroup& sg)
@@ -836,12 +799,11 @@ void begin_without_validation(SharedGroup& sg)
     LangBindHelper::promote_to_write(sg);
 }
 
-void begin(SharedGroup& sg, BindingContext* context, SchemaMode schema_mode,
-           NotifierPackage& notifiers)
+void begin(SharedGroup& sg, BindingContext* context, NotifierPackage& notifiers)
 {
     TransactLogObserver(context, sg, [&](auto&&... args) {
         LangBindHelper::promote_to_write(sg, std::move(args)...);
-    }, schema_mode, notifiers);
+    }, notifiers);
 }
 
 void commit(SharedGroup& sg)
@@ -854,12 +816,10 @@ void cancel(SharedGroup& sg, BindingContext* context)
     _impl::NotifierPackage notifiers;
     TransactLogObserver(context, sg, [&](auto&&... args) {
         LangBindHelper::rollback_and_continue_as_read(sg, std::move(args)...);
-    }, util::none, notifiers);
+    }, notifiers, false);
 }
 
-void advance(SharedGroup& sg,
-             TransactionChangeInfo& info,
-             VersionID version)
+void advance(SharedGroup& sg, TransactionChangeInfo& info, VersionID version)
 {
     if (!info.track_all && info.table_modifications_needed.empty() && info.lists.empty()) {
         LangBindHelper::advance_read(sg, version);

--- a/src/impl/transact_log_handler.hpp
+++ b/src/impl/transact_log_handler.hpp
@@ -25,7 +25,6 @@
 namespace realm {
 class BindingContext;
 class SharedGroup;
-enum class SchemaMode : uint8_t;
 
 namespace _impl {
 class NotifierPackage;
@@ -34,16 +33,13 @@ struct TransactionChangeInfo;
 namespace transaction {
 // Advance the read transaction version, with change notifications sent to delegate
 // Must not be called from within a write transaction.
-void advance(SharedGroup& sg, BindingContext* binding_context,
-             SchemaMode schema_mode, NotifierPackage&);
-void advance(SharedGroup& sg, BindingContext* binding_context,
-             SchemaMode schema_mode, VersionID);
+void advance(SharedGroup& sg, BindingContext* binding_context, NotifierPackage&);
+void advance(SharedGroup& sg, BindingContext* binding_context, VersionID);
 
 // Begin a write transaction
 // If the read transaction version is not up to date, will first advance to the
 // most recent read transaction and sent notifications to delegate
-void begin(SharedGroup& sg, BindingContext* binding_context, SchemaMode schema_mode,
-           NotifierPackage&);
+void begin(SharedGroup& sg, BindingContext* binding_context, NotifierPackage&);
 void begin_without_validation(SharedGroup& sg);
 
 // Commit a write transaction

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -464,7 +464,7 @@ void Realm::begin_transaction()
     // state, but that's unavoidable.
     if (m_is_sending_notifications) {
         _impl::NotifierPackage notifiers;
-        transaction::begin(*m_shared_group, m_binding_context.get(), m_config.schema_mode, notifiers);
+        transaction::begin(*m_shared_group, m_binding_context.get(), notifiers);
         return;
     }
 
@@ -680,7 +680,7 @@ void Realm::HandoverPackage::advance_to_version(VersionID new_version)
     // Import handover, advance version, and then repackage for handover
     auto objects = realm->accept_handover(std::move(*this));
     transaction::advance(*realm->m_shared_group, realm->m_binding_context.get(),
-                         realm->m_config.schema_mode, new_version);
+                         new_version);
     *this = realm->package_for_handover(std::move(objects));
 }
 
@@ -747,7 +747,7 @@ std::vector<AnyThreadConfined> Realm::accept_handover(Realm::HandoverPackage han
         } else {
             // We're behind, so advance to the handover's version
             transaction::advance(*m_shared_group, m_binding_context.get(),
-                                 m_config.schema_mode, handover.m_version_id);
+                                 handover.m_version_id);
             m_coordinator->process_available_async(*this);
         }
     }


### PR DESCRIPTION
The checks for things which are valid for additive-only but not automatic Realms was not being consistently applied, and fixing this isn't really worth the effort as everything either works or fails in a sensible way anyway. The checks for destructive changes remain as they actually provide some value (without the validation, trying to use a column which was deleted by a different process would produce mysterious crashes not obviously related to the root problem), and are already being always used.