### PR TITLE
Introduce the concept of an abstract execution context

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -56,6 +56,7 @@ set(HEADERS
     util/generic/event_loop_signal.hpp
     util/uv/event_loop_signal.hpp
 
+    util/aligned_union.hpp
     util/atomic_shared_ptr.hpp
     util/compiler.hpp
     util/event_loop_signal.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ set(SOURCES
 
 set(HEADERS
     collection_notifications.hpp
+    execution_context_id.hpp
     index_set.hpp
     list.hpp
     object_schema.hpp

--- a/src/execution_context_id.hpp
+++ b/src/execution_context_id.hpp
@@ -19,6 +19,8 @@
 #ifndef REALM_OS_EXECUTION_CONTEXT_ID_HPP
 #define REALM_OS_EXECUTION_CONTEXT_ID_HPP
 
+#include "util/aligned_union.hpp"
+
 #include <cstring>
 #include <thread>
 
@@ -93,7 +95,7 @@ private:
 
     template <typename> struct TypeForStorageType;
 
-    std::aligned_union_t<2, std::thread::id, AbstractExecutionContextID> m_storage;
+    util::AlignedUnion<1, std::thread::id, AbstractExecutionContextID>::type m_storage;
     Type m_type;
 };
 

--- a/src/execution_context_id.hpp
+++ b/src/execution_context_id.hpp
@@ -1,0 +1,112 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or utilied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_OS_EXECUTION_CONTEXT_ID_HPP
+#define REALM_OS_EXECUTION_CONTEXT_ID_HPP
+
+#include <cstring>
+#include <thread>
+
+#include <realm/util/assert.hpp>
+#include <realm/util/optional.hpp>
+
+namespace realm {
+
+// An identifier for an execution context other than a thread.
+// Different execution contexts must have different IDs.
+using AbstractExecutionContextID = uintptr_t;
+
+// Identifies an execution context in which a Realm will be used.
+// Can contain either a std::thread::id or an AbstractExecutionContextID.
+//
+// FIXME: This can eventually be:
+//        using AnyExecutionContextID = std::variant<std::thread::id, AbstractExecutionContextID>;
+class AnyExecutionContextID {
+    enum class Type {
+        Thread,
+        Abstract,
+    };
+
+public:
+
+    // Convert from the representation used by Realm::Config, where the absence of an
+    // explicit abstract execution context indicates that the current thread's identifier
+    // should be used.
+    AnyExecutionContextID(util::Optional<AbstractExecutionContextID> maybe_abstract_id)
+    {
+        if (maybe_abstract_id)
+            *this = AnyExecutionContextID(*maybe_abstract_id);
+        else
+            *this = AnyExecutionContextID(std::this_thread::get_id());
+    }
+
+    AnyExecutionContextID(std::thread::id thread_id) : AnyExecutionContextID(Type::Thread, std::move(thread_id)) { }
+    AnyExecutionContextID(AbstractExecutionContextID abstract_id) : AnyExecutionContextID(Type::Abstract, abstract_id) { }
+
+    template <typename StorageType>
+    bool contains() const
+    {
+        return TypeForStorageType<StorageType>::value == m_type;
+    }
+
+    template <typename StorageType>
+    StorageType get() const
+    {
+        REALM_ASSERT_DEBUG(contains<StorageType>());
+        return *reinterpret_cast<const StorageType*>(&m_storage);
+    }
+
+    bool operator==(const AnyExecutionContextID& other) const
+    {
+        return m_type == other.m_type && std::memcmp(&m_storage, &other.m_storage, sizeof(m_storage)) == 0;
+    }
+
+    bool operator!=(const AnyExecutionContextID& other) const
+    {
+        return !(*this == other);
+    }
+
+private:
+    template <typename T>
+    AnyExecutionContextID(Type type, T value) : m_type(type)
+    {
+        // operator== relies on being able to compare the raw bytes of m_storage,
+        // so zero everything before intializing the portion in use.
+        std::memset(&m_storage, 0, sizeof(m_storage));
+        new (&m_storage) T(std::move(value));
+    }
+
+    template <typename> struct TypeForStorageType;
+
+    std::aligned_union_t<2, std::thread::id, AbstractExecutionContextID> m_storage;
+    Type m_type;
+};
+
+template <>
+struct AnyExecutionContextID::TypeForStorageType<std::thread::id> {
+    constexpr static Type value = Type::Thread;
+};
+
+template <>
+struct AnyExecutionContextID::TypeForStorageType<AbstractExecutionContextID> {
+    constexpr static Type value = Type::Abstract;
+};
+
+} // namespace realm
+
+#endif // REALM_OS_EXECUTION_CONTEXT_ID_HPP

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -153,8 +153,9 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
     set_config(config);
 
     if (config.cache) {
+        AnyExecutionContextID execution_context(config.execution_context);
         for (auto& cached_realm : m_weak_realm_notifiers) {
-            if (cached_realm.is_cached_for_current_thread()) {
+            if (cached_realm.is_cached_for_execution_context(execution_context)) {
                 // can be null if we jumped in between ref count hitting zero and
                 // unregister_realm() getting the lock
                 if (auto realm = cached_realm.realm()) {

--- a/src/impl/weak_realm_notifier.cpp
+++ b/src/impl/weak_realm_notifier.cpp
@@ -24,8 +24,10 @@
 using namespace realm;
 using namespace realm::_impl;
 
+
 WeakRealmNotifier::WeakRealmNotifier(const std::shared_ptr<Realm>& realm, bool cache)
 : m_realm(realm)
+, m_execution_context(realm->config().execution_context)
 , m_realm_key(realm.get())
 , m_cache(cache)
 , m_signal(std::make_shared<util::EventLoopSignal<Callback>>(Callback{realm}))

--- a/src/impl/weak_realm_notifier.hpp
+++ b/src/impl/weak_realm_notifier.hpp
@@ -22,6 +22,8 @@
 #include <memory>
 #include <thread>
 
+#include "execution_context_id.hpp"
+
 namespace realm {
 class Realm;
 
@@ -44,7 +46,10 @@ public:
     std::shared_ptr<Realm> realm() const { return m_realm.lock(); }
 
     // Does this WeakRealmNotifier store a Realm instance that should be used on the current thread?
-    bool is_cached_for_current_thread() const { return m_cache && is_for_current_thread(); }
+    bool is_cached_for_execution_context(const AnyExecutionContextID& execution_context) const
+    {
+        return m_cache && m_execution_context == execution_context;
+    }
 
     // Has the Realm instance been destroyed?
     bool expired() const { return m_realm.expired(); }
@@ -52,13 +57,11 @@ public:
     // Is this a WeakRealmNotifier for the given Realm instance?
     bool is_for_realm(Realm* realm) const { return realm == m_realm_key; }
 
-    bool is_for_current_thread() const { return m_thread_id == std::this_thread::get_id(); }
-
     void notify();
 
 private:
     std::weak_ptr<Realm> m_realm;
-    std::thread::id m_thread_id = std::this_thread::get_id();
+    AnyExecutionContextID m_execution_context;
     void* m_realm_key;
     bool m_cache = false;
 

--- a/src/impl/weak_realm_notifier.hpp
+++ b/src/impl/weak_realm_notifier.hpp
@@ -19,10 +19,10 @@
 #ifndef REALM_WEAK_REALM_NOTIFIER_HPP
 #define REALM_WEAK_REALM_NOTIFIER_HPP
 
+#include "execution_context_id.hpp"
+
 #include <memory>
 #include <thread>
-
-#include "execution_context_id.hpp"
 
 namespace realm {
 class Realm;

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -22,8 +22,6 @@
 #include "impl/realm_coordinator.hpp"
 #include "impl/transact_log_handler.hpp"
 
-#include "execution_context_id.hpp"
-
 #include "binding_context.hpp"
 #include "object_schema.hpp"
 #include "object_store.hpp"
@@ -432,10 +430,10 @@ static void check_read_write(Realm *realm)
 
 void Realm::verify_thread() const
 {
-    if (!m_execution_context.template contains<std::thread::id>())
+    if (!m_execution_context.contains<std::thread::id>())
         return;
 
-    auto thread_id = m_execution_context.template get<std::thread::id>();
+    auto thread_id = m_execution_context.get<std::thread::id>();
     if (thread_id != std::this_thread::get_id())
         throw IncorrectThreadException();
 }

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -20,6 +20,7 @@
 #define REALM_REALM_HPP
 
 #include "schema.hpp"
+#include "execution_context_id.hpp"
 
 #include <realm/util/optional.hpp>
 #include <realm/version_id.hpp>
@@ -29,7 +30,6 @@
 #endif
 
 #include <memory>
-#include <thread>
 
 namespace realm {
 class AnyThreadConfined;
@@ -166,6 +166,10 @@ public:
         // speeds up tests that don't need notifications.
         bool automatic_change_notifications = true;
 
+        // The identifier of the abstract execution context in which this Realm will be used.
+        // If unset, the current thread's identifier will be used to identify the execution context.
+        util::Optional<AbstractExecutionContextID> execution_context;
+
         /// A data structure storing data used to configure the Realm for sync support.
         std::shared_ptr<SyncConfig> sync_config;
     };
@@ -202,7 +206,6 @@ public:
     bool compact();
     void write_copy(StringData path, BinaryData encryption_key);
 
-    std::thread::id thread_id() const { return m_thread_id; }
     void verify_thread() const;
     void verify_in_write() const;
 
@@ -296,7 +299,7 @@ private:
     Realm(Config config);
 
     Config m_config;
-    std::thread::id m_thread_id = std::this_thread::get_id();
+    AnyExecutionContextID m_execution_context;
     bool m_auto_refresh = true;
 
     std::unique_ptr<Replication> m_history;

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -19,8 +19,8 @@
 #ifndef REALM_REALM_HPP
 #define REALM_REALM_HPP
 
-#include "schema.hpp"
 #include "execution_context_id.hpp"
+#include "schema.hpp"
 
 #include <realm/util/optional.hpp>
 #include <realm/version_id.hpp>

--- a/src/util/aligned_union.hpp
+++ b/src/util/aligned_union.hpp
@@ -1,0 +1,65 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or utilied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_OS_ALIGNED_UNION_HPP
+#define REALM_OS_ALIGNED_UNION_HPP
+
+#include <cstddef>
+#include <initializer_list>
+#include <type_traits>
+
+namespace realm {
+
+// Provide our own implementation of max as GCC 4.9's is not marked as constexpr.
+namespace _impl {
+
+template <typename T>
+static constexpr const T& constexpr_max(const T& a, const T& b)
+{
+    return a > b ? a : b;
+}
+
+template <typename T>
+static constexpr const T& constexpr_max(const T* begin, const T *end)
+{
+    return begin + 1 == end ? *begin : constexpr_max(*begin, constexpr_max(begin + 1, end));
+}
+
+template <typename T>
+static constexpr const T& constexpr_max(std::initializer_list<T> list)
+{
+    return constexpr_max(list.begin(), list.end());
+}
+
+} // namespace _impl
+
+namespace util {
+
+// Provide our own implementation of `std::aligned_union` as it is missing from GCC 4.9.
+template <size_t Len, typename... Types>
+struct AlignedUnion
+{
+    static constexpr size_t alignment_value = _impl::constexpr_max({alignof(Types)...});
+    static constexpr size_t storage_size = _impl::constexpr_max({Len, sizeof(Types)...});
+    using type = typename std::aligned_storage<storage_size, alignment_value>::type;
+};
+
+} // namespace util
+} // namespace realm
+
+#endif // REALM_OS_ALIGNED_UNION_HPP

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -198,6 +198,51 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
         REQUIRE_THROWS(Realm::get_shared_realm(config));
         util::remove_dir(config.path + ".note");
     }
+
+    SECTION("should get different instances on different threads") {
+        auto realm1 = Realm::get_shared_realm(config);
+        std::thread([&]{
+            auto realm2 = Realm::get_shared_realm(config);
+            REQUIRE(realm1 != realm2);
+        }).join();
+    }
+
+    SECTION("should detect use of Realm on incorrect thread") {
+        auto realm = Realm::get_shared_realm(config);
+        std::thread([&]{
+            REQUIRE_THROWS_AS(realm->verify_thread(), IncorrectThreadException);
+        }).join();
+    }
+
+    SECTION("should get different instances for different explicit execuction contexts") {
+        config.execution_context = 0;
+        auto realm1 = Realm::get_shared_realm(config);
+        config.execution_context = 1;
+        auto realm2 = Realm::get_shared_realm(config);
+        REQUIRE(realm1 != realm2);
+
+        config.execution_context = util::none;
+        auto realm3 = Realm::get_shared_realm(config);
+        REQUIRE(realm1 != realm3);
+        REQUIRE(realm2 != realm3);
+    }
+
+    SECTION("can use Realm with explicit execution context on different thread") {
+        config.execution_context = 1;
+        auto realm = Realm::get_shared_realm(config);
+        std::thread([&]{
+            REQUIRE_NOTHROW(realm->verify_thread());
+        }).join();
+    }
+
+    SECTION("should get same instance for same explicit execution context on different thread") {
+        config.execution_context = 1;
+        auto realm1 = Realm::get_shared_realm(config);
+        std::thread([&]{
+            auto realm2 = Realm::get_shared_realm(config);
+            REQUIRE(realm1 == realm2);
+        }).join();
+    }
 }
 
 TEST_CASE("SharedRealm: notifications") {


### PR DESCRIPTION
This can be used by bindings that wish cached Realms to be keyed on something other than the thread they were created on, such as a JavaScript context or Python interpreter state.

Related to realm/realm-js#552, and will allow realm-js to easily fix realm/realm-js#473.

This should allow the thread ID changes from c34b3db85d86bf542fb57cd34f393efeac87b929 to be dropped from the `js` branch, making it possible for realm-js to use master directly.