### PR TITLE
Allow sync file manager to act on "client reset" file actions

### DIFF
--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -21,6 +21,19 @@
 #include <realm/util/file.hpp>
 #include <realm/util/scope_exit.hpp>
 
+#include <iomanip>
+#include <sstream>
+
+#if WIN32
+#include <io.h>
+#include <fcntl.h>
+
+inline static int mkstemp(char* _template) { return _open(_mktemp(_template), _O_CREAT | _O_TEMPORARY, _S_IREAD | _S_IWRITE); }
+#else
+#include <unistd.h>
+#endif
+
+
 using File = realm::util::File;
 
 namespace realm {
@@ -180,20 +193,47 @@ std::string file_path_by_appending_extension(const std::string& path, const std:
     return buffer;
 }
 
+std::string create_timestamped_template(const std::string& prefix, int wildcard_count)
+{
+    constexpr int WILDCARD_MAX = 20;
+    constexpr int WILDCARD_MIN = 6;
+    wildcard_count = std::min(WILDCARD_MAX, std::max(WILDCARD_MIN, wildcard_count));
+    std::time_t time = std::time(nullptr);
+    std::stringstream stream;
+    stream << prefix << "-" << std::put_time(std::localtime(&time), "%Y%m%d-%H%M%S") << "-" << std::string(wildcard_count, 'X');
+    return stream.str();
+}
+
+std::string reserve_unique_file_name(const std::string& path, const std::string& template_string)
+{
+    REALM_ASSERT_DEBUG(template_string.find("XXXXXX") != std::string::npos);
+    std::string path_buffer = file_path_by_appending_component(path, template_string, FilePathType::File);
+    int fd = mkstemp(&path_buffer[0]);
+    if (fd < 0) {
+        int err = errno;
+        throw std::system_error(err, std::system_category());
+    }
+    // Remove the file so we can use the name for our own file.
+    close(fd);
+    unlink(path_buffer.c_str());
+    return path_buffer;
+}
+
 } // util
 
 constexpr const char SyncFileManager::c_sync_directory[];
 constexpr const char SyncFileManager::c_utility_directory[];
+constexpr const char SyncFileManager::c_recovery_directory[];
 constexpr const char SyncFileManager::c_metadata_directory[];
 constexpr const char SyncFileManager::c_metadata_realm[];
 
-std::string SyncFileManager::get_utility_directory() const
+std::string SyncFileManager::get_special_directory(std::string directory_name) const
 {
-    auto util_path = file_path_by_appending_component(get_base_sync_directory(),
-                                                      c_utility_directory,
-                                                      util::FilePathType::Directory);
-    util::try_make_dir(util_path);
-    return util_path;
+    auto dir_path = file_path_by_appending_component(get_base_sync_directory(),
+                                                     directory_name,
+                                                     util::FilePathType::Directory);
+    util::try_make_dir(dir_path);
+    return dir_path;
 }
 
 std::string SyncFileManager::get_base_sync_directory() const
@@ -230,23 +270,17 @@ void SyncFileManager::remove_user_directory(const std::string& user_identity) co
     util::remove_nonempty_dir(user_path);
 }
 
