### PR TITLE
Allow GlobalNotifier to access the functions declared in Realm::Internal

### DIFF
--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -271,6 +271,7 @@ public:
     // without making it public to everyone
     class Internal {
         friend class AnyThreadConfined;
+        friend class GlobalNotifier;
         friend class _impl::CollectionNotifier;
         friend class _impl::ListNotifier;
         friend class _impl::RealmCoordinator;


### PR DESCRIPTION
This was made on the `js` branch but had not made it over to `master`.