### PR TITLE
Fix some issues related to changing the read transaction version from within notifications

### DIFF
--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -239,10 +239,13 @@ public:
                 func(TransactLogValidator());
             else
                 func();
-            if (context && old_version != sg.get_version_of_current_transaction()) {
+            auto new_version = sg.get_version_of_current_transaction();
+            if (context && old_version != new_version)
                 context->did_change({}, {});
-            }
-            m_notifiers.deliver(sg);
+            // did_change() can change the read version, and if it does we can't
+            // deliver notifiers
+            if (new_version == sg.get_version_of_current_transaction())
+                m_notifiers.deliver(sg);
             m_notifiers.after_advance();
             return;
         }

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -509,6 +509,10 @@ void Realm::invalidate()
     verify_thread();
     check_read_write(this);
 
+    if (m_is_sending_notifications) {
+        return;
+    }
+
     if (is_in_transaction()) {
         cancel_transaction();
     }
@@ -573,30 +577,37 @@ void Realm::notify()
 
     verify_thread();
 
-    m_is_sending_notifications = true;
-    auto cleanup = util::make_scope_exit([this]() noexcept { m_is_sending_notifications = false; });
-
     if (m_binding_context) {
         m_binding_context->before_notify();
     }
-    if (m_shared_group->has_changed()) { // Throws
-        if (m_binding_context) {
-            m_binding_context->changes_available();
-        }
-        if (m_auto_refresh) {
-            if (m_group) {
-                m_coordinator->advance_to_ready(*this);
-            }
-            else  {
-                if (m_binding_context) {
-                    m_binding_context->did_change({}, {});
-                }
-                m_coordinator->process_available_async(*this);
-            }
-        }
-    }
-    else {
+
+    auto cleanup = util::make_scope_exit([this]() noexcept { m_is_sending_notifications = false; });
+    if (!m_shared_group->has_changed()) {
+        m_is_sending_notifications = true;
         m_coordinator->process_available_async(*this);
+        return;
+    }
+
+    if (m_binding_context) {
+        m_binding_context->changes_available();
+
+        // changes_available() may have advanced the read version, and if
+        // so we don't need to do anything further
+        if (!m_shared_group->has_changed())
+            return;
+    }
+
+    m_is_sending_notifications = true;
+    if (m_auto_refresh) {
+        if (m_group) {
+            m_coordinator->advance_to_ready(*this);
+        }
+        else  {
+            if (m_binding_context) {
+                m_binding_context->did_change({}, {});
+            }
+            m_coordinator->process_available_async(*this);
+        }
     }
 }
 

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -306,6 +306,8 @@ private:
     // File format versions populated when a file format upgrade takes place during realm opening
     int upgrade_initial_version = 0, upgrade_final_version = 0;
 
+    // True while sending the notifications caused by advancing the read
+    // transaction version, to avoid recursive notifications where possible
     bool m_is_sending_notifications = false;
 
     void set_schema(Schema schema, uint64_t version);


### PR DESCRIPTION
Allow calling `refresh()` and send notifications as usual when beginning a write transaction from the `changes_available()` notification.

Make `invalidate()` a no-op when called from within a notification as with `refresh()` since it doesn't have sensible semantics when there are additional notifications to be delivered.

Fix a crash when advancing the read transaction version from within `did_change()` by beginning a write transaction when there are async queries. This still breaks sensibly delivering correct fine-grained notifications.

Fixes #317.