-bool SyncFileManager::remove_realm(const std::string& user_identity, const std::string& raw_realm_path) const
+bool SyncFileManager::remove_realm(const std::string& absolute_path) const
 {
-    REALM_ASSERT(user_identity.length() > 0);
-    REALM_ASSERT(raw_realm_path.length() > 0);
-    if (filename_is_reserved(user_identity) || filename_is_reserved(raw_realm_path)) {
-        throw std::invalid_argument("A user or Realm can't have an identifier reserved by the filesystem.");
-    }
-    auto escaped = util::make_percent_encoded_string(raw_realm_path);
-    auto realm_path = util::file_path_by_appending_component(user_directory(user_identity), escaped);
+    REALM_ASSERT(absolute_path.length() > 0);
     bool success = true;
     // Remove the base Realm file (e.g. "example.realm").
-    success = File::try_remove(realm_path);
+    success = File::try_remove(absolute_path);
     // Remove the lock file (e.g. "example.realm.lock").
-    auto lock_path = util::file_path_by_appending_extension(realm_path, "lock");
+    auto lock_path = util::file_path_by_appending_extension(absolute_path, "lock");
     success = File::try_remove(lock_path);
     // Remove the management directory (e.g. "example.realm.management").
-    auto management_path = util::file_path_by_appending_extension(realm_path, "management");
+    auto management_path = util::file_path_by_appending_extension(absolute_path, "management");
     try {
         util::remove_nonempty_dir(management_path);
     }
@@ -256,6 +290,36 @@ bool SyncFileManager::remove_realm(const std::string& user_identity, const std::
         success = false;
     }
     return success;
+}
+
+bool SyncFileManager::copy_realm_file_to_recovery_directory(const std::string& absolute_path, const std::string& new_name) const
+{
+    REALM_ASSERT(absolute_path.length() > 0);
+    try {
+        auto new_path = util::file_path_by_appending_component(recovery_directory_path(), new_name);
+        if (File::exists(new_path)) {
+            return false;
+        }
+        File::copy(absolute_path, std::move(new_path));
+    } 
+    catch (File::NotFound const&) {
+    }
+    catch (File::AccessError const&) {
+        return false;
+    }
+    return true;
+}
+
+bool SyncFileManager::remove_realm(const std::string& user_identity, const std::string& raw_realm_path) const
+{
+    REALM_ASSERT(user_identity.length() > 0);
+    REALM_ASSERT(raw_realm_path.length() > 0);
+    if (filename_is_reserved(user_identity) || filename_is_reserved(raw_realm_path)) {
+        throw std::invalid_argument("A user or Realm can't have an identifier reserved by the filesystem.");
+    }
+    auto escaped = util::make_percent_encoded_string(raw_realm_path);
+    auto realm_path = util::file_path_by_appending_component(user_directory(user_identity), escaped);
+    return remove_realm(realm_path);
 }
 
 std::string SyncFileManager::path(const std::string& user_identity, const std::string& raw_realm_path) const

--- a/src/sync/impl/sync_file.hpp
+++ b/src/sync/impl/sync_file.hpp
@@ -45,6 +45,13 @@ std::string file_path_by_appending_component(const std::string& path,
 /// Given a file path and an extension, append the extension to the path.
 std::string file_path_by_appending_extension(const std::string& path, const std::string& extension);
 
+/// Create a timestamped `mktemp`-compatible template string using the current local time.
+std::string create_timestamped_template(const std::string& prefix, int wildcard_count=8);
+
+/// Reserve a unique file name based on a base directory path and a `mktemp`-compatible template string.
+/// Returns the path of the file.
+std::string reserve_unique_file_name(const std::string& path, const std::string& template_string);
+
 /// Remove a directory, including non-empty directories.
 void remove_nonempty_dir(const std::string& path);
 
@@ -66,14 +73,27 @@ public:
     /// Remove the Realm at a given path for a given user. Returns `true` if the remove operation fully succeeds.
     bool remove_realm(const std::string& user_identity, const std::string& raw_realm_path) const;
 
+    /// Remove the Realm whose primary Realm file is located at `absolute_path`. Returns `true` if the remove
+    /// operation fully succeeds.
+    bool remove_realm(const std::string& absolute_path) const;
+
+    /// Copy the Realm file at `absolute_path` to the recovery directory, with the specified `new_name`.
+    bool copy_realm_file_to_recovery_directory(const std::string& absolute_path, const std::string& new_name) const;
+
     /// Return the path for the metadata Realm files.
     std::string metadata_path() const;
 
     /// Remove the metadata Realm.
     bool remove_metadata_realm() const;
 
-    const std::string& base_path() const {
+    const std::string& base_path() const
+    {
         return m_base_path;
+    }
+
+    std::string recovery_directory_path() const
+    {
+        return get_special_directory(c_recovery_directory);
     }
 
 private:
@@ -81,10 +101,17 @@ private:
 
     static constexpr const char c_sync_directory[] = "realm-object-server";
     static constexpr const char c_utility_directory[] = "io.realm.object-server-utility";
+    static constexpr const char c_recovery_directory[] = "io.realm.object-server-recovered-realms";
     static constexpr const char c_metadata_directory[] = "metadata";
     static constexpr const char c_metadata_realm[] = "sync_metadata.realm";
 
-    std::string get_utility_directory() const;
+    std::string get_special_directory(std::string directory_name) const;
+
+    std::string get_utility_directory() const
+    {
+        return get_special_directory(c_utility_directory);
+    }
+
     std::string get_base_sync_directory() const;
 };
 

--- a/src/sync/impl/sync_metadata.cpp
+++ b/src/sync/impl/sync_metadata.cpp
@@ -264,6 +264,17 @@ void SyncUserMetadata::remove()
     m_realm = nullptr;
 }
 
