### PR TITLE
Add before_notify to binding_context

### DIFF
--- a/src/binding_context.hpp
+++ b/src/binding_context.hpp
@@ -74,8 +74,9 @@ public:
     // actually be called?
     virtual bool can_deliver_notifications() const noexcept { return true; }
 
-    // Called by the Realm when a notification arrives which is triggered through
-    // write transaction committed by itself or a different Realm instance.
+    // Called by the Realm when refresh called or a notification arrives which
+    // is triggered through write transaction committed by itself or a different
+    // Realm instance.
     virtual void before_notify() { }
 
     // Called by the Realm when a write transaction is committed to the file by

--- a/src/binding_context.hpp
+++ b/src/binding_context.hpp
@@ -74,6 +74,10 @@ public:
     // actually be called?
     virtual bool can_deliver_notifications() const noexcept { return true; }
 
+    // Called by the Realm when a notification arrives which is triggered through
+    // write transaction committed by itself or a different Realm instance.
+    virtual void before_notify() { }
+
     // Called by the Realm when a write transaction is committed to the file by
     // a different Realm instance (possibly in a different process)
     virtual void changes_available() { }

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -559,6 +559,9 @@ void Realm::notify()
     m_is_sending_notifications = true;
     auto cleanup = util::make_scope_exit([this]() noexcept { m_is_sending_notifications = false; });
 
+    if (m_binding_context) {
+        m_binding_context->before_notify();
+    }
     if (m_shared_group->has_changed()) { // Throws
         if (m_binding_context) {
             m_binding_context->changes_available();

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -601,6 +601,9 @@ bool Realm::refresh()
     m_is_sending_notifications = true;
     auto cleanup = util::make_scope_exit([this]() noexcept { m_is_sending_notifications = false; });
 
+    if (m_binding_context) {
+        m_binding_context->before_notify();
+    }
     if (m_group) {
         return m_coordinator->advance_to_latest(*this);
     }


### PR DESCRIPTION
This is needed by java binding to integrate the Results and keep the
current realm-java collection iterator behaviour:
When write transaction begins, all collections on that thread have to be
frozen (stop calling sync_if_needed) until next event loop.
Since there is no way to inject code to be ran at the end of current
loop, realm-java needs to refresh the Results at the very beginning of
the next event loop as much as possible.

java could use binding_context::changes_available for transaction
committed by other threads, but there is no place to refresh all Results
if the transaction has been committed locally and async callback called
in the process_available_async. CollectionChangeCallback::after cannot
be used in this case since we have to ensure all the collections are
refreshed before when it will be used (eg.: in results1's async after
callback, the results2 has to be refreshed already.)

More details about java stable iterator can be seen:
https://github.com/realm/realm-java/issues/3883#issuecomment-265659475