### PR TITLE
Fix some incorrect handling of schema changes in the notification code

### DIFF
--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -147,7 +147,7 @@ void rotate(Container& container, size_t from, size_t to)
     if (from >= container.size() || to >= container.size())
         container.resize(std::max(from, to) + 1);
     if (from < to)
-        std::rotate(begin(container) + from, begin(container) + to, begin(container) + to + 1);
+        std::rotate(begin(container) + from, begin(container) + from + 1, begin(container) + to + 1);
     else
         std::rotate(begin(container) + to, begin(container) + from, begin(container) + from + 1);
 }
@@ -165,7 +165,7 @@ void adjust_for_move(size_t& value, size_t from, size_t to)
 {
     if (value == from)
         value = to;
-    else if (value > from && value < to)
+    else if (value > from && value <= to)
         --value;
     else if (value < from && value >= to)
         ++value;

--- a/tests/transaction_log_parsing.cpp
+++ b/tests/transaction_log_parsing.cpp
@@ -1119,7 +1119,7 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
                 }
             }
 
-            bool modified(size_t index, size_t col)
+            bool modified(size_t index, size_t col) const
             {
                 auto it = std::find_if(begin(m_result), end(m_result),
                                        [=](auto&& change) { return (void *)(uintptr_t)index == change.info; });
@@ -1128,12 +1128,12 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
                 return it->changes[col].kind != BindingContext::ColumnInfo::Kind::None;
             }
 
-            bool invalidated(size_t index)
+            bool invalidated(size_t index) const
             {
                 return std::find(begin(m_invalidated), end(m_invalidated), (void *)(uintptr_t)index) != end(m_invalidated);
             }
 
-            bool has_array_change(size_t index, size_t col, ColumnInfo::Kind kind, IndexSet values)
+            bool has_array_change(size_t index, size_t col, ColumnInfo::Kind kind, IndexSet values) const
             {
                 auto& changes = m_result[index].changes;
                 if (changes.size() <= col)
@@ -1141,6 +1141,15 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
                 auto& column = changes[col];
                 return column.kind == kind && std::equal(column.indices.as_indexes().begin(), column.indices.as_indexes().end(),
                                                          values.as_indexes().begin(), values.as_indexes().end());
+            }
+
+            size_t initial_column_index(size_t index, size_t col) const
+            {
+                auto it = std::find_if(begin(m_result), end(m_result),
+                                       [=](auto&& change) { return (void *)(uintptr_t)index == change.info; });
+                if (it == m_result.end() || col >= it->changes.size())
+                    return npos;
+                return it->changes[col].initial_column_index;
             }
 
         private:
@@ -1428,6 +1437,7 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             Row r3 = target->back();
             changes = observe({r}, [&] {
                 r.set_int(1, 6);
+                target->insert_empty_row(2);
                 size_t old = r.get_index();
                 target->merge_rows(old, 2);
                 target->move_last_over(old);
@@ -1442,6 +1452,7 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             REQUIRE(r.get_index() < target->size() - 1);
             changes = observe({r}, [&] {
                 r.set_int(1, 6);
+                target->insert_empty_row(4);
                 target->merge_rows(0, 4);
                 target->move_last_over(0);
                 r.set_int(2, 6);
@@ -1451,7 +1462,23 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             REQUIRE(changes.modified(0, 2));
         }
 
-        SECTION("inserting a column into an observed table does not break tracking") {
+        SECTION("inserting a column into an observed table before the modified column") {
+            Row r = target->get(0);
+            auto changes = observe({r}, [&] {
+                r.set_int(1, 5);
+                target->insert_column(0, type_String, "col");
+                r.set_int(3, 5);
+            });
+            REQUIRE_FALSE(changes.modified(0, 0));
+            REQUIRE_FALSE(changes.modified(0, 1));
+            REQUIRE(changes.modified(0, 2));
+            REQUIRE(changes.modified(0, 3));
+
+            REQUIRE(changes.initial_column_index(0, 2) == 1);
+            REQUIRE(changes.initial_column_index(0, 3) == 2);
+        }
+
+        SECTION("inserting a column into an observed table directly at the modified column") {
             Row r = target->get(0);
             auto changes = observe({r}, [&] {
                 r.set_int(0, 5);
@@ -1462,18 +1489,51 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             REQUIRE(changes.modified(0, 1));
             REQUIRE_FALSE(changes.modified(0, 2));
             REQUIRE(changes.modified(0, 3));
+
+            REQUIRE(changes.initial_column_index(0, 1) == 0);
+            REQUIRE(changes.initial_column_index(0, 3) == 2);
         }
 
-        SECTION("moving columns in observed tables does not break tracking") {
+        SECTION("inserting a column into an observed table after the modified column") {
             Row r = target->get(0);
             auto changes = observe({r}, [&] {
                 r.set_int(0, 5);
-                _impl::TableFriend::move_column(*target->get_descriptor(), 0, 1);
-                r.set_int(2, 5);
+                target->insert_column(1, type_String, "col");
+                r.set_int(3, 5);
+            });
+            REQUIRE(changes.modified(0, 0));
+            REQUIRE_FALSE(changes.modified(0, 1));
+            REQUIRE_FALSE(changes.modified(0, 2));
+            REQUIRE(changes.modified(0, 3));
+        }
+
+        SECTION("move modified columns") {
+            Row r = target->get(0);
+            auto changes = observe({r}, [&] {
+                r.set_int(0, 5);
+                _impl::TableFriend::move_column(*target->get_descriptor(), 0, 2);
+                r.set_int(1, 5);
             });
             REQUIRE_FALSE(changes.modified(0, 0));
             REQUIRE(changes.modified(0, 1));
             REQUIRE(changes.modified(0, 2));
+
+            REQUIRE(changes.initial_column_index(0, 0) == 1);
+            REQUIRE(changes.initial_column_index(0, 1) == 2);
+            REQUIRE(changes.initial_column_index(0, 2) == 0);
+
+            changes = observe({r}, [&] {
+                r.set_int(2, 5);
+                _impl::TableFriend::move_column(*target->get_descriptor(), 2, 0);
+                r.set_int(2, 5);
+            });
+            REQUIRE(changes.modified(0, 0));
+            REQUIRE_FALSE(changes.modified(0, 1));
+            REQUIRE(changes.modified(0, 2));
+
+            REQUIRE(changes.initial_column_index(0, 0) == 2);
+            REQUIRE(changes.initial_column_index(0, 1) == 0);
+            REQUIRE(changes.initial_column_index(0, 2) == 1);
         }
 
         SECTION("moving an observed table does not break tracking") {
@@ -1507,6 +1567,15 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             changes = observe({r}, [&] {
                 r.set_int(0, 5);
                 realm->read_group().move_table(realm->read_group().size() - 1, 0);
+                r.set_int(1, 5);
+            });
+            REQUIRE(changes.modified(0, 0));
+            REQUIRE(changes.modified(0, 1));
+
+            // moving a table directly to the position of the observed table
+            changes = observe({r}, [&] {
+                r.set_int(0, 5);
+                realm->read_group().move_table(0, r.get_table()->get_index_in_group());
                 r.set_int(1, 5);
             });
             REQUIRE(changes.modified(0, 0));


### PR DESCRIPTION
Table moves had an off-by-one error, and columns being moved to a higher index did completely the wrong thing with any modifications made before the move.