+util::Optional<SyncFileActionMetadata> SyncFileActionMetadata::metadata_for_path(const std::string& original_name, const SyncMetadataManager& manager)
+{
+    auto realm = Realm::get_shared_realm(manager.get_configuration());
+    auto schema = manager.m_file_action_schema;
+    TableRef table = ObjectStore::table_for_object_type(realm->read_group(), c_sync_fileActionMetadata);
+    size_t row_idx = table->find_first_string(schema.idx_original_name, original_name);
+    if (row_idx == not_found) {
+        return none;
+    }
+    return SyncFileActionMetadata(std::move(schema), std::move(realm), table->get(row_idx));
+}                   
 
 SyncFileActionMetadata::SyncFileActionMetadata(const SyncMetadataManager& manager,
                                                Action action,

--- a/src/sync/impl/sync_metadata.hpp
+++ b/src/sync/impl/sync_metadata.hpp
@@ -93,6 +93,8 @@ public:
         HandleRealmForClientReset
     };
 
+    static util::Optional<SyncFileActionMetadata> metadata_for_path(const std::string&, const SyncMetadataManager&);
+
     // The absolute path to the Realm file in question.
     std::string original_name() const;
 

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -88,6 +88,30 @@ void SyncManager::configure_file_system(const std::string& base_file_path,
         }
 
         REALM_ASSERT(m_metadata_manager);
+        // Perform any necessary file actions.
+        std::vector<SyncFileActionMetadata> completed_actions;
+        SyncFileActionMetadataResults file_actions = m_metadata_manager->all_pending_actions();
+        for (size_t i = 0; i < file_actions.size(); i++) {
+            SyncFileActionMetadata file_action = file_actions.get(i);
+            switch (file_action.action()) {
+                case SyncFileActionMetadata::Action::DeleteRealm:
+                    // Delete all the files for the given Realm.
+                    m_file_manager->remove_realm(file_action.original_name());
+                    completed_actions.emplace_back(std::move(file_action));
+                    break;
+                case SyncFileActionMetadata::Action::HandleRealmForClientReset:
+                    // Copy the primary Realm file to the recovery dir, and then delete the Realm.
+                    auto new_name = file_action.new_name();
+                    if (new_name && m_file_manager->copy_realm_file_to_recovery_directory(file_action.original_name(), *new_name)) {
+                        m_file_manager->remove_realm(file_action.original_name());
+                        completed_actions.emplace_back(std::move(file_action));
+                    }
+                    break;
+            }
+        }
+        for (auto& action : completed_actions) {
+            action.remove();
+        }
         // Load persisted users into the users map.
         SyncUserMetadataResults users = m_metadata_manager->all_unmarked_users();
         for (size_t i = 0; i < users.size(); i++) {
@@ -128,6 +152,35 @@ void SyncManager::configure_file_system(const std::string& base_file_path,
                                                                             user_data.server_url) });
         }
     }
