### PR TITLE
Fix compile warning -Wvariadic-macros

### DIFF
--- a/src/impl/epoll/external_commit_helper.cpp
+++ b/src/impl/epoll/external_commit_helper.cpp
@@ -43,9 +43,9 @@
 using namespace realm;
 using namespace realm::_impl;
 
-#define LOGE(fmt...) do { \
-    fprintf(stderr, fmt); \
-    ANDROID_LOG(ANDROID_LOG_ERROR, "REALM", fmt); \
+#define LOGE(...) do { \
+    fprintf(stderr, __VA_ARGS__); \
+    ANDROID_LOG(ANDROID_LOG_ERROR, "REALM", __VA_ARGS__); \
 } while (0)
 
 namespace {

--- a/src/util/android/event_loop_signal.hpp
+++ b/src/util/android/event_loop_signal.hpp
@@ -25,9 +25,9 @@
 #include <android/log.h>
 #include <android/looper.h>
 
-#define LOGE(fmt...) do { \
-    fprintf(stderr, fmt); \
-    __android_log_print(ANDROID_LOG_ERROR, "REALM", fmt); \
+#define LOGE(...) do { \
+    fprintf(stderr, __VA_ARGS__); \
+    __android_log_print(ANDROID_LOG_ERROR, "REALM", __VA_ARGS__); \
 } while (0)
 
 namespace realm {


### PR DESCRIPTION
Gcc 4.9: "iso c does not permit named variadic macros"