### PR TITLE
Add proper support for opening a Realm without a schema and then with a schema

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -101,7 +101,9 @@ void RealmCoordinator::create_sync_session()
 
 void RealmCoordinator::set_config(const Realm::Config& config)
 {
-    if ((!m_config.read_only() && !m_notifier) || (m_config.read_only() && m_weak_realm_notifiers.empty())) {
+    bool no_existing_realm = std::all_of(begin(m_weak_realm_notifiers), end(m_weak_realm_notifiers),
+                                         [](auto& realm) { return realm.expired(); });
+    if (no_existing_realm) {
         m_config = config;
     }
     else {
@@ -116,9 +118,6 @@ void RealmCoordinator::set_config(const Realm::Config& config)
         }
         if (m_config.schema_mode != config.schema_mode) {
             throw MismatchedConfigException("Realm at path '%1' already opened with a different schema mode.", config.path);
-        }
-        if (m_config.schema_version != config.schema_version && config.schema_version != ObjectStore::NotVersioned) {
-            throw MismatchedConfigException("Realm at path '%1' already opened with different schema version.", config.path);
         }
 
 #if REALM_ENABLE_SYNC
@@ -148,35 +147,52 @@ void RealmCoordinator::set_config(const Realm::Config& config)
 
 std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
 {
-    std::lock_guard<std::mutex> lock(m_realm_mutex);
+    std::unique_lock<std::mutex> lock(m_realm_mutex);
 
     set_config(config);
 
+    auto schema = std::move(config.schema);
+    auto migration_function = std::move(config.migration_function);
+    config.schema = {};
+
+    std::shared_ptr<Realm> realm;
     if (config.cache) {
         AnyExecutionContextID execution_context(config.execution_context);
         for (auto& cached_realm : m_weak_realm_notifiers) {
-            if (cached_realm.is_cached_for_execution_context(execution_context)) {
-                // can be null if we jumped in between ref count hitting zero and
-                // unregister_realm() getting the lock
-                if (auto realm = cached_realm.realm()) {
-                    return realm;
-                }
+            if (!cached_realm.is_cached_for_execution_context(execution_context))
+                continue;
+            realm = cached_realm.realm();
+            // can be null if we jumped in between ref count hitting zero and
+            // unregister_realm() getting the lock
+            if (realm)
+                break;
+        }
+    }
+    if (!realm) {
+        realm = Realm::make_shared_realm(std::move(config), shared_from_this());
+        if (!config.read_only() && !m_notifier && config.automatic_change_notifications) {
+            try {
+                m_notifier = std::make_unique<ExternalCommitHelper>(*this);
+            }
+            catch (std::system_error const& ex) {
+                lock.unlock();
+                throw RealmFileException(RealmFileException::Kind::AccessError, config.path, ex.code().message(), "");
             }
         }
+        m_weak_realm_notifiers.emplace_back(realm, m_config.cache);
     }
 
-    auto realm = Realm::make_shared_realm(std::move(config));
-    if (!config.read_only() && !m_notifier && config.automatic_change_notifications) {
-        try {
-            m_notifier = std::make_unique<ExternalCommitHelper>(*this);
-        }
-        catch (std::system_error const& ex) {
-            throw RealmFileException(RealmFileException::Kind::AccessError, config.path, ex.code().message(), "");
-        }
-    }
-    realm->init(shared_from_this());
+    if (schema) {
+        auto old_schema_version = m_schema_version;
+        lock.unlock();
 
-    m_weak_realm_notifiers.emplace_back(realm, m_config.cache);
+        if (config.schema_version == ObjectStore::NotVersioned)
+            throw std::logic_error("A schema version must be specified when the schema is specified");
+        if (old_schema_version != ObjectStore::NotVersioned && old_schema_version != config.schema_version)
+            throw MismatchedConfigException("Realm at path '%1' already opened with different schema version.", config.path);
+        realm->update_schema(std::move(*schema), config.schema_version, std::move(migration_function));
+    }
+
     return realm;
 }
 
@@ -192,14 +208,8 @@ const Schema* RealmCoordinator::get_schema() const noexcept
 
 void RealmCoordinator::update_schema(Schema const& schema, uint64_t schema_version)
 {
-    if (m_schema_version != uint64_t(-1) && m_schema_version != schema_version && m_weak_realm_notifiers.size() > 1) {
-        throw MismatchedConfigException("Realm at path '%1' already opened with a different schema version.", m_config.path);
-    }
-
     m_schema = schema;
     m_schema_version = schema_version;
-
-    // FIXME: notify realms of the schema change
 }
 
 RealmCoordinator::RealmCoordinator() = default;

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -158,17 +158,6 @@ void Realm::open_with_config(const Config& config,
                              std::unique_ptr<Group>& read_only_group,
                              Realm* realm)
 {
-    if (config.encryption_key.data() && config.encryption_key.size() != 64)
-        throw InvalidEncryptionKeyException();
-    if (config.schema_mode == SchemaMode::ReadOnly && config.sync_config)
-        throw std::logic_error("Synchronized Realms cannot be opened in read-only mode");
-    if (config.schema_mode == SchemaMode::Additive && config.migration_function)
-        throw std::logic_error("Realms opened in Additive-only schema mode do not use a migration function");
-    if (config.schema_mode == SchemaMode::ReadOnly && config.migration_function)
-        throw std::logic_error("Realms opened in read-only mode do not use a migration function");
-    // ResetFile also won't use the migration function, but specifying one is
-    // allowed to simplify temporarily switching modes during development
-
     try {
         if (config.read_only()) {
             read_only_group = std::make_unique<Group>(config.path, config.encryption_key.data(), Group::mode_ReadOnly);

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -240,13 +240,13 @@ public:
     template <typename T>
     T resolve_thread_safe_reference(ThreadSafeReference<T> reference);
 
-    static SharedRealm make_shared_realm(Config config) {
+    static SharedRealm make_shared_realm(Config config, std::shared_ptr<_impl::RealmCoordinator> coordinator = nullptr) {
         struct make_shared_enabler : public Realm {
-            make_shared_enabler(Config config) : Realm(std::move(config)) {}
+            make_shared_enabler(Config config, std::shared_ptr<_impl::RealmCoordinator> coordinator)
+            : Realm(std::move(config), std::move(coordinator)) { }
         };
-        return std::make_shared<make_shared_enabler>(std::move(config));
+        return std::make_shared<make_shared_enabler>(std::move(config), std::move(coordinator));
     }
-    void init(std::shared_ptr<_impl::RealmCoordinator> coordinator);
 
     // Expose some internal functionality to other parts of the ObjectStore
     // without making it public to everyone
@@ -280,7 +280,7 @@ public:
 
 private:
     // `enable_shared_from_this` is unsafe with public constructors; use `make_shared_realm` instead
-    Realm(Config config);
+    Realm(Config config, std::shared_ptr<_impl::RealmCoordinator> coordinator);
 
     Config m_config;
     AnyExecutionContextID m_execution_context;


### PR DESCRIPTION
The GN needs to open Realms without specifying a schema, while in the same process the user needs to be able to open the same Realm, on the same thread/execution context and specify a schema. The code previously assumed that this switch would never happen, and so it would either throw an exception or outright ignore the supplied schema, depending on the sequence things were supplied and whether or not caching was enabled.

Fixes https://github.com/realm/realm-object-server/issues/737 and similar issues that anyone trying to use the GN would probably eventually hit.