### PR TITLE
reset file if a file format upgrade is required in ResetFile mode

### DIFF
--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -210,8 +210,8 @@ void Realm::open_with_config(const Config& config,
             options.durability = config.in_memory ? SharedGroupOptions::Durability::MemOnly :
                                                     SharedGroupOptions::Durability::Full;
             options.encryption_key = config.encryption_key.data();
-            options.allow_file_format_upgrade = !(config.disable_format_upgrade ||
-                                                  config.schema_mode == SchemaMode::ResetFile);
+            options.allow_file_format_upgrade = !config.disable_format_upgrade &&
+                                                config.schema_mode != SchemaMode::ResetFile;
             options.upgrade_callback = [&](int from_version, int to_version) {
                 if (realm) {
                     realm->upgrade_initial_version = from_version;
@@ -225,7 +225,6 @@ void Realm::open_with_config(const Config& config,
     catch (realm::FileFormatUpgradeRequired const& ex) {
         if (config.schema_mode != SchemaMode::ResetFile) {
             translate_file_exception(config.path, config.read_only());
-            return;
         }
         util::File::remove(config.path);
         open_with_config(config, history, shared_group, read_only_group, realm);


### PR DESCRIPTION
As requested in realm/realm-cocoa#4470. An alternative would be to require that both `deleteRealmIfMigrationNeeded` _and_ `disableFormatUpgrade` be set to enable this behavior. I have a test in Realm Objective-C since we don't seem to have object store tests related to file format upgrades, or sample Realms in this repo.

/cc @bdash @tgoyne 