### PR TITLE
Write to fifo could fail with EAGAIN

### DIFF
--- a/src/impl/epoll/external_commit_helper.cpp
+++ b/src/impl/epoll/external_commit_helper.cpp
@@ -65,7 +65,9 @@ void notify_fd(int fd)
         // write.
         if (ret != 0) {
             int err = errno;
-            throw std::system_error(err, std::system_category());
+            if (err != EAGAIN) {
+                throw std::system_error(err, std::system_category());
+            }
         }
         std::vector<uint8_t> buff(1024);
         read(fd, buff.data(), buff.size());


### PR DESCRIPTION
It is just because of the fifo is full. Clear the fifo and retry.
See https://github.com/realm/realm-java/issues/3964