+}
+
+bool SyncManager::immediately_run_file_actions(const std::string& realm_path)
+{
+    if (!m_metadata_manager) {
+        return false;
+    }
+    auto metadata = SyncFileActionMetadata::metadata_for_path(realm_path, *m_metadata_manager);
+    if (!metadata) {
+        return false;
+    }
+    auto& md = *metadata;
+    switch (md.action()) {
+        case SyncFileActionMetadata::Action::DeleteRealm:
+            // Delete all the files for the given Realm.
+            m_file_manager->remove_realm(md.original_name());
+            md.remove();
+            return true;
+        case SyncFileActionMetadata::Action::HandleRealmForClientReset:
+            // Copy the primary Realm file to the recovery dir, and then delete the Realm.
+            auto new_name = md.new_name();
+            if (new_name && m_file_manager->copy_realm_file_to_recovery_directory(md.original_name(), *new_name)) {
+                m_file_manager->remove_realm(md.original_name());
+                md.remove();
+                return true;
+            }
+            break;
+    }
+    return false;
 }
 
 void SyncManager::reset_for_testing()
@@ -304,6 +357,13 @@ std::string SyncManager::path_for_realm(const std::string& user_identity, const 
     std::lock_guard<std::mutex> lock(m_file_system_mutex);
     REALM_ASSERT(m_file_manager);
     return m_file_manager->path(user_identity, raw_realm_url);
+}
+
+std::string SyncManager::recovery_directory_path() const
+{
+    std::lock_guard<std::mutex> lock(m_file_system_mutex);
+    REALM_ASSERT(m_file_manager);
+    return m_file_manager->recovery_directory_path();        
 }
 
 std::shared_ptr<SyncSession> SyncManager::get_existing_active_session(const std::string& path) const

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -69,6 +69,12 @@ public:
                                util::Optional<std::vector<char>> custom_encryption_key=none,
                                bool reset_metadata_on_error=false);
 
+    // Immediately run file actions for a single Realm at a given original path.
+    // Returns whether or not a file action was successfully executed for the specified Realm.
+    // Preconditions: all references to the Realm at the given path must have already been invalidated.
+    // The metadata and file management subsystems must also have already been configured.
+    bool immediately_run_file_actions(const std::string& original_name);
+
     void set_log_level(util::Logger::Level) noexcept;
     void set_logger_factory(SyncLoggerFactory&) noexcept;
 
@@ -103,6 +109,9 @@ public:
 
     // Get the default path for a Realm for the given user and absolute unresolved URL.
     std::string path_for_realm(const std::string& user_identity, const std::string& raw_realm_url) const;
+
+    // Get the path of the recovery directory for backed-up or recovered Realms.
+    std::string recovery_directory_path() const;
 
     // Reset the singleton state for testing purposes. DO NOT CALL OUTSIDE OF TESTING CODE.
     // Precondition: any synced Realms or `SyncSession`s must be closed or rendered inactive prior to

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -128,6 +128,14 @@ public:
         }
     };
 
+    // Expose some internal functionality to testing code.
+    struct OnlyForTesting {
+        static void handle_error(SyncSession& session, SyncError error)
+        {
+            session.handle_error(std::move(error));
+        }
+    };
+
 private:
     struct State;
     friend struct _impl::sync_session_states::WaitingForAccessToken;
@@ -142,6 +150,9 @@ private:
     // }
 
     bool can_wait_for_network_completion() const;
+
+    void handle_error(SyncError);
+    static std::string get_recovery_file_path();
 
     void set_sync_transact_callback(std::function<SyncSessionTransactCallback>);
     void set_error_handler(std::function<SyncSessionErrorHandler>);

