### PR TITLE
Bring changes to lifetime of statics in realm_coordinator.cpp to master

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -44,8 +44,7 @@ using namespace realm;
 using namespace realm::_impl;
 
 static std::mutex s_coordinator_mutex;
-static std::unordered_map<std::string, std::weak_ptr<RealmCoordinator>> s_coordinators_per_path;
-
+static auto& s_coordinators_per_path = *new std::unordered_map<std::string, std::weak_ptr<RealmCoordinator>>;
 std::shared_ptr<RealmCoordinator> RealmCoordinator::get_coordinator(StringData path)
 {
     std::lock_guard<std::mutex> lock(s_coordinator_mutex);

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -43,8 +43,9 @@
 using namespace realm;
 using namespace realm::_impl;
 
-static std::mutex s_coordinator_mutex;
+static auto& s_coordinator_mutex = *new std::mutex;
 static auto& s_coordinators_per_path = *new std::unordered_map<std::string, std::weak_ptr<RealmCoordinator>>;
+
 std::shared_ptr<RealmCoordinator> RealmCoordinator::get_coordinator(StringData path)
 {
     std::lock_guard<std::mutex> lock(s_coordinator_mutex);


### PR DESCRIPTION
This brings #202 to `master` from `js`, and also fixes the lifetime of `s_coordinator_mutex` in a similar way, fixing an exception being thrown during quit that the JS binding was still working around.