### PR TITLE
Bring verify_open to master

### DIFF
--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -235,6 +235,8 @@ Realm::~Realm()
 
 Group& Realm::read_group()
 {
+    verify_open();
+
     if (!m_group) {
         m_group = &const_cast<Group&>(m_shared_group->begin_read());
         add_schema_change_handler();
@@ -445,6 +447,13 @@ void Realm::verify_in_write() const
     }
 }
 
+void Realm::verify_open() const
+{
+    if (is_closed()) {
+        throw ClosedRealmException("Cannot access realm that has been closed.");
+    }
+}
+
 bool Realm::is_in_transaction() const noexcept
 {
     if (!m_shared_group) {
@@ -507,6 +516,7 @@ void Realm::cancel_transaction()
 
 void Realm::invalidate()
 {
+    verify_open();
     verify_thread();
     check_read_write(this);
 

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -450,7 +450,7 @@ void Realm::verify_in_write() const
 void Realm::verify_open() const
 {
     if (is_closed()) {
-        throw ClosedRealmException("Cannot access realm that has been closed.");
+        throw ClosedRealmException();
     }
 }
 

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -208,13 +208,14 @@ public:
 
     void verify_thread() const;
     void verify_in_write() const;
+    void verify_open() const;
 
     bool can_deliver_notifications() const noexcept;
 
     // Close this Realm and remove it from the cache. Continuing to use a
-    // Realm after closing it will produce undefined behavior.
+    // Realm after closing it will throw ClosedRealmException
     void close();
-    bool is_closed() { return !m_read_only_group && !m_shared_group; }
+    bool is_closed() const { return !m_read_only_group && !m_shared_group; }
 
     // returns the file format version upgraded from if an upgrade took place
     util::Optional<int> file_format_upgraded_from_version() const;
@@ -381,6 +382,11 @@ public:
 class IncorrectThreadException : public std::logic_error {
 public:
     IncorrectThreadException() : std::logic_error("Realm accessed from incorrect thread.") {}
+};
+
+class ClosedRealmException : public std::runtime_error {
+public:
+    ClosedRealmException(std::string message) : std::runtime_error(message) {}
 };
 
 class UninitializedRealmException : public std::runtime_error {

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -384,9 +384,9 @@ public:
     IncorrectThreadException() : std::logic_error("Realm accessed from incorrect thread.") {}
 };
 
-class ClosedRealmException : public std::runtime_error {
+class ClosedRealmException : public std::logic_error {
 public:
-    ClosedRealmException(std::string message) : std::runtime_error(message) {}
+    ClosedRealmException() : std::logic_error("Cannot access realm that has been closed.") {}
 };
 
 class UninitializedRealmException : public std::runtime_error {

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -288,3 +288,28 @@ TEST_CASE("SharedRealm: notifications") {
         REQUIRE(change_count == 1);
     }
 }
+
+TEST_CASE("SharedRealm: closed realm") {
+    TestFile config;
+    config.schema_version = 1;
+    config.schema = Schema{
+        {"object", {
+            {"value", PropertyType::Int, "", "", false, false, false}
+        }},
+    };
+
+    auto realm = Realm::get_shared_realm(config);
+    realm->close();
+
+    REQUIRE(realm->is_closed());
+
+    REQUIRE_THROWS_AS(realm->read_group(), ClosedRealmException);
+    REQUIRE_THROWS_AS(realm->begin_transaction(), ClosedRealmException);
+    REQUIRE(!realm->is_in_transaction());
+    REQUIRE_THROWS_AS(realm->commit_transaction(), InvalidTransactionException);
+    REQUIRE_THROWS_AS(realm->cancel_transaction(), InvalidTransactionException);
+
+    REQUIRE_THROWS_AS(realm->refresh(), ClosedRealmException);
+    REQUIRE_THROWS_AS(realm->invalidate(), ClosedRealmException);
+    REQUIRE_THROWS_AS(realm->compact(), ClosedRealmException);
+}


### PR DESCRIPTION
This brings @kristiandupont's changes to the JS branch from #278 over to master, with the addition of some basic testing.

This is the only remaining change in `js` but not `master`.