--- a/tests/sync/metadata.cpp
+++ b/tests/sync/metadata.cpp
@@ -169,7 +169,7 @@ TEST_CASE("sync_metadata: file action metadata", "[sync]") {
     const std::string url_2 = "realm://realm.example.com/2";
 
     SECTION("can be properly constructed") {
-        const auto original_name = "/tmp/foobar/test1";
+        const auto original_name = tmp_dir() + "foobar/test1";
         auto user_metadata = SyncFileActionMetadata(manager, SyncAction::HandleRealmForClientReset, original_name, url_1, identity_1);
         REQUIRE(user_metadata.original_name() == original_name);
         REQUIRE(user_metadata.new_name() == none);
@@ -179,9 +179,9 @@ TEST_CASE("sync_metadata: file action metadata", "[sync]") {
     }
 
     SECTION("properly reflects updating state, across multiple instances") {
-        const auto original_name = "/tmp/foobar/test2a";
-        const std::string new_name_1 = "/tmp/foobar/test2b";
-        const std::string new_name_2 = "/tmp/foobar/test2c";
+        const auto original_name = tmp_dir() + "foobar/test2a";
+        const std::string new_name_1 = tmp_dir() + "foobar/test2b";
+        const std::string new_name_2 = tmp_dir() + "foobar/test2c";
         auto user_metadata_1 = SyncFileActionMetadata(manager, SyncAction::HandleRealmForClientReset, original_name, url_1, identity_1, new_name_1);
         REQUIRE(user_metadata_1.original_name() == original_name);
         REQUIRE(user_metadata_1.new_name() == new_name_1);
@@ -205,9 +205,9 @@ TEST_CASE("sync_metadata: file action metadata APIs", "[sync]") {
     reset_test_directory(base_path);
     SyncMetadataManager manager(metadata_path, false);
     SECTION("properly list all pending actions, reflecting their deletion") {
-        const auto filename1 = "/tmp/foobar/file1";
-        const auto filename2 = "/tmp/foobar/file2";
-        const auto filename3 = "/tmp/foobar/file3";
+        const auto filename1 = tmp_dir() + "foobar/file1";
+        const auto filename2 = tmp_dir() + "foobar/file2";
+        const auto filename3 = tmp_dir() + "foobar/file3";
         auto first = SyncFileActionMetadata(manager, SyncAction::HandleRealmForClientReset, filename1, "asdf", "realm://realm.example.com/1");
         auto second = SyncFileActionMetadata(manager, SyncAction::HandleRealmForClientReset, filename2, "asdf", "realm://realm.example.com/2");
         auto third = SyncFileActionMetadata(manager, SyncAction::HandleRealmForClientReset, filename3, "asdf", "realm://realm.example.com/3");

--- a/tests/sync/sync_test_utils.cpp
+++ b/tests/sync/sync_test_utils.cpp
@@ -22,9 +22,10 @@ namespace realm {
 
 bool create_dummy_realm(std::string path) {
     Realm::Config config;
-    config.path = std::move(path);
+    config.path = path;
     try {
         Realm::make_shared_realm(config);
+        REQUIRE_REALM_EXISTS(path);
         return true;
     } catch (std::exception&) {
         return false;

--- a/tests/sync/sync_test_utils.hpp
+++ b/tests/sync/sync_test_utils.hpp
@@ -48,4 +48,16 @@ std::vector<char> make_test_encryption_key(const char start = 0);
     if (dir_listing) closedir(dir_listing); \
 } while (0)
 
+#define REQUIRE_REALM_EXISTS(macro_path) do { \
+	REQUIRE(realm::util::File::exists(macro_path)); \
+	REQUIRE(realm::util::File::exists((macro_path) + ".lock")); \
+	REQUIRE_DIR_EXISTS((macro_path) + ".management"); \
+} while (0)
+
+#define REQUIRE_REALM_DOES_NOT_EXIST(macro_path) do { \
+	REQUIRE(!realm::util::File::exists(macro_path)); \
+	REQUIRE(!realm::util::File::exists((macro_path) + ".lock")); \
+	REQUIRE_DIR_DOES_NOT_EXIST((macro_path) + ".management"); \
+} while (0)
+
 #endif // REALM_SYNC_TEST_UTILS_HPP


### PR DESCRIPTION
Changes:
- When receiving a 'diverging histories' error, a client reset file action is generated
- `SyncManager` now acts on file reset actions
- `SyncError` now has a user info map
- Added more tests

Note that I had a review for this branch but I accidentally completely destroyed it when I erased the `az/client-reset` branch. @jpsim 