### PR TITLE
Add a single-object "collection" notifier

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,6 +24,8 @@ set(HEADERS
     execution_context_id.hpp
     index_set.hpp
     list.hpp
+    object.hpp
+    object_accessor.hpp
     object_schema.hpp
     object_store.hpp
     property.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ set(SOURCES
     collection_notifications.cpp
     index_set.cpp
     list.cpp
+    object.cpp
     object_schema.cpp
     object_store.cpp
     results.cpp
@@ -11,6 +12,7 @@ set(SOURCES
     impl/collection_change_builder.cpp
     impl/collection_notifier.cpp
     impl/list_notifier.cpp
+    impl/object_notifier.cpp
     impl/realm_coordinator.cpp
     impl/results_notifier.cpp
     impl/transact_log_handler.cpp
@@ -43,6 +45,7 @@ set(HEADERS
     impl/collection_notifier.hpp
     impl/external_commit_helper.hpp
     impl/list_notifier.hpp
+    impl/object_notifier.hpp
     impl/realm_coordinator.hpp
     impl/results_notifier.hpp
     impl/transact_log_handler.hpp

--- a/src/binding_context.hpp
+++ b/src/binding_context.hpp
@@ -21,6 +21,7 @@
 
 #include "index_set.hpp"
 
+#include <memory>
 #include <tuple>
 #include <vector>
 
@@ -66,9 +67,12 @@ namespace realm {
 // private:
 //     std::list<std::function<void ()>> m_registered_notifications;
 // };
+class Realm;
 class BindingContext {
 public:
     virtual ~BindingContext() = default;
+
+    std::weak_ptr<Realm> realm;
 
     // If the user adds a notification handler to the Realm, will it ever
     // actually be called?

--- a/src/collection_notifications.hpp
+++ b/src/collection_notifications.hpp
@@ -85,6 +85,9 @@ struct CollectionChangeSet {
     // unreported moves which show up only as a delete/insert pair.
     std::vector<Move> moves;
 
+    // Per-column version of `modifications`
+    std::vector<IndexSet> columns;
+
     bool empty() const
     {
         return deletions.empty() && insertions.empty() && modifications.empty()

--- a/src/collection_notifications.hpp
+++ b/src/collection_notifications.hpp
@@ -23,8 +23,8 @@
 #include "util/atomic_shared_ptr.hpp"
 
 #include <exception>
-#include <functional>
 #include <memory>
+#include <type_traits>
 #include <vector>
 
 namespace realm {

--- a/src/impl/collection_change_builder.cpp
+++ b/src/impl/collection_change_builder.cpp
@@ -50,6 +50,18 @@ void CollectionChangeBuilder::merge(CollectionChangeBuilder&& c)
     verify();
     c.verify();
 
+    auto for_each_col = [&](auto&& f) {
+        f(modifications, c.modifications);
+        if (m_track_columns) {
+            if (columns.size() < c.columns.size())
+                columns.resize(c.columns.size());
+            else if (columns.size() > c.columns.size())
+                c.columns.resize(columns.size());
+            for (size_t i = 0; i < columns.size(); ++i)
+                f(columns[i], c.columns[i]);
+        }
+    };
+
     // First update any old moves
     if (!c.moves.empty() || !c.deletions.empty() || !c.insertions.empty()) {
         auto it = std::remove_if(begin(moves), end(moves), [&](auto& old) {
@@ -58,8 +70,10 @@ void CollectionChangeBuilder::merge(CollectionChangeBuilder&& c)
                 return old.to == m.from;
             });
             if (it != c.moves.end()) {
-                if (modifications.contains(it->from))
-                    c.modifications.add(it->to);
+                for_each_col([&](auto& col, auto& other) {
+                    if (col.contains(it->from))
+                        other.add(it->to);
+                });
                 old.to = it->to;
                 *it = c.moves.back();
                 c.moves.pop_back();
@@ -90,8 +104,10 @@ void CollectionChangeBuilder::merge(CollectionChangeBuilder&& c)
     // Ensure that any previously modified rows which were moved are still modified
     if (!modifications.empty() && !c.moves.empty()) {
         for (auto const& move : c.moves) {
-            if (modifications.contains(move.from))
-                c.modifications.add(move.to);
+            for_each_col([&](auto& col, auto& other) {
+                if (col.contains(move.from))
+                    other.add(move.to);
+            });
         }
     }
 
@@ -114,9 +130,11 @@ void CollectionChangeBuilder::merge(CollectionChangeBuilder&& c)
 
     clean_up_stale_moves();
 
-    modifications.erase_at(c.deletions);
-    modifications.shift_for_insert_at(c.insertions);
-    modifications.add(c.modifications);
+    for_each_col([&](auto& col, auto& other) {
+        col.erase_at(c.deletions);
+        col.shift_for_insert_at(c.insertions);
+        col.add(other);
+    });
 
     c = {};
     verify();
@@ -154,14 +172,30 @@ void CollectionChangeBuilder::parse_complete()
               [](auto const& a, auto const& b) { return a.from < b.from; });
 }
 
-void CollectionChangeBuilder::modify(size_t ndx)
+void CollectionChangeBuilder::modify(size_t ndx, size_t col)
 {
     modifications.add(ndx);
+    if (!m_track_columns || col == IndexSet::npos)
+        return;
+
+    if (col >= columns.size())
+        columns.resize(col + 1);
+    columns[col].add(ndx);
+}
+
+template<typename Func>
+void CollectionChangeBuilder::for_each_col(Func&& f)
+{
+    f(modifications);
+    if (m_track_columns) {
+        for (auto& col : columns)
+            f(col);
+    }
 }
 
 void CollectionChangeBuilder::insert(size_t index, size_t count, bool track_moves)
 {
-    modifications.shift_for_insert_at(index, count);
+    for_each_col([=](auto& col) { col.shift_for_insert_at(index, count); });
     if (!track_moves)
         return;
 
@@ -175,7 +209,7 @@ void CollectionChangeBuilder::insert(size_t index, size_t count, bool track_move
 
 void CollectionChangeBuilder::erase(size_t index)
 {
-    modifications.erase_at(index);
+    for_each_col([=](auto& col) { col.erase_at(index); });
     size_t unshifted = insertions.erase_or_unshift(index);
     if (unshifted != IndexSet::npos)
         deletions.add_shifted(unshifted);
@@ -204,6 +238,7 @@ void CollectionChangeBuilder::clear(size_t old_size)
     insertions.clear();
     moves.clear();
     m_move_mapping.clear();
+    columns.clear();
     deletions.set(old_size);
 }
 
@@ -243,13 +278,15 @@ void CollectionChangeBuilder::move(size_t from, size_t to)
         }
     }
 
-    bool modified = modifications.contains(from);
-    modifications.erase_at(from);
+    for_each_col([=](auto& col) {
+        bool modified = col.contains(from);
+        col.erase_at(from);
 
-    if (modified)
-        modifications.insert_at(to);
-    else
-        modifications.shift_for_insert_at(to);
+        if (modified)
+            col.insert_at(to);
+        else
+            col.shift_for_insert_at(to);
+    });
 }
 
 void CollectionChangeBuilder::move_over(size_t row_ndx, size_t last_row, bool track_moves)
@@ -265,17 +302,19 @@ void CollectionChangeBuilder::move_over(size_t row_ndx, size_t last_row, bool tr
                 deletions.add_shifted(shifted_from);
             m_move_mapping.erase(row_ndx);
         }
-        modifications.remove(row_ndx);
+        for_each_col([=](auto& col) { col.remove(row_ndx); });
         return;
     }
 
-    bool modified = modifications.contains(last_row);
-    if (modified) {
-        modifications.remove(last_row);
-        modifications.add(row_ndx);
-    }
-    else
-        modifications.remove(row_ndx);
+    for_each_col([=](auto& col) {
+        bool modified = col.contains(last_row);
+        if (modified) {
+            col.remove(last_row);
+            col.add(row_ndx);
+        }
+        else
+            col.remove(row_ndx);
+    });
 
     if (!track_moves)
         return;
@@ -329,18 +368,20 @@ void CollectionChangeBuilder::swap(size_t ndx_1, size_t ndx_2, bool track_moves)
     if (ndx_1 > ndx_2)
         std::swap(ndx_1, ndx_2);
 
-    bool row_1_modified = modifications.contains(ndx_1);
-    bool row_2_modified = modifications.contains(ndx_2);
-    if (row_1_modified != row_2_modified) {
-        if (row_1_modified) {
-            modifications.remove(ndx_1);
-            modifications.add(ndx_2);
+    for_each_col([=](auto& col) {
+        bool row_1_modified = col.contains(ndx_1);
+        bool row_2_modified = col.contains(ndx_2);
+        if (row_1_modified != row_2_modified) {
+            if (row_1_modified) {
+                col.remove(ndx_1);
+                col.add(ndx_2);
+            }
+            else {
+                col.remove(ndx_2);
+                col.add(ndx_1);
+            }
         }
-        else {
-            modifications.remove(ndx_2);
-            modifications.add(ndx_1);
-        }
-    }
+    });
 
     if (!track_moves)
         return;
@@ -390,9 +431,11 @@ void CollectionChangeBuilder::subsume(size_t old_ndx, size_t new_ndx, bool track
 {
     REALM_ASSERT(old_ndx != new_ndx);
 
-    if (modifications.contains(old_ndx)) {
-        modifications.add(new_ndx);
-    }
+    for_each_col([=](auto& col) {
+        if (col.contains(old_ndx)) {
+            col.add(new_ndx);
+        }
+    });
 
     if (!track_moves)
         return;
@@ -422,6 +465,24 @@ void CollectionChangeBuilder::verify()
         REALM_ASSERT(insertions.contains(move.to));
     }
 #endif
+}
+
+void CollectionChangeBuilder::insert_column(size_t ndx)
+{
+    if (ndx < columns.size())
+        columns.insert(columns.begin() + ndx, IndexSet{});
+}
+
+void CollectionChangeBuilder::move_column(size_t from, size_t to)
+{
+    if (from >= columns.size() && to >= columns.size())
+        return;
+    if (from >= columns.size() || to >= columns.size())
+        columns.resize(std::max(from, to) + 1);
+    if (from < to)
+        std::rotate(begin(columns) + from, begin(columns) + from + 1, begin(columns) + to + 1);
+    else
+        std::rotate(begin(columns) + to, begin(columns) + from, begin(columns) + from + 1);
 }
 
 namespace {
@@ -801,6 +862,7 @@ CollectionChangeSet CollectionChangeBuilder::finalize() &&
         std::move(insertions),
         std::move(modifications_in_old),
         std::move(modifications),
-        std::move(moves)
+        std::move(moves),
+        std::move(columns)
     };
 }

--- a/src/impl/collection_change_builder.hpp
+++ b/src/impl/collection_change_builder.hpp
@@ -54,7 +54,7 @@ public:
     void merge(CollectionChangeBuilder&&);
 
     void insert(size_t ndx, size_t count=1, bool track_moves=true);
-    void modify(size_t ndx);
+    void modify(size_t ndx, size_t col=-1);
     void erase(size_t ndx);
     void clear(size_t old_size);
     // }
@@ -74,8 +74,15 @@ public:
     void parse_complete();
     // }
 
+    void insert_column(size_t ndx);
+    void move_column(size_t from, size_t to);
+
 private:
     std::unordered_map<size_t, size_t> m_move_mapping;
+    bool m_track_columns = true;
+
+    template<typename Func>
+    void for_each_col(Func&& f);
 
     void verify();
 };

--- a/src/impl/collection_notifier.cpp
+++ b/src/impl/collection_notifier.cpp
@@ -266,7 +266,7 @@ void CollectionNotifier::set_table(Table const& table)
 
 void CollectionNotifier::add_required_change_info(TransactionChangeInfo& info)
 {
-    if (!do_add_required_change_info(info)) {
+    if (!do_add_required_change_info(info) || m_related_tables.empty()) {
         return;
     }
 
@@ -466,4 +466,10 @@ void NotifierPackage::after_advance()
         return;
     for (auto& notifier : m_notifiers)
         notifier->after_advance();
+}
+
+void NotifierPackage::add_notifier(std::shared_ptr<CollectionNotifier> notifier)
+{
+    m_notifiers.push_back(notifier);
+    m_coordinator->register_notifier(notifier);
 }

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -50,19 +50,9 @@ struct TransactionChangeInfo {
     std::vector<bool> table_moves_needed;
     std::vector<ListChangeInfo> lists;
     std::vector<CollectionChangeBuilder> tables;
-    bool track_all = false;
-
-#if __GNUC__ < 5
-    // GCC 4.9 does not support C++14 braced-init with NSDMIs
-    TransactionChangeInfo() {}
-    TransactionChangeInfo(std::vector<bool> table_modifications_needed,
-                          std::vector<bool> table_moves_needed,
-                          std::vector<ListChangeInfo> lists)
-    : table_modifications_needed(std::move(table_modifications_needed)),
-      table_moves_needed(std::move(table_moves_needed)),
-      lists(std::move(lists))
-    {}
-#endif
+    std::vector<std::vector<size_t>> column_indices;
+    std::vector<size_t> table_indices;
+    bool track_all;
 };
 
 class DeepChangeChecker {
@@ -314,6 +304,8 @@ public:
     void deliver(SharedGroup& sg);
     // Send the after-change notifications
     void after_advance();
+
+    void add_notifier(std::shared_ptr<CollectionNotifier> notifier);
 
 private:
     util::Optional<VersionID> m_version;

--- a/src/impl/object_notifier.cpp
+++ b/src/impl/object_notifier.cpp
@@ -1,0 +1,98 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "impl/object_notifier.hpp"
+
+#include "shared_realm.hpp"
+
+using namespace realm;
+using namespace realm::_impl;
+
+ObjectNotifier::ObjectNotifier(Row const& row, std::shared_ptr<Realm> realm)
+: CollectionNotifier(std::move(realm))
+{
+    REALM_ASSERT(row.get_table());
+    set_table(*row.get_table());
+
+    auto& sg = Realm::Internal::get_shared_group(*get_realm());
+    m_handover = sg.export_for_handover(row);
+}
+
+void ObjectNotifier::release_data() noexcept
+{
+    m_row = nullptr;
+}
+
+void ObjectNotifier::do_attach_to(SharedGroup& sg)
+{
+    REALM_ASSERT(m_handover);
+    REALM_ASSERT(!m_row);
+    m_row = sg.import_from_handover(std::move(m_handover));
+}
+
+void ObjectNotifier::do_detach_from(SharedGroup& sg)
+{
+    REALM_ASSERT(!m_handover);
+    if (m_row) {
+        m_handover = sg.export_for_handover(*m_row);
+        m_row = nullptr;
+    }
+}
+
+bool ObjectNotifier::do_add_required_change_info(TransactionChangeInfo& info)
+{
+    REALM_ASSERT(!m_handover);
+    m_info = &info;
+    if (m_row && m_row->is_attached()) {
+        size_t table_ndx = m_row->get_table()->get_index_in_group();
+        if (table_ndx >= info.table_modifications_needed.size())
+            info.table_modifications_needed.resize(table_ndx + 1);
+        info.table_modifications_needed[table_ndx] = true;
+    }
+    return false;
+}
+
+void ObjectNotifier::run()
+{
+    if (!m_row)
+        return;
+    if (!m_row->is_attached()) {
+        m_change.deletions.add(0);
+        m_row = nullptr;
+        return;
+    }
+
+    size_t table_ndx = m_row->get_table()->get_index_in_group();
+    if (table_ndx >= m_info->tables.size())
+        return;
+    auto& change = m_info->tables[table_ndx];
+    if (!change.modifications.contains(m_row->get_index()))
+        return;
+    m_change.modifications.add(0);
+    m_change.columns.reserve(change.columns.size());
+    for (auto& col : change.columns) {
+        m_change.columns.emplace_back();
+        if (col.contains(m_row->get_index()))
+            m_change.columns.back().add(0);
+    }
+}
+
+void ObjectNotifier::do_prepare_handover(SharedGroup&)
+{
+    add_changes(std::move(m_change));
+}

--- a/src/impl/object_notifier.cpp
+++ b/src/impl/object_notifier.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2016 Realm Inc.
+// Copyright 2017 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/impl/object_notifier.hpp
+++ b/src/impl/object_notifier.hpp
@@ -1,0 +1,53 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_OS_OBJECT_NOTIFIER_HPP
+#define REALM_OS_OBJECT_NOTIFIER_HPP
+
+#include "impl/collection_notifier.hpp"
+
+#include <realm/group_shared.hpp>
+
+namespace realm {
+namespace _impl {
+class ObjectNotifier : public CollectionNotifier {
+public:
+    ObjectNotifier(Row const& row, std::shared_ptr<Realm> realm);
+
+private:
+    std::unique_ptr<Row> m_row;
+    std::unique_ptr<SharedGroup::Handover<Row>> m_handover;
+
+    // The actual change, calculated in run() and delivered in prepare_handover()
+    CollectionChangeBuilder m_change;
+    TransactionChangeInfo* m_info;
+
+    void run() override;
+
+    void do_prepare_handover(SharedGroup&) override;
+
+    void do_attach_to(SharedGroup& sg) override;
+    void do_detach_from(SharedGroup& sg) override;
+
+    void release_data() noexcept override;
+    bool do_add_required_change_info(TransactionChangeInfo& info) override;
+};
+}
+}
+
+#endif // REALM_OS_OBJECT_NOTIFIER_HPP

--- a/src/impl/object_notifier.hpp
+++ b/src/impl/object_notifier.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2016 Realm Inc.
+// Copyright 2017 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -683,9 +683,10 @@ void RealmCoordinator::advance_to_ready(Realm& realm)
     notifiers.package_and_wait(util::none);
 
     auto& sg = Realm::Internal::get_shared_group(realm);
-    if (!notifiers) {
-        transaction::advance(sg, realm.m_binding_context.get(), VersionID{});
-        return;
+    if (notifiers) {
+        auto version = notifiers.version();
+        if (version && *version <= sg.get_version_of_current_transaction())
+            return;
     }
 
     transaction::advance(sg, realm.m_binding_context.get(), notifiers);

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -21,6 +21,8 @@
 
 #include "shared_realm.hpp"
 
+#include <realm/version_id.hpp>
+
 #include <condition_variable>
 #include <mutex>
 

--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -79,7 +79,7 @@ KVOAdapter::KVOAdapter(std::vector<BindingContext::ObserverState>& observers, Bi
         }
     }
 
-    auto max = max_element(begin(tables_needed), end(tables_needed));
+    auto max = std::max_element(begin(tables_needed), end(tables_needed));
     if (*max >= table_modifications_needed.size())
         table_modifications_needed.resize(*max + 1, false);
     if (*max >= table_moves_needed.size())

--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -27,10 +27,168 @@
 #include <realm/lang_bind_helper.hpp>
 
 #include <algorithm>
+#include <numeric>
 
 using namespace realm;
 
 namespace {
+
+class KVOAdapter : public _impl::TransactionChangeInfo {
+public:
+    KVOAdapter(std::vector<BindingContext::ObserverState>& observers, BindingContext* context);
+
+    void before(SharedGroup& sg);
+    void after(SharedGroup& sg);
+
+private:
+    BindingContext* m_context;
+    std::vector<BindingContext::ObserverState>& m_observers;
+    std::vector<void *> m_invalidated;
+
+    struct ListInfo {
+        BindingContext::ObserverState* observer;
+        size_t col;
+        _impl::CollectionChangeBuilder builder;
+    };
+    std::vector<ListInfo> m_lists;
+    VersionID m_version;
+};
+
+KVOAdapter::KVOAdapter(std::vector<BindingContext::ObserverState>& observers, BindingContext* context)
+: m_context(context)
+, m_observers(observers)
+{
+    if (m_observers.empty())
+        return;
+
+    std::vector<size_t> tables_needed;
+    for (auto& observer : observers) {
+        tables_needed.push_back(observer.table_ndx);
+    }
+    std::sort(begin(tables_needed), end(tables_needed));
+    tables_needed.erase(std::unique(begin(tables_needed), end(tables_needed)), end(tables_needed));
+
+    auto realm = context->realm.lock();
+    auto& group = realm->read_group();
+    for (auto& observer : observers) {
+        auto table = group.get_table(observer.table_ndx);
+        for (size_t i = 0, count = table->get_column_count(); i < count; ++i) {
+            if (table->get_column_type(i) != type_LinkList)
+                continue;
+            m_lists.push_back({&observer, i, {}});
+        }
+    }
+
+    auto max = max_element(begin(tables_needed), end(tables_needed));
+    if (*max >= table_modifications_needed.size())
+        table_modifications_needed.resize(*max + 1, false);
+    if (*max >= table_moves_needed.size())
+        table_moves_needed.resize(*max + 1, false);
+    for (auto& tbl : tables_needed) {
+        table_modifications_needed[tbl] = true;
+        table_moves_needed[tbl] = true;
+    }
+    for (auto& list : m_lists)
+        lists.push_back({list.observer->table_ndx, list.observer->row_ndx, list.col, &list.builder});
+}
+
+void KVOAdapter::before(SharedGroup& sg)
+{
+    if (!m_context)
+        return;
+
+    m_version = sg.get_version_of_current_transaction();
+    if (tables.empty())
+        return;
+
+    for (auto& observer : m_observers) {
+        size_t table_ndx = observer.table_ndx;
+        if (table_ndx < table_indices.size())
+            table_ndx = table_indices[table_ndx];
+        if (table_ndx >= tables.size())
+            continue;
+
+        auto const& table = tables[table_ndx];
+        auto const& moves = table.moves;
+        auto idx = observer.row_ndx;
+        auto it = lower_bound(begin(moves), end(moves), idx,
+                              [](auto const& a, auto b) { return a.from < b; });
+        if (it != moves.end() && it->from == idx)
+            idx = it->to;
+        else if (table.deletions.contains(idx)) {
+            m_invalidated.push_back(observer.info);
+            continue;
+        }
+        else
+            idx = table.insertions.shift(table.deletions.unshift(idx));
+        if (table.modifications.contains(idx)) {
+            observer.changes.resize(table.columns.size());
+            size_t i = 0;
+            for (auto& c : table.columns) {
+                auto& change = observer.changes[i];
+                if (table_ndx >= column_indices.size() || column_indices[table_ndx].empty())
+                    change.initial_column_index = i;
+                else if (i >= column_indices[table_ndx].size())
+                    change.initial_column_index = i - column_indices[table_ndx].size() + column_indices[table_ndx].back() + 1;
+                else
+                    change.initial_column_index = column_indices[table_ndx][i];
+                if (change.initial_column_index != npos && c.contains(idx))
+                    change.kind = BindingContext::ColumnInfo::Kind::Set;
+                ++i;
+            }
+        }
+    }
+
+    for (auto& list : m_lists) {
+        if (list.builder.empty())
+            continue;
+        // column should have been marked as modified and thus already exist in `changes`
+        REALM_ASSERT(list.col < list.observer->changes.size());
+        auto& builder = list.builder;
+        auto& changes = list.observer->changes[list.col];
+
+        // KVO can't express moves (becuase NSArray doesn't have them), so
+        // transform them into a series of sets on each effected index when possible
+        if (!builder.insertions.empty() && builder.insertions.count() == builder.moves.size()) {
+            changes.kind = BindingContext::ColumnInfo::Kind::Set;
+            changes.indices = builder.modifications;
+
+            size_t start = std::min(builder.insertions.begin()->first, builder.deletions.begin()->first);
+            size_t end = std::max(std::prev(builder.insertions.end())->second,
+                                  std::prev(builder.deletions.end())->second);
+            for (size_t i = start; i < end; ++i)
+                changes.indices.add(i);
+        }
+        // KVO can't express multiple types of changes at once
+        else if (builder.insertions.empty() + builder.modifications.empty() + builder.deletions.empty() < 2) {
+            changes.kind = BindingContext::ColumnInfo::Kind::SetAll;
+        }
+        else if (!builder.insertions.empty()) {
+            changes.kind = BindingContext::ColumnInfo::Kind::Insert;
+            changes.indices = builder.insertions;
+        }
+        else if (!builder.modifications.empty()) {
+            changes.kind = BindingContext::ColumnInfo::Kind::Set;
+            changes.indices = builder.modifications;
+        }
+        else {
+            REALM_ASSERT(!builder.deletions.empty());
+            changes.kind = BindingContext::ColumnInfo::Kind::Remove;
+            changes.indices = builder.deletions;
+        }
+    }
+    m_context->will_change(m_observers, m_invalidated);
+}
+
+void KVOAdapter::after(SharedGroup& sg)
+{
+    if (!m_context)
+        return;
+    m_context->did_change(m_observers, m_invalidated,
+                          m_version != VersionID{} &&
+                          m_version != sg.get_version_of_current_transaction());
+}
+
 template<typename Derived>
 struct MarkDirtyMixin  {
     bool mark_dirty(size_t row, size_t col, _impl::Instruction instr=_impl::instr_Set)
@@ -171,391 +329,33 @@ void adjust_for_move(size_t& value, size_t from, size_t to)
         ++value;
 }
 
-// Extends TransactLogValidator to also track changes and report it to the
-// binding context if any properties are being observed
-class TransactLogObserver : public TransactLogValidationMixin, public MarkDirtyMixin<TransactLogObserver> {
-    using ColumnInfo = BindingContext::ColumnInfo;
-    using ObserverState = BindingContext::ObserverState;
+void adjust_for_move(std::vector<size_t>& values, size_t from, size_t to)
+{
+    for (auto& value : values)
+        adjust_for_move(value, from, to);
+}
 
-    // Observed table rows which need change information
-    std::vector<ObserverState> m_observers;
-    // Userdata pointers for rows which have been deleted
-    std::vector<void *> invalidated;
-    // Delegate to send change information to
-    BindingContext* m_context;
+void expand_to(std::vector<size_t>& cols, size_t i)
+{
+    auto old_size = cols.size();
+    if (old_size > i)
+        return;
 
-    // Change information for the currently selected LinkList, if any
-    ColumnInfo* m_active_linklist = nullptr;
+    auto new_size = std::max(old_size * 2, i + 1);
+    cols.resize(new_size);
+    std::iota(&cols[old_size], &cols[new_size], old_size == 0 ? 0 : cols[old_size - 1] + 1);
+}
 
-    _impl::NotifierPackage& m_notifiers;
-    SharedGroup& m_sg;
-
-    // Get the change info for the given column, creating it if needed
-    static ColumnInfo& get_change(ObserverState& state, size_t i)
-    {
-        expand_to(state, i);
-        return state.changes[i];
+void adjust_ge(std::vector<size_t>& values, size_t i)
+{
+    for (auto& value : values) {
+        if (value >= i)
+            ++value;
     }
-
-    static void expand_to(ObserverState& state, size_t i)
-    {
-        auto old_size = state.changes.size();
-        if (old_size <= i) {
-            auto new_size = std::max(state.changes.size() * 2, i + 1);
-            state.changes.resize(new_size);
-            size_t base = old_size == 0 ? 0 : state.changes[old_size - 1].initial_column_index + 1;
-            for (size_t i = old_size; i < new_size; ++i)
-                state.changes[i].initial_column_index = i - old_size + base;
-        }
-    }
-
-    // Remove the given observer from the list of observed objects and add it
-    // to the listed of invalidated objects
-    void invalidate(ObserverState *o)
-    {
-        invalidated.push_back(o->info);
-        m_observers.erase(m_observers.begin() + (o - &m_observers[0]));
-    }
-
-public:
-    template<typename Func>
-    TransactLogObserver(BindingContext* context, SharedGroup& sg, Func&& func,
-                        _impl::NotifierPackage& notifiers, bool validate=true)
-    : m_context(context)
-    , m_notifiers(notifiers)
-    , m_sg(sg)
-    {
-        auto old_version = sg.get_version_of_current_transaction();
-        if (context) {
-            m_observers = context->get_observed_rows();
-        }
-
-        // If we have collection notifiers we have to use the transaction log
-        // observer to send will_change notifications once we know what the
-        // target version is, despite not otherwise needing to observe anything
-        if (m_observers.empty() && (!m_notifiers || m_notifiers.version())) {
-            m_notifiers.before_advance();
-            if (validate)
-                func(TransactLogValidator());
-            else
-                func();
-            auto new_version = sg.get_version_of_current_transaction();
-            if (context && old_version != new_version)
-                context->did_change({}, {});
-            // did_change() can change the read version, and if it does we can't
-            // deliver notifiers
-            if (new_version == sg.get_version_of_current_transaction())
-                m_notifiers.deliver(sg);
-            m_notifiers.after_advance();
-            return;
-        }
-
-        std::sort(begin(m_observers), end(m_observers));
-        func(*this);
-        if (context)
-            context->did_change(m_observers, invalidated, old_version != sg.get_version_of_current_transaction());
-        m_notifiers.package_and_wait(sg.get_version_of_current_transaction().version); // is a no-op if parse_complete() was called
-        m_notifiers.deliver(sg); // only will ever deliver errors
-        m_notifiers.after_advance();
-    }
-
-    // Mark the given row/col as needing notifications sent
-    void mark_dirty(size_t row_ndx, size_t col_ndx)
-    {
-        auto it = lower_bound(begin(m_observers), end(m_observers), ObserverState{current_table(), row_ndx, nullptr});
-        if (it != end(m_observers) && it->table_ndx == current_table() && it->row_ndx == row_ndx) {
-            get_change(*it, col_ndx).kind = ColumnInfo::Kind::Set;
-        }
-    }
-
-    // Called at the end of the transaction log immediately before the version
-    // is advanced
-    void parse_complete()
-    {
-        if (m_context)
-            m_context->will_change(m_observers, invalidated);
-        using sgf = _impl::SharedGroupFriend;
-        m_notifiers.package_and_wait(sgf::get_version_of_latest_snapshot(m_sg));
-        m_notifiers.before_advance();
-    }
-
-    bool insert_group_level_table(size_t table_ndx, size_t prior_size, StringData name)
-    {
-        for (auto& observer : m_observers) {
-            if (observer.table_ndx >= table_ndx)
-                ++observer.table_ndx;
-        }
-        TransactLogValidationMixin::insert_group_level_table(table_ndx, prior_size, name);
-        return true;
-    }
-
-    bool insert_empty_rows(size_t row_ndx, size_t num_rows, size_t prior_size, bool)
-    {
-        if (row_ndx != prior_size) {
-            for (auto& observer : m_observers) {
-                if (observer.table_ndx == current_table() && observer.row_ndx >= row_ndx)
-                    observer.row_ndx += num_rows;
-            }
-        }
-        return true;
-    }
-
-    bool erase_rows(size_t row_ndx, size_t rows_to_erase, size_t prior_size, bool unordered)
-    {
-        REALM_ASSERT(unordered || rows_to_erase == 1);
-        size_t last_row_ndx = prior_size - 1;
-
-        if (unordered) {
-            auto end = m_observers.end();
-            auto row_it = lower_bound(begin(m_observers), end, ObserverState{current_table(), row_ndx, nullptr});
-            auto last_it = lower_bound(row_it, end, ObserverState{current_table(), last_row_ndx, nullptr});
-            bool have_row = row_it != end && row_it->table_ndx == current_table() && row_it->row_ndx == row_ndx;
-            bool have_last = last_it != end && last_it->table_ndx == current_table() && last_it->row_ndx == last_row_ndx;
-            if (have_row && have_last) {
-                invalidated.push_back(row_it->info);
-                row_it->info = last_it->info;
-                row_it->changes = std::move(last_it->changes);
-                m_observers.erase(last_it);
-            }
-            else if (have_row) {
-                invalidated.push_back(row_it->info);
-                m_observers.erase(row_it);
-            }
-            else if (have_last) {
-                last_it->row_ndx = row_ndx;
-                std::rotate(row_it, last_it, end);
-            }
-        }
-        else {
-            for (size_t i = 0; i < m_observers.size(); ++i) {
-                auto& o = m_observers[i];
-                if (o.table_ndx == current_table()) {
-                    if (o.row_ndx == row_ndx) {
-                        invalidate(&o);
-                        --i;
-                    }
-                    else if (o.row_ndx > row_ndx) {
-                        o.row_ndx -= rows_to_erase;
-                    }
-                }
-            }
-        }
-        return true;
-    }
-
-    bool swap_rows(size_t row_ndx_1, size_t row_ndx_2)
-    {
-        REALM_ASSERT(row_ndx_1 < row_ndx_2); // this is enforced by core
-
-        auto end = m_observers.end();
-        auto it_1 = lower_bound(begin(m_observers), end, ObserverState{current_table(), row_ndx_1, nullptr});
-        auto it_2 = lower_bound(it_1, end, ObserverState{current_table(), row_ndx_2, nullptr});
-        bool have_row_1 = it_1 != end && it_1->table_ndx == current_table() && it_1->row_ndx == row_ndx_1;
-        bool have_row_2 = it_2 != end && it_2->table_ndx == current_table() && it_2->row_ndx == row_ndx_2;
-
-        if (have_row_1 && have_row_2) {
-            std::swap(it_1->info, it_2->info);
-            std::swap(it_1->changes, it_2->changes);
-        }
-        else if (have_row_1) {
-            it_1->row_ndx = row_ndx_2;
-            std::rotate(it_1, it_1 + 1, it_2);
-        }
-        else if (have_row_2) {
-            it_2->row_ndx = row_ndx_1;
-            std::rotate(it_1, it_2, end);
-        }
-
-        return true;
-    }
-
-    bool merge_rows(size_t from, size_t to)
-    {
-        REALM_ASSERT(from != to);
-
-        auto end = m_observers.end();
-        auto from_it = lower_bound(begin(m_observers), end, ObserverState{current_table(), from, nullptr});
-        if (from_it == end || from_it->table_ndx != current_table() || from_it->row_ndx != from)
-            return true;
-
-        auto to_it = lower_bound(begin(m_observers), end, ObserverState{current_table(), to, nullptr});
-        // an observer for the subsuming row should not already exist
-        REALM_ASSERT_DEBUG(to_it == end || (ObserverState{current_table(), to, nullptr}) < *to_it);
-
-        from_it->row_ndx = to;
-        if (from < to)
-            std::rotate(from_it, from_it + 1, to_it);
-        else
-            std::rotate(to_it, from_it, from_it + 1);
-        return true;
-    }
-
-    bool clear_table()
-    {
-        for (size_t i = 0; i < m_observers.size(); ) {
-            auto& o = m_observers[i];
-            if (o.table_ndx == current_table()) {
-                invalidate(&o);
-            }
-            else {
-                ++i;
-            }
-        }
-        return true;
-    }
-
-    bool select_link_list(size_t col, size_t row, size_t)
-    {
-        m_active_linklist = nullptr;
-        for (auto& o : m_observers) {
-            if (o.table_ndx == current_table() && o.row_ndx == row) {
-                m_active_linklist = &get_change(o, col);
-                break;
-            }
-        }
-        return true;
-    }
-
-    void append_link_list_change(ColumnInfo::Kind kind, size_t index) {
-        ColumnInfo *o = m_active_linklist;
-        if (!o || o->kind == ColumnInfo::Kind::SetAll) {
-            // Active LinkList isn't observed or already has multiple kinds of changes
-            return;
-        }
-
-        if (o->kind == ColumnInfo::Kind::None) {
-            o->kind = kind;
-            o->indices.add(index);
-        }
-        else if (o->kind == kind) {
-            if (kind == ColumnInfo::Kind::Remove) {
-                o->indices.add_shifted(index);
-            }
-            else if (kind == ColumnInfo::Kind::Insert) {
-                o->indices.insert_at(index);
-            }
-            else {
-                o->indices.add(index);
-            }
-        }
-        else {
-            // Array KVO can only send a single kind of change at a time, so
-            // if there are multiple just give up and send "Set"
-            o->indices.set(0);
-            o->kind = ColumnInfo::Kind::SetAll;
-        }
-    }
-
-    bool link_list_set(size_t index, size_t, size_t)
-    {
-        append_link_list_change(ColumnInfo::Kind::Set, index);
-        return true;
-    }
-
-    bool link_list_insert(size_t index, size_t, size_t)
-    {
-        append_link_list_change(ColumnInfo::Kind::Insert, index);
-        return true;
-    }
-
-    bool link_list_erase(size_t index, size_t)
-    {
-        append_link_list_change(ColumnInfo::Kind::Remove, index);
-        return true;
-    }
-
-    bool link_list_nullify(size_t index, size_t)
-    {
-        append_link_list_change(ColumnInfo::Kind::Remove, index);
-        return true;
-    }
-
-    bool link_list_swap(size_t index1, size_t index2)
-    {
-        append_link_list_change(ColumnInfo::Kind::Set, index1);
-        append_link_list_change(ColumnInfo::Kind::Set, index2);
-        return true;
-    }
-
-    bool link_list_clear(size_t old_size)
-    {
-        ColumnInfo *o = m_active_linklist;
-        if (!o || o->kind == ColumnInfo::Kind::SetAll) {
-            return true;
-        }
-
-        if (o->kind == ColumnInfo::Kind::Remove)
-            old_size += o->indices.count();
-        else if (o->kind == ColumnInfo::Kind::Insert)
-            old_size -= o->indices.count();
-
-        o->indices.set(old_size);
-
-        o->kind = ColumnInfo::Kind::Remove;
-        return true;
-    }
-
-    bool link_list_move(size_t from, size_t to)
-    {
-        ColumnInfo *o = m_active_linklist;
-        if (!o || o->kind == ColumnInfo::Kind::SetAll) {
-            return true;
-        }
-        if (from > to) {
-            std::swap(from, to);
-        }
-
-        if (o->kind == ColumnInfo::Kind::None) {
-            o->kind = ColumnInfo::Kind::Set;
-        }
-        if (o->kind == ColumnInfo::Kind::Set) {
-            for (size_t i = from; i <= to; ++i)
-                o->indices.add(i);
-        }
-        else {
-            o->indices.set(0);
-            o->kind = ColumnInfo::Kind::SetAll;
-        }
-        return true;
-    }
-
-    bool insert_column(size_t ndx, DataType, StringData, bool)
-    {
-        for (auto& observer : m_observers) {
-            if (observer.table_ndx == current_table()) {
-                expand_to(observer, ndx);
-                insert_empty_at(observer.changes, ndx);
-            }
-        }
-        return true;
-    }
-
-    bool move_column(size_t from, size_t to)
-    {
-        for (auto& observer : m_observers) {
-            if (observer.table_ndx == current_table()) {
-                // have to initialize the columns one past the moved one so that
-                // we can later initialize any more columns after that
-                expand_to(observer, std::max(from, to) + 1);
-                rotate(observer.changes, from, to);
-            }
-        }
-        return true;
-    }
-
-    bool move_group_level_table(size_t from, size_t to)
-    {
-        for (auto& observer : m_observers)
-            adjust_for_move(observer.table_ndx, from, to);
-        return true;
-    }
-
-    bool insert_link_column(size_t ndx, DataType type, StringData name, size_t, size_t) { return insert_column(ndx, type, name, false); }
-
-};
+}
 
 // Extends TransactLogValidator to track changes made to LinkViews
-class LinkViewObserver : public TransactLogValidationMixin, public MarkDirtyMixin<LinkViewObserver> {
+class TransactLogObserver : public TransactLogValidationMixin, public MarkDirtyMixin<TransactLogObserver> {
     _impl::TransactionChangeInfo& m_info;
     _impl::CollectionChangeBuilder* m_active = nullptr;
 
@@ -576,14 +376,15 @@ class LinkViewObserver : public TransactLogValidationMixin, public MarkDirtyMixi
         return m_info.track_all || (tbl_ndx < m_info.table_moves_needed.size() && m_info.table_moves_needed[tbl_ndx]);
     }
 
+
 public:
-    LinkViewObserver(_impl::TransactionChangeInfo& info)
+    TransactLogObserver(_impl::TransactionChangeInfo& info)
     : m_info(info) { }
 
-    void mark_dirty(size_t row, size_t)
+    void mark_dirty(size_t row, size_t col)
     {
         if (auto change = get_change())
-            change->modify(row);
+            change->modify(row, col);
     }
 
     void parse_complete()
@@ -660,21 +461,24 @@ public:
         return true;
     }
 
-    bool insert_empty_rows(size_t row_ndx, size_t num_rows_to_insert, size_t, bool unordered)
+    bool insert_empty_rows(size_t row_ndx, size_t num_rows_to_insert, size_t, bool)
     {
-        REALM_ASSERT(!unordered);
         if (auto change = get_change())
             change->insert(row_ndx, num_rows_to_insert, need_move_info());
         for (auto& list : m_info.lists) {
             if (list.table_ndx == current_table() && list.row_ndx >= row_ndx)
                 list.row_ndx += num_rows_to_insert;
         }
-
         return true;
     }
 
     bool erase_rows(size_t row_ndx, size_t, size_t prior_num_rows, bool unordered)
     {
+        if (!unordered) {
+            if (auto change = get_change())
+                change->deletions.add(row_ndx);
+            return true;
+        }
         REALM_ASSERT(unordered);
         size_t last_row = prior_num_rows - 1;
 
@@ -735,11 +539,27 @@ public:
 
     bool insert_column(size_t ndx, DataType, StringData, bool)
     {
+        if (auto change = get_change())
+            change->insert_column(ndx);
         for (auto& list : m_info.lists) {
             if (list.table_ndx == current_table() && list.col_ndx >= ndx)
                 ++list.col_ndx;
         }
+        if (m_info.column_indices.size() <= current_table())
+            m_info.column_indices.resize(current_table() + 1);
+        auto& indices = m_info.column_indices[current_table()];
+        expand_to(indices, ndx);
+        insert_empty_at(indices, ndx);
+        indices[ndx] = npos;
         return true;
+    }
+
+    void prepare_table_indices()
+    {
+        if (m_info.table_indices.empty() && !m_info.table_modifications_needed.empty()) {
+            m_info.table_indices.resize(m_info.table_modifications_needed.size());
+            std::iota(begin(m_info.table_indices), end(m_info.table_indices), 0);
+        }
     }
 
     bool insert_group_level_table(size_t ndx, size_t, StringData)
@@ -748,6 +568,8 @@ public:
             if (list.table_ndx >= ndx)
                 ++list.table_ndx;
         }
+        prepare_table_indices();
+        adjust_ge(m_info.table_indices, ndx);
         insert_empty_at(m_info.tables, ndx);
         insert_empty_at(m_info.table_moves_needed, ndx);
         insert_empty_at(m_info.table_modifications_needed, ndx);
@@ -756,10 +578,16 @@ public:
 
     bool move_column(size_t from, size_t to)
     {
+        if (auto change = get_change())
+            change->move_column(from, to);
         for (auto& list : m_info.lists) {
             if (list.table_ndx == current_table())
                 adjust_for_move(list.col_ndx, from, to);
         }
+        if (m_info.column_indices.size() <= current_table())
+            m_info.column_indices.resize(current_table() + 1);
+        expand_to(m_info.column_indices[current_table()], std::max(from, to) + 1);
+        rotate(m_info.column_indices[current_table()], from, to);
         return true;
     }
 
@@ -767,6 +595,9 @@ public:
     {
         for (auto& list : m_info.lists)
             adjust_for_move(list.table_ndx, from, to);
+
+        prepare_table_indices();
+        adjust_for_move(m_info.table_indices, from, to);
         rotate(m_info.tables, from, to);
         rotate(m_info.table_modifications_needed, from, to);
         rotate(m_info.table_moves_needed, from, to);
@@ -774,25 +605,88 @@ public:
     }
 
     bool insert_link_column(size_t ndx, DataType type, StringData name, size_t, size_t) { return insert_column(ndx, type, name, false); }
-
 };
+
+class KVOTransactLogObserver : public TransactLogObserver {
+    KVOAdapter m_adapter;
+    _impl::NotifierPackage& m_notifiers;
+    SharedGroup& m_sg;
+
+public:
+    KVOTransactLogObserver(std::vector<BindingContext::ObserverState>& observers,
+                     BindingContext* context,
+                     _impl::NotifierPackage& notifiers,
+                     SharedGroup& sg)
+    : TransactLogObserver(m_adapter)
+    , m_adapter(observers, context)
+    , m_notifiers(notifiers)
+    , m_sg(sg)
+    {
+    }
+
+    ~KVOTransactLogObserver()
+    {
+        m_adapter.after(m_sg);
+    }
+
+    void parse_complete()
+    {
+        TransactLogObserver::parse_complete();
+        m_adapter.before(m_sg);
+
+        using sgf = _impl::SharedGroupFriend;
+        m_notifiers.package_and_wait(sgf::get_version_of_latest_snapshot(m_sg));
+        m_notifiers.before_advance();
+    }
+};
+
+template<typename Func>
+void advance_with_notifications(BindingContext* context, SharedGroup& sg, Func&& func,
+                                _impl::NotifierPackage& notifiers)
+{
+    auto old_version = sg.get_version_of_current_transaction();
+    std::vector<BindingContext::ObserverState> observers;
+    if (context) {
+        observers = context->get_observed_rows();
+    }
+
+    // Advancing to the latest version with notifiers requires using the full
+    // transaction log observer so that we have a point where we know what
+    // version we're going to before we actually advance to that version
+    if (observers.empty() && (!notifiers || notifiers.version())) {
+        notifiers.before_advance();
+        func(TransactLogValidator());
+        auto new_version = sg.get_version_of_current_transaction();
+        if (context && old_version != new_version)
+            context->did_change({}, {});
+        // did_change() can change the read version, and if it does we can't
+        // deliver notifiers
+        if (new_version == sg.get_version_of_current_transaction())
+            notifiers.deliver(sg);
+        notifiers.after_advance();
+        return;
+    }
+
+    func(KVOTransactLogObserver(observers, context, notifiers, sg));
+    notifiers.package_and_wait(sg.get_version_of_current_transaction().version); // is a no-op if parse_complete() was called
+    notifiers.deliver(sg);
+    notifiers.after_advance();
+}
+
 } // anonymous namespace
 
 namespace realm {
 namespace _impl {
 
 namespace transaction {
-void advance(SharedGroup& sg, BindingContext* context, VersionID version)
+void advance(SharedGroup& sg, BindingContext*, VersionID version)
 {
-    _impl::NotifierPackage notifiers;
-    TransactLogObserver(context, sg, [&](auto&&... args) {
-        LangBindHelper::advance_read(sg, std::move(args)..., version);
-    }, notifiers);
+    LangBindHelper::advance_read(sg, TransactLogValidator(), version);
 }
 
 void advance(SharedGroup& sg, BindingContext* context, NotifierPackage& notifiers)
 {
-    TransactLogObserver(context, sg, [&](auto&&... args) {
+    advance_with_notifications(context, sg, [&](auto&&... args) {
         LangBindHelper::advance_read(sg, std::move(args)..., notifiers.version().value_or(VersionID{}));
     }, notifiers);
 }
@@ -804,7 +698,7 @@ void begin_without_validation(SharedGroup& sg)
 
 void begin(SharedGroup& sg, BindingContext* context, NotifierPackage& notifiers)
 {
-    TransactLogObserver(context, sg, [&](auto&&... args) {
+    advance_with_notifications(context, sg, [&](auto&&... args) {
         LangBindHelper::promote_to_write(sg, std::move(args)...);
     }, notifiers);
 }
@@ -816,10 +710,17 @@ void commit(SharedGroup& sg)
 
 void cancel(SharedGroup& sg, BindingContext* context)
 {
+    std::vector<BindingContext::ObserverState> observers;
+    if (context) {
+        observers = context->get_observed_rows();
+    }
+    if (observers.empty()) {
+        LangBindHelper::rollback_and_continue_as_read(sg);
+        return;
+    }
+
     _impl::NotifierPackage notifiers;
-    TransactLogObserver(context, sg, [&](auto&&... args) {
-        LangBindHelper::rollback_and_continue_as_read(sg, std::move(args)...);
-    }, notifiers, false);
+    LangBindHelper::rollback_and_continue_as_read(sg, KVOTransactLogObserver(observers, context, notifiers, sg));
 }
 
 void advance(SharedGroup& sg, TransactionChangeInfo& info, VersionID version)
@@ -828,7 +729,7 @@ void advance(SharedGroup& sg, TransactionChangeInfo& info, VersionID version)
         LangBindHelper::advance_read(sg, version);
     }
     else {
-        LangBindHelper::advance_read(sg, LinkViewObserver(info), version);
+        LangBindHelper::advance_read(sg, TransactLogObserver(info), version);
     }
 
 }

--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -147,8 +147,8 @@ void KVOAdapter::before(SharedGroup& sg)
         auto& builder = list.builder;
         auto& changes = list.observer->changes[list.col];
 
-        // KVO can't express moves (becuase NSArray doesn't have them), so
-        // transform them into a series of sets on each effected index when possible
+        // KVO can't express moves (becaue NSArray doesn't have them), so
+        // transform them into a series of sets on each affected index when possible
         if (!builder.insertions.empty() && builder.insertions.count() == builder.moves.size()) {
             changes.kind = BindingContext::ColumnInfo::Kind::Set;
             changes.indices = builder.modifications;

--- a/src/impl/transact_log_handler.hpp
+++ b/src/impl/transact_log_handler.hpp
@@ -50,9 +50,7 @@ void commit(SharedGroup& sg);
 void cancel(SharedGroup& sg, BindingContext* binding_context);
 
 // Advance the read transaction version, with change information gathered in info
-void advance(SharedGroup& sg,
-             TransactionChangeInfo& info,
-             VersionID version=VersionID{});
+void advance(SharedGroup& sg, TransactionChangeInfo& info, VersionID version=VersionID{});
 } // namespace transaction
 } // namespace _impl
 } // namespace realm

--- a/src/index_set.hpp
+++ b/src/index_set.hpp
@@ -20,7 +20,6 @@
 #define REALM_INDEX_SET_HPP
 
 #include <cstddef>
-#include <cstdlib>
 #include <initializer_list>
 #include <iterator>
 #include <type_traits>

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1,0 +1,34 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "object.hpp"
+
+#include "impl/object_notifier.hpp"
+#include "impl/realm_coordinator.hpp"
+
+using namespace realm;
+
+Object::~Object() = default;
+
+NotificationToken Object::add_notification_block(CollectionChangeCallback callback)
+{
+    if (!m_notifier)
+        m_notifier = std::make_shared<_impl::ObjectNotifier>(m_row, m_realm);
+    _impl::RealmCoordinator::register_notifier(m_notifier);
+    return {m_notifier, m_notifier->add_callback(std::move(callback))};
+}

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2016 Realm Inc.
+// Copyright 2017 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -1,0 +1,85 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_OS_OBJECT_HPP
+#define REALM_OS_OBJECT_HPP
+
+#include "shared_realm.hpp"
+
+#include <realm/row.hpp>
+
+namespace realm {
+class ObjectSchema;
+
+namespace _impl {
+    class ObjectNotifier;
+}
+
+class Object {
+public:
+    Object(SharedRealm r, ObjectSchema const& s, BasicRowExpr<Table> const& o)
+    : m_realm(std::move(r)), m_object_schema(&s), m_row(o) { }
+
+    Object(SharedRealm r, ObjectSchema const& s, Row const& o)
+    : m_realm(std::move(r)), m_object_schema(&s), m_row(o) { }
+
+    // property getter/setter
+    template<typename ValueType, typename ContextType>
+    void set_property_value(ContextType ctx, std::string prop_name,
+                            ValueType value, bool try_update);
+
+    template<typename ValueType, typename ContextType>
+    ValueType get_property_value(ContextType ctx, std::string prop_name);
+
+    // create an Object from a native representation
+    template<typename ValueType, typename ContextType>
+    static Object create(ContextType ctx, SharedRealm realm,
+                         const ObjectSchema &object_schema, ValueType value,
+                         bool try_update);
+
+    template<typename ValueType, typename ContextType>
+    static Object get_for_primary_key(ContextType ctx, SharedRealm realm,
+                                      const ObjectSchema &object_schema,
+                                      ValueType primary_value);
+
+    SharedRealm const& realm() const { return m_realm; }
+    ObjectSchema const& get_object_schema() const { return *m_object_schema; }
+    Row row() const { return m_row; }
+
+    bool is_valid() const { return m_row.is_attached(); }
+
+private:
+    SharedRealm m_realm;
+    const ObjectSchema *m_object_schema;
+    Row m_row;
+    std::shared_ptr<_impl::ObjectNotifier> m_notifier;
+
+    template<typename ValueType, typename ContextType>
+    void set_property_value_impl(ContextType ctx, const Property &property, ValueType value, bool try_update);
+    template<typename ValueType, typename ContextType>
+    ValueType get_property_value_impl(ContextType ctx, const Property &property);
+
+    template<typename ValueType, typename ContextType>
+    static size_t get_for_primary_key_impl(ContextType ctx, Table const& table,
+                                           const Property &primary_prop, ValueType primary_value);
+
+    inline void verify_attached();
+};
+} // namespace realm
+
+#endif // REALM_OS_OBJECT_HPP

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -24,7 +24,9 @@
 #include <realm/row.hpp>
 
 namespace realm {
+class CollectionChangeCallback;
 class ObjectSchema;
+struct NotificationToken;
 
 namespace _impl {
     class ObjectNotifier;
@@ -37,6 +39,8 @@ public:
 
     Object(SharedRealm r, ObjectSchema const& s, Row const& o)
     : m_realm(std::move(r)), m_object_schema(&s), m_row(o) { }
+
+    ~Object();
 
     // property getter/setter
     template<typename ValueType, typename ContextType>
@@ -62,6 +66,8 @@ public:
     Row row() const { return m_row; }
 
     bool is_valid() const { return m_row.is_attached(); }
+
+    NotificationToken add_notification_block(CollectionChangeCallback callback);
 
 private:
     SharedRealm m_realm;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2016 Realm Inc.
+// Copyright 2017 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/src/object_accessor.hpp
+++ b/src/object_accessor.hpp
@@ -16,15 +16,16 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#ifndef REALM_OBJECT_ACCESSOR_HPP
-#define REALM_OBJECT_ACCESSOR_HPP
+#ifndef REALM_OS_OBJECT_ACCESSOR_HPP
+#define REALM_OS_OBJECT_ACCESSOR_HPP
+
+#include "object.hpp"
 
 #include "list.hpp"
 #include "object_schema.hpp"
 #include "object_store.hpp"
 #include "results.hpp"
 #include "schema.hpp"
-#include "shared_realm.hpp"
 #include "util/format.hpp"
 
 #include <string>
@@ -32,410 +33,369 @@
 #include <realm/table_view.hpp>
 
 namespace realm {
+//
+// Value converters - template specializations must be implemented for each platform in order to call templated methods on Object
+//
+template<typename ValueType, typename ContextType>
+class NativeAccessor {
+public:
+    static bool dict_has_value_for_key(ContextType ctx, ValueType dict, const std::string &prop_name);
+    static ValueType dict_value_for_key(ContextType ctx, ValueType dict, const std::string &prop_name);
 
-    class Object {
-    public:
-        Object(SharedRealm r, const ObjectSchema &s, Row o) : m_realm(r), m_object_schema(&s), m_row(o) {}
+    static bool has_default_value_for_property(ContextType ctx, Realm *realm, const ObjectSchema &object_schema, const std::string &prop_name);
+    static ValueType default_value_for_property(ContextType ctx, Realm *realm, const ObjectSchema &object_schema, const std::string &prop_name);
 
-        // property getter/setter
-        template<typename ValueType, typename ContextType>
-        inline void set_property_value(ContextType ctx, std::string prop_name, ValueType value, bool try_update);
+    static bool to_bool(ContextType, ValueType &);
+    static ValueType from_bool(ContextType, bool);
+    static long long to_long(ContextType, ValueType &);
+    static ValueType from_long(ContextType, long long);
+    static float to_float(ContextType, ValueType &);
+    static ValueType from_float(ContextType, float);
+    static double to_double(ContextType, ValueType &);
+    static ValueType from_double(ContextType, double);
+    static std::string to_string(ContextType, ValueType &);
+    static ValueType from_string(ContextType, StringData);
+    static std::string to_binary(ContextType, ValueType &);
+    static ValueType from_binary(ContextType, BinaryData);
+    static Timestamp to_timestamp(ContextType, ValueType &);
+    static ValueType from_timestamp(ContextType, Timestamp);
 
-        template<typename ValueType, typename ContextType>
-        inline ValueType get_property_value(ContextType ctx, std::string prop_name);
+    static bool is_null(ContextType, ValueType &);
+    static ValueType null_value(ContextType);
 
-        // create an Object from a native representation
-        template<typename ValueType, typename ContextType>
-        static inline Object create(ContextType ctx, SharedRealm realm, const ObjectSchema &object_schema, ValueType value, bool try_update);
+    // convert value to persisted object
+    // for existing objects return the existing row index
+    // for new/updated objects return the row index
+    static size_t to_object_index(ContextType ctx, SharedRealm realm, ValueType &val, const std::string &type, bool try_update);
+    static ValueType from_object(ContextType ctx, Object);
 
-        template<typename ValueType, typename ContextType>
-        static Object get_for_primary_key(ContextType ctx, SharedRealm realm, const ObjectSchema &object_schema, ValueType primary_value);
+    // object index for an existing object
+    static size_t to_existing_object_index(ContextType ctx, SharedRealm realm, ValueType &val);
 
-        SharedRealm realm() const { return m_realm; }
-        const ObjectSchema &get_object_schema() const { return *m_object_schema; }
-        Row row() const { return m_row; }
+    // list value accessors
+    static size_t list_size(ContextType ctx, ValueType &val);
+    static ValueType list_value_at_index(ContextType ctx, ValueType &val, size_t index);
+    static ValueType from_list(ContextType ctx, List);
 
-        bool is_valid() const { return m_row.is_attached(); }
-
-    private:
-        SharedRealm m_realm;
-        const ObjectSchema *m_object_schema;
-        Row m_row;
-
-        template<typename ValueType, typename ContextType>
-        inline void set_property_value_impl(ContextType ctx, const Property &property, ValueType value, bool try_update);
-        template<typename ValueType, typename ContextType>
-        inline ValueType get_property_value_impl(ContextType ctx, const Property &property);
-
-        template<typename ValueType, typename ContextType>
-        static size_t get_for_primary_key_impl(ContextType ctx, const ConstTableRef &table, const Property &primary_prop, ValueType primary_value);
-        
-        inline void verify_attached();
-    };
-
-    //
-    // Value converters - template specializations must be implemented for each platform in order to call templated methods on Object
-    //
-    template<typename ValueType, typename ContextType>
-    class NativeAccessor {
-    public:
-        static bool dict_has_value_for_key(ContextType ctx, ValueType dict, const std::string &prop_name);
-        static ValueType dict_value_for_key(ContextType ctx, ValueType dict, const std::string &prop_name);
-
-        static bool has_default_value_for_property(ContextType ctx, Realm *realm, const ObjectSchema &object_schema, const std::string &prop_name);
-        static ValueType default_value_for_property(ContextType ctx, Realm *realm, const ObjectSchema &object_schema, const std::string &prop_name);
-
-        static bool to_bool(ContextType, ValueType &);
-        static ValueType from_bool(ContextType, bool);
-        static long long to_long(ContextType, ValueType &);
-        static ValueType from_long(ContextType, long long);
-        static float to_float(ContextType, ValueType &);
-        static ValueType from_float(ContextType, float);
-        static double to_double(ContextType, ValueType &);
-        static ValueType from_double(ContextType, double);
-        static std::string to_string(ContextType, ValueType &);
-        static ValueType from_string(ContextType, StringData);
-        static std::string to_binary(ContextType, ValueType &);
-        static ValueType from_binary(ContextType, BinaryData);
-        static Timestamp to_timestamp(ContextType, ValueType &);
-        static ValueType from_timestamp(ContextType, Timestamp);
-
-        static bool is_null(ContextType, ValueType &);
-        static ValueType null_value(ContextType);
-
-        // convert value to persisted object
-        // for existing objects return the existing row index
-        // for new/updated objects return the row index
-        static size_t to_object_index(ContextType ctx, SharedRealm realm, ValueType &val, const std::string &type, bool try_update);
-        static ValueType from_object(ContextType ctx, Object);
-
-        // object index for an existing object
-        static size_t to_existing_object_index(ContextType ctx, SharedRealm realm, ValueType &val);
-
-        // list value accessors
-        static size_t list_size(ContextType ctx, ValueType &val);
-        static ValueType list_value_at_index(ContextType ctx, ValueType &val, size_t index);
-        static ValueType from_list(ContextType ctx, List);
-
-        // results value accessors
-        static ValueType from_results(ContextType ctx, Results);
-
-        //
-        // Deprecated
-        //
-        static Mixed to_mixed(ContextType, ValueType&) { throw std::logic_error("'Any' type is unsupported"); }
-    };
-
-    struct InvalidatedObjectException : public std::logic_error {
-        InvalidatedObjectException(const std::string& object_type, const std::string& message) :
-            std::logic_error(message), object_type(object_type) {}
-        const std::string object_type;
-    };
-    
-    struct InvalidPropertyException : public std::logic_error {
-        InvalidPropertyException(const std::string& object_type, const std::string& property_name, const std::string& message) :
-            std::logic_error(message), object_type(object_type), property_name(property_name) {}
-        const std::string object_type;
-        const std::string property_name;
-    };
-
-    struct MissingPropertyValueException : public std::logic_error {
-        MissingPropertyValueException(const std::string& object_type, const std::string& property_name, const std::string& message) :
-            std::logic_error(message), object_type(object_type), property_name(property_name) {}
-        const std::string object_type;
-        const std::string property_name;
-    };
-
-    struct MissingPrimaryKeyException : public std::logic_error {
-        MissingPrimaryKeyException(const std::string& object_type, const std::string& message) : std::logic_error(message), object_type(object_type) {}
-        const std::string object_type;
-    };
-
-    struct ReadOnlyPropertyException : public std::logic_error {
-        ReadOnlyPropertyException(const std::string& object_type, const std::string& property_name, const std::string& message) :
-            std::logic_error(message), object_type(object_type), property_name(property_name) {}
-        const std::string object_type;
-        const std::string property_name;
-    };
-
-    struct MutationOutsideTransactionException : public std::logic_error {
-        MutationOutsideTransactionException(const std::string& message) : std::logic_error(message) {}
-    };
+    // results value accessors
+    static ValueType from_results(ContextType ctx, Results);
 
     //
-    // template method implementations
+    // Deprecated
     //
-    template <typename ValueType, typename ContextType>
-    inline void Object::set_property_value(ContextType ctx, std::string prop_name, ValueType value, bool try_update)
-    {
-        const Property *prop = m_object_schema->property_for_name(prop_name);
-        if (!prop) {
-            throw InvalidPropertyException(m_object_schema->name, prop_name,
-                "Setting invalid property '" + prop_name + "' on object '" + m_object_schema->name + "'.");
-        }
-        set_property_value_impl(ctx, *prop, value, try_update);
+    static Mixed to_mixed(ContextType, ValueType&) { throw std::logic_error("'Any' type is unsupported"); }
+};
+
+struct InvalidatedObjectException : public std::logic_error {
+    InvalidatedObjectException(const std::string& object_type, const std::string& message) :
+        std::logic_error(message), object_type(object_type) {}
+    const std::string object_type;
+};
+
+struct InvalidPropertyException : public std::logic_error {
+    InvalidPropertyException(const std::string& object_type, const std::string& property_name, const std::string& message) :
+        std::logic_error(message), object_type(object_type), property_name(property_name) {}
+    const std::string object_type;
+    const std::string property_name;
+};
+
+struct MissingPropertyValueException : public std::logic_error {
+    MissingPropertyValueException(const std::string& object_type, const std::string& property_name, const std::string& message) :
+        std::logic_error(message), object_type(object_type), property_name(property_name) {}
+    const std::string object_type;
+    const std::string property_name;
+};
+
+struct MissingPrimaryKeyException : public std::logic_error {
+    MissingPrimaryKeyException(const std::string& object_type, const std::string& message) : std::logic_error(message), object_type(object_type) {}
+    const std::string object_type;
+};
+
+struct ReadOnlyPropertyException : public std::logic_error {
+    ReadOnlyPropertyException(const std::string& object_type, const std::string& property_name, const std::string& message) :
+        std::logic_error(message), object_type(object_type), property_name(property_name) {}
+    const std::string object_type;
+    const std::string property_name;
+};
+
+struct MutationOutsideTransactionException : public std::logic_error {
+    MutationOutsideTransactionException(const std::string& message) : std::logic_error(message) {}
+};
+
+//
+// template method implementations
+//
+template <typename ValueType, typename ContextType>
+void Object::set_property_value(ContextType ctx, std::string prop_name, ValueType value, bool try_update)
+{
+    const Property *prop = m_object_schema->property_for_name(prop_name);
+    if (!prop) {
+        throw InvalidPropertyException(m_object_schema->name, prop_name,
+            "Setting invalid property '" + prop_name + "' on object '" + m_object_schema->name + "'.");
+    }
+    set_property_value_impl(ctx, *prop, value, try_update);
+}
+
+template <typename ValueType, typename ContextType>
+ValueType Object::get_property_value(ContextType ctx, std::string prop_name)
+{
+    const Property *prop = m_object_schema->property_for_name(prop_name);
+    if (!prop) {
+        throw InvalidPropertyException(m_object_schema->name, prop_name,
+            "Getting invalid property '" + prop_name + "' on object '" + m_object_schema->name + "'.");
+    }
+    return get_property_value_impl<ValueType>(ctx, *prop);
+}
+
+template <typename ValueType, typename ContextType>
+void Object::set_property_value_impl(ContextType ctx, const Property &property, ValueType value, bool try_update)
+{
+    using Accessor = NativeAccessor<ValueType, ContextType>;
+
+    verify_attached();
+
+    if (!m_realm->is_in_transaction()) {
+        throw MutationOutsideTransactionException("Can only set property values within a transaction.");
     }
 
-    template <typename ValueType, typename ContextType>
-    inline ValueType Object::get_property_value(ContextType ctx, std::string prop_name)
-    {
-        const Property *prop = m_object_schema->property_for_name(prop_name);
-        if (!prop) {
-            throw InvalidPropertyException(m_object_schema->name, prop_name,
-                "Getting invalid property '" + prop_name + "' on object '" + m_object_schema->name + "'.");
+    size_t column = property.table_column;
+    if (property.is_nullable && Accessor::is_null(ctx, value)) {
+        if (property.type == PropertyType::Object) {
+            m_row.nullify_link(column);
         }
-        return get_property_value_impl<ValueType>(ctx, *prop);
+        else {
+            m_row.set_null(column);
+        }
+        return;
     }
 
-    template <typename ValueType, typename ContextType>
-    inline void Object::set_property_value_impl(ContextType ctx, const Property &property, ValueType value, bool try_update)
-    {
-        using Accessor = NativeAccessor<ValueType, ContextType>;
-
-        verify_attached();
-
-        if (!m_realm->is_in_transaction()) {
-            throw MutationOutsideTransactionException("Can only set property values within a transaction.");
+    switch (property.type) {
+        case PropertyType::Bool:
+            m_row.set_bool(column, Accessor::to_bool(ctx, value));
+            break;
+        case PropertyType::Int:
+            if (property.is_primary)
+                m_row.set_int_unique(column, Accessor::to_long(ctx, value));
+            else
+                m_row.set_int(column, Accessor::to_long(ctx, value));
+            break;
+        case PropertyType::Float:
+            m_row.set_float(column, Accessor::to_float(ctx, value));
+            break;
+        case PropertyType::Double:
+            m_row.set_double(column, Accessor::to_double(ctx, value));
+            break;
+        case PropertyType::String: {
+            auto string_value = Accessor::to_string(ctx, value);
+            if (property.is_primary)
+                m_row.set_string_unique(column, string_value);
+            else
+                m_row.set_string(column, string_value);
+            break;
         }
-
-        size_t column = property.table_column;
-        if (property.is_nullable && Accessor::is_null(ctx, value)) {
-            if (property.type == PropertyType::Object) {
+        case PropertyType::Data:
+            m_row.set_binary(column, BinaryData(Accessor::to_binary(ctx, value)));
+            break;
+        case PropertyType::Any:
+            m_row.set_mixed(column, Accessor::to_mixed(ctx, value));
+            break;
+        case PropertyType::Date:
+            m_row.set_timestamp(column, Accessor::to_timestamp(ctx, value));
+            break;
+        case PropertyType::Object: {
+            if (Accessor::is_null(ctx, value)) {
                 m_row.nullify_link(column);
             }
             else {
-                m_row.set_null(column);
+                m_row.set_link(column, Accessor::to_object_index(ctx, m_realm, value, property.object_type, try_update));
             }
-            return;
+            break;
         }
-
-        switch (property.type) {
-            case PropertyType::Bool:
-                m_row.set_bool(column, Accessor::to_bool(ctx, value));
-                break;
-            case PropertyType::Int:
-                if (property.is_primary)
-                    m_row.set_int_unique(column, Accessor::to_long(ctx, value));
-                else
-                    m_row.set_int(column, Accessor::to_long(ctx, value));
-                break;
-            case PropertyType::Float:
-                m_row.set_float(column, Accessor::to_float(ctx, value));
-                break;
-            case PropertyType::Double:
-                m_row.set_double(column, Accessor::to_double(ctx, value));
-                break;
-            case PropertyType::String: {
-                auto string_value = Accessor::to_string(ctx, value);
-                if (property.is_primary)
-                    m_row.set_string_unique(column, string_value);
-                else
-                    m_row.set_string(column, string_value);
-                break;
-            }
-            case PropertyType::Data:
-                m_row.set_binary(column, BinaryData(Accessor::to_binary(ctx, value)));
-                break;
-            case PropertyType::Any:
-                m_row.set_mixed(column, Accessor::to_mixed(ctx, value));
-                break;
-            case PropertyType::Date:
-                m_row.set_timestamp(column, Accessor::to_timestamp(ctx, value));
-                break;
-            case PropertyType::Object: {
-                if (Accessor::is_null(ctx, value)) {
-                    m_row.nullify_link(column);
-                }
-                else {
-                    m_row.set_link(column, Accessor::to_object_index(ctx, m_realm, value, property.object_type, try_update));
-                }
-                break;
-            }
-            case PropertyType::Array: {
-                realm::LinkViewRef link_view = m_row.get_linklist(column);
-                link_view->clear();
-                if (!Accessor::is_null(ctx, value)) {
-                    size_t count = Accessor::list_size(ctx, value);
-                    for (size_t i = 0; i < count; i++) {
-                        ValueType element = Accessor::list_value_at_index(ctx, value, i);
-                        link_view->add(Accessor::to_object_index(ctx, m_realm, element, property.object_type, try_update));
-                    }
-                }
-                break;
-            }
-            case PropertyType::LinkingObjects:
-                throw ReadOnlyPropertyException(m_object_schema->name, property.name,
-                                                util::format("Cannot modify read-only property '%1.%2'",
-                                                             m_object_schema->name, property.name));
-        }
-    }
-
-    template <typename ValueType, typename ContextType>
-    inline ValueType Object::get_property_value_impl(ContextType ctx, const Property &property)
-    {
-        using Accessor = NativeAccessor<ValueType, ContextType>;
-
-        verify_attached();
-
-        size_t column = property.table_column;
-        if (property.is_nullable && m_row.is_null(column)) {
-            return Accessor::null_value(ctx);
-        }
-
-        switch (property.type) {
-            case PropertyType::Bool:
-                return Accessor::from_bool(ctx, m_row.get_bool(column));
-            case PropertyType::Int:
-                return Accessor::from_long(ctx, m_row.get_int(column));
-            case PropertyType::Float:
-                return Accessor::from_float(ctx, m_row.get_float(column));
-            case PropertyType::Double:
-                return Accessor::from_double(ctx, m_row.get_double(column));
-            case PropertyType::String:
-                return Accessor::from_string(ctx, m_row.get_string(column));
-            case PropertyType::Data:
-                return Accessor::from_binary(ctx, m_row.get_binary(column));
-            case PropertyType::Any:
-                throw "Any not supported";
-            case PropertyType::Date:
-                return Accessor::from_timestamp(ctx, m_row.get_timestamp(column));
-            case PropertyType::Object: {
-                auto linkObjectSchema = m_realm->schema().find(property.object_type);
-                TableRef table = ObjectStore::table_for_object_type(m_realm->read_group(), linkObjectSchema->name);
-                if (m_row.is_null_link(property.table_column)) {
-                    return Accessor::null_value(ctx);
-                }
-                return Accessor::from_object(ctx, std::move(Object(m_realm, *linkObjectSchema, table->get(m_row.get_link(column)))));
-            }
-            case PropertyType::Array:
-                return Accessor::from_list(ctx, List(m_realm, static_cast<LinkViewRef>(m_row.get_linklist(column))));
-            case PropertyType::LinkingObjects: {
-                auto target_object_schema = m_realm->config().schema->find(property.object_type);
-                auto link_property = target_object_schema->property_for_name(property.link_origin_property_name);
-                TableRef table = ObjectStore::table_for_object_type(m_realm->read_group(), target_object_schema->name);
-                auto tv = m_row.get_table()->get_backlink_view(m_row.get_index(), table.get(), link_property->table_column);
-                Results results(m_realm, std::move(tv));
-                return Accessor::from_results(ctx, std::move(results));
-            }
-        }
-    }
-
-    template<typename ValueType, typename ContextType>
-    inline Object Object::create(ContextType ctx, SharedRealm realm, const ObjectSchema &object_schema, ValueType value, bool try_update)
-    {
-        using Accessor = NativeAccessor<ValueType, ContextType>;
-
-        if (!realm->is_in_transaction()) {
-            throw MutationOutsideTransactionException("Can only create objects within a transaction.");
-        }
-
-        // get or create our accessor
-        bool created = false;
-
-        // try to get existing row if updating
-        size_t row_index = realm::not_found;
-        realm::TableRef table = ObjectStore::table_for_object_type(realm->read_group(), object_schema.name);
-        const Property *primary_prop = object_schema.primary_key_property();
-
-        if (primary_prop) {
-            // search for existing object based on primary key type
-            ValueType primary_value = Accessor::dict_value_for_key(ctx, value, object_schema.primary_key);
-            row_index = get_for_primary_key_impl(ctx, table, *primary_prop, primary_value);
-
-            if (row_index == realm::not_found) {
-                row_index = table->add_empty_row();
-                created = true;
-                Object object(realm, object_schema, table->get(row_index));
-                object.set_property_value_impl(ctx, *primary_prop, primary_value, try_update);
-            }
-            else if (!try_update) {
-                throw std::logic_error(util::format("Attempting to create an object of type '%1' with an existing primary key value.", object_schema.name));
-            }
-        }
-        else {
-            row_index = table->add_empty_row();
-            created = true;
-        }
-
-        // populate
-        Object object(realm, object_schema, table->get(row_index));
-        for (const Property& prop : object_schema.persisted_properties) {
-            if (!prop.is_primary) {
-                if (Accessor::dict_has_value_for_key(ctx, value, prop.name)) {
-                    object.set_property_value_impl(ctx, prop, Accessor::dict_value_for_key(ctx, value, prop.name), try_update);
-                }
-                else if (created) {
-                    if (Accessor::has_default_value_for_property(ctx, realm.get(), object_schema, prop.name)) {
-                        object.set_property_value_impl(ctx, prop, Accessor::default_value_for_property(ctx, realm.get(), object_schema, prop.name), try_update);
-                    }
-                    else if (prop.is_nullable || prop.type == PropertyType::Array) {
-                        object.set_property_value_impl(ctx, prop, Accessor::null_value(ctx), try_update);
-                    }
-                    else {
-                        throw MissingPropertyValueException(object_schema.name, prop.name,
-                            "Missing property value for property " + prop.name);
-                    }
+        case PropertyType::Array: {
+            realm::LinkViewRef link_view = m_row.get_linklist(column);
+            link_view->clear();
+            if (!Accessor::is_null(ctx, value)) {
+                size_t count = Accessor::list_size(ctx, value);
+                for (size_t i = 0; i < count; i++) {
+                    ValueType element = Accessor::list_value_at_index(ctx, value, i);
+                    link_view->add(Accessor::to_object_index(ctx, m_realm, element, property.object_type, try_update));
                 }
             }
+            break;
         }
-        return object;
-    }
-
-    template<typename ValueType, typename ContextType>
-    inline Object Object::get_for_primary_key(ContextType ctx, SharedRealm realm, const ObjectSchema &object_schema, ValueType primary_value)
-    {
-        auto primary_prop = object_schema.primary_key_property();
-        if (!primary_prop) {
-            throw MissingPrimaryKeyException(object_schema.name, object_schema.name + " does not have a primary key");
-        }
-
-        auto table = ObjectStore::table_for_object_type(realm->read_group(), object_schema.name);
-        auto row_index = get_for_primary_key_impl(ctx, table, *primary_prop, primary_value);
-
-        return Object(realm, object_schema, row_index == realm::not_found ? Row() : table->get(row_index));
-    }
-
-    template<typename ValueType, typename ContextType>
-    inline size_t Object::get_for_primary_key_impl(ContextType ctx, const ConstTableRef &table, const Property &primary_prop, ValueType primary_value) {
-        using Accessor = NativeAccessor<ValueType, ContextType>;
-
-        if (primary_prop.type == PropertyType::String) {
-            auto primary_string = Accessor::to_string(ctx, primary_value);
-            return table->find_first_string(primary_prop.table_column, primary_string);
-        }
-        else {
-            return table->find_first_int(primary_prop.table_column, Accessor::to_long(ctx, primary_value));
-        }
-    }
-
-    inline void Object::verify_attached() {
-        if (!m_row.is_attached()) {
-            throw InvalidatedObjectException(m_object_schema->name,
-                "Accessing object of type " + m_object_schema->name + " which has been deleted"
-            );
-        }
-    }
-
-    //
-    // List implementation
-    //
-    template<typename ValueType, typename ContextType>
-    void List::add(ContextType ctx, ValueType value)
-    {
-        add(NativeAccessor<ValueType, ContextType>::to_object_index(ctx, m_realm, value, get_object_schema().name, false));
-    }
-
-    template<typename ValueType, typename ContextType>
-    void List::insert(ContextType ctx, ValueType value, size_t list_ndx)
-    {
-        insert(list_ndx, NativeAccessor<ValueType, ContextType>::to_object_index(ctx, m_realm, value, get_object_schema().name, false));
-    }
-
-    template<typename ValueType, typename ContextType>
-    void List::set(ContextType ctx, ValueType value, size_t list_ndx)
-    {
-        set(list_ndx, NativeAccessor<ValueType, ContextType>::to_object_index(ctx, m_realm, value, get_object_schema().name, false));
+        case PropertyType::LinkingObjects:
+            throw ReadOnlyPropertyException(m_object_schema->name, property.name,
+                                            util::format("Cannot modify read-only property '%1.%2'",
+                                                         m_object_schema->name, property.name));
     }
 }
 
-#endif /* defined(REALM_OBJECT_ACCESSOR_HPP) */
+template <typename ValueType, typename ContextType>
+ValueType Object::get_property_value_impl(ContextType ctx, const Property &property)
+{
+    using Accessor = NativeAccessor<ValueType, ContextType>;
+
+    verify_attached();
+
+    size_t column = property.table_column;
+    if (property.is_nullable && m_row.is_null(column)) {
+        return Accessor::null_value(ctx);
+    }
+
+    switch (property.type) {
+        case PropertyType::Bool:
+            return Accessor::from_bool(ctx, m_row.get_bool(column));
+        case PropertyType::Int:
+            return Accessor::from_long(ctx, m_row.get_int(column));
+        case PropertyType::Float:
+            return Accessor::from_float(ctx, m_row.get_float(column));
+        case PropertyType::Double:
+            return Accessor::from_double(ctx, m_row.get_double(column));
+        case PropertyType::String:
+            return Accessor::from_string(ctx, m_row.get_string(column));
+        case PropertyType::Data:
+            return Accessor::from_binary(ctx, m_row.get_binary(column));
+        case PropertyType::Any:
+            throw "Any not supported";
+        case PropertyType::Date:
+            return Accessor::from_timestamp(ctx, m_row.get_timestamp(column));
+        case PropertyType::Object: {
+            auto linkObjectSchema = m_realm->schema().find(property.object_type);
+            TableRef table = ObjectStore::table_for_object_type(m_realm->read_group(), linkObjectSchema->name);
+            if (m_row.is_null_link(property.table_column)) {
+                return Accessor::null_value(ctx);
+            }
+            return Accessor::from_object(ctx, std::move(Object(m_realm, *linkObjectSchema, table->get(m_row.get_link(column)))));
+        }
+        case PropertyType::Array:
+            return Accessor::from_list(ctx, List(m_realm, static_cast<LinkViewRef>(m_row.get_linklist(column))));
+        case PropertyType::LinkingObjects: {
+            auto target_object_schema = m_realm->config().schema->find(property.object_type);
+            auto link_property = target_object_schema->property_for_name(property.link_origin_property_name);
+            TableRef table = ObjectStore::table_for_object_type(m_realm->read_group(), target_object_schema->name);
+            auto tv = m_row.get_table()->get_backlink_view(m_row.get_index(), table.get(), link_property->table_column);
+            Results results(m_realm, std::move(tv));
+            return Accessor::from_results(ctx, std::move(results));
+        }
+    }
+}
+
+template<typename ValueType, typename ContextType>
+Object Object::create(ContextType ctx, SharedRealm realm, const ObjectSchema &object_schema, ValueType value, bool try_update)
+{
+    using Accessor = NativeAccessor<ValueType, ContextType>;
+
+    if (!realm->is_in_transaction()) {
+        throw MutationOutsideTransactionException("Can only create objects within a transaction.");
+    }
+
+    // get or create our accessor
+    bool created = false;
+
+    // try to get existing row if updating
+    size_t row_index = realm::not_found;
+    realm::TableRef table = ObjectStore::table_for_object_type(realm->read_group(), object_schema.name);
+    const Property *primary_prop = object_schema.primary_key_property();
+
+    if (primary_prop) {
+        // search for existing object based on primary key type
+        ValueType primary_value = Accessor::dict_value_for_key(ctx, value, object_schema.primary_key);
+        row_index = get_for_primary_key_impl(ctx, table, *primary_prop, primary_value);
+
+        if (row_index == realm::not_found) {
+            row_index = table->add_empty_row();
+            created = true;
+            Object object(realm, object_schema, table->get(row_index));
+            object.set_property_value_impl(ctx, *primary_prop, primary_value, try_update);
+        }
+        else if (!try_update) {
+            throw std::logic_error(util::format("Attempting to create an object of type '%1' with an existing primary key value.", object_schema.name));
+        }
+    }
+    else {
+        row_index = table->add_empty_row();
+        created = true;
+    }
+
+    // populate
+    Object object(realm, object_schema, table->get(row_index));
+    for (const Property& prop : object_schema.persisted_properties) {
+        if (!prop.is_primary) {
+            if (Accessor::dict_has_value_for_key(ctx, value, prop.name)) {
+                object.set_property_value_impl(ctx, prop, Accessor::dict_value_for_key(ctx, value, prop.name), try_update);
+            }
+            else if (created) {
+                if (Accessor::has_default_value_for_property(ctx, realm.get(), object_schema, prop.name)) {
+                    object.set_property_value_impl(ctx, prop, Accessor::default_value_for_property(ctx, realm.get(), object_schema, prop.name), try_update);
+                }
+                else if (prop.is_nullable || prop.type == PropertyType::Array) {
+                    object.set_property_value_impl(ctx, prop, Accessor::null_value(ctx), try_update);
+                }
+                else {
+                    throw MissingPropertyValueException(object_schema.name, prop.name,
+                        "Missing property value for property " + prop.name);
+                }
+            }
+        }
+    }
+    return object;
+}
+
+template<typename ValueType, typename ContextType>
+Object Object::get_for_primary_key(ContextType ctx, SharedRealm realm, const ObjectSchema &object_schema, ValueType primary_value)
+{
+    auto primary_prop = object_schema.primary_key_property();
+    if (!primary_prop) {
+        throw MissingPrimaryKeyException(object_schema.name, object_schema.name + " does not have a primary key");
+    }
+
+    auto table = ObjectStore::table_for_object_type(realm->read_group(), object_schema.name);
+    auto row_index = get_for_primary_key_impl(ctx, table, *primary_prop, primary_value);
+
+    return Object(realm, object_schema, row_index == realm::not_found ? Row() : table->get(row_index));
+}
+
+template<typename ValueType, typename ContextType>
+size_t Object::get_for_primary_key_impl(ContextType ctx, Table const& table, const Property &primary_prop, ValueType primary_value) {
+    using Accessor = NativeAccessor<ValueType, ContextType>;
+
+    if (primary_prop.type == PropertyType::String) {
+        auto primary_string = Accessor::to_string(ctx, primary_value);
+        return table.find_first_string(primary_prop.table_column, primary_string);
+    }
+    else {
+        return table.find_first_int(primary_prop.table_column, Accessor::to_long(ctx, primary_value));
+    }
+}
+
+inline void Object::verify_attached() {
+    if (!m_row.is_attached()) {
+        throw InvalidatedObjectException(m_object_schema->name,
+            "Accessing object of type " + m_object_schema->name + " which has been deleted"
+        );
+    }
+}
+
+//
+// List implementation
+//
+template<typename ValueType, typename ContextType>
+void List::add(ContextType ctx, ValueType value)
+{
+    add(NativeAccessor<ValueType, ContextType>::to_object_index(ctx, m_realm, value, get_object_schema().name, false));
+}
+
+template<typename ValueType, typename ContextType>
+void List::insert(ContextType ctx, ValueType value, size_t list_ndx)
+{
+    insert(list_ndx, NativeAccessor<ValueType, ContextType>::to_object_index(ctx, m_realm, value, get_object_schema().name, false));
+}
+
+template<typename ValueType, typename ContextType>
+void List::set(ContextType ctx, ValueType value, size_t list_ndx)
+{
+    set(list_ndx, NativeAccessor<ValueType, ContextType>::to_object_index(ctx, m_realm, value, get_object_schema().name, false));
+}
+} // namespace realm
+
+#endif /* defined(REALM_OS_OBJECT_ACCESSOR_HPP) */

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -18,12 +18,16 @@
 
 #include "shared_realm.hpp"
 
+#include "impl/collection_notifier.hpp"
 #include "impl/realm_coordinator.hpp"
 #include "impl/transact_log_handler.hpp"
 
 #include "binding_context.hpp"
+#include "list.hpp"
+#include "object.hpp"
 #include "object_schema.hpp"
 #include "object_store.hpp"
+#include "results.hpp"
 #include "schema.hpp"
 #include "thread_safe_reference.hpp"
 

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -258,7 +258,6 @@ public:
     // Expose some internal functionality to other parts of the ObjectStore
     // without making it public to everyone
     class Internal {
-        friend class _impl::AnyHandover;
         friend class _impl::CollectionNotifier;
         friend class _impl::ListNotifier;
         friend class _impl::ObjectNotifier;

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -23,7 +23,6 @@
 #include "schema.hpp"
 
 #include <realm/util/optional.hpp>
-#include <realm/version_id.hpp>
 #include <realm/binary_data.hpp>
 
 #if REALM_ENABLE_SYNC
@@ -33,17 +32,19 @@
 #include <memory>
 
 namespace realm {
-class BinaryData;
 class BindingContext;
 class Group;
 class Realm;
 class Replication;
 class SharedGroup;
 class StringData;
+class Table;
 struct SyncConfig;
 class ThreadSafeReferenceBase;
 template <typename T> class ThreadSafeReference;
 struct VersionID;
+template<typename Table> class BasicRow;
+typedef BasicRow<Table> Row;
 typedef std::shared_ptr<Realm> SharedRealm;
 typedef std::weak_ptr<Realm> WeakRealm;
 

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -57,6 +57,7 @@ namespace _impl {
     class AnyHandover;
     class CollectionNotifier;
     class ListNotifier;
+    class ObjectNotifier;
     class RealmCoordinator;
     class ResultsNotifier;
     class RealmFriend;
@@ -256,13 +257,12 @@ public:
     // Expose some internal functionality to other parts of the ObjectStore
     // without making it public to everyone
     class Internal {
-        friend class AnyThreadConfined;
-        friend class GlobalNotifier;
+        friend class _impl::AnyHandover;
         friend class _impl::CollectionNotifier;
         friend class _impl::ListNotifier;
+        friend class _impl::ObjectNotifier;
         friend class _impl::RealmCoordinator;
         friend class _impl::ResultsNotifier;
-        friend class _impl::AnyHandover;
         friend class ThreadSafeReferenceBase;
 
         // ResultsNotifier and ListNotifier need access to the SharedGroup

--- a/src/thread_safe_reference.cpp
+++ b/src/thread_safe_reference.cpp
@@ -19,6 +19,10 @@
 #include "thread_safe_reference.hpp"
 
 #include "impl/realm_coordinator.hpp"
+#include "list.hpp"
+#include "object.hpp"
+#include "object_schema.hpp"
+#include "results.hpp"
 
 #include <realm/util/scope_exit.hpp>
 

--- a/src/thread_safe_reference.hpp
+++ b/src/thread_safe_reference.hpp
@@ -19,17 +19,18 @@
 #ifndef REALM_THREAD_SAFE_REFERENCE_HPP
 #define REALM_THREAD_SAFE_REFERENCE_HPP
 
-#include "list.hpp"
-#include "object_accessor.hpp"
-#include "results.hpp"
-
 #include <realm/group_shared.hpp>
-#include <realm/link_view.hpp>
-#include <realm/query.hpp>
-#include <realm/row.hpp>
-#include <realm/table_view.hpp>
 
 namespace realm {
+class LinkView;
+class List;
+class Object;
+class Query;
+class Realm;
+class Results;
+class TableView;
+template<typename T> class BasicRow;
+typedef BasicRow<Table> Row;
 
 // Opaque type representing an object for handover
 class ThreadSafeReferenceBase {
@@ -45,7 +46,7 @@ public:
 
 protected:
     // Precondition: The associated Realm is for the current thread and is not in a write transaction;.
-    ThreadSafeReferenceBase(SharedRealm source_realm);
+    ThreadSafeReferenceBase(std::shared_ptr<Realm> source_realm);
 
     SharedGroup& get_source_shared_group() const;
 
@@ -56,7 +57,7 @@ private:
     friend Realm;
 
     VersionID m_version_id;
-    SharedRealm m_source_realm; // Strong reference keeps alive so version stays pinned! Don't touch!!
+    std::shared_ptr<Realm> m_source_realm; // Strong reference keeps alive so version stays pinned! Don't touch!!
 
     bool has_same_config(Realm& realm) const;
     void invalidate();
@@ -71,7 +72,7 @@ private:
     ThreadSafeReference(T value);
 
     // Precondition: Realm and handover are on same version
-    T import_into_realm(SharedRealm realm) &&;
+    T import_into_realm(std::shared_ptr<Realm> realm) &&;
 };
 
 template<>
@@ -85,7 +86,7 @@ private:
     ThreadSafeReference(List const& value);
 
     // Precondition: Realm and handover are on same version.
-    List import_into_realm(SharedRealm realm) &&;
+    List import_into_realm(std::shared_ptr<Realm> realm) &&;
 };
 
 template<>
@@ -100,7 +101,7 @@ private:
     ThreadSafeReference(Object const& value);
 
     // Precondition: Realm and handover are on same version.
-    Object import_into_realm(SharedRealm realm) &&;
+    Object import_into_realm(std::shared_ptr<Realm> realm) &&;
 };
 
 template<>
@@ -116,7 +117,7 @@ private:
     ThreadSafeReference(Results const& value);
 
     // Precondition: Realm and handover are on same version.
-    Results import_into_realm(SharedRealm realm) &&;
+    Results import_into_realm(std::shared_ptr<Realm> realm) &&;
 };
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -13,6 +13,7 @@ set(SOURCES
     list.cpp
     main.cpp
     migrations.cpp
+    object.cpp
     object_store.cpp
     parser.cpp
     realm.cpp

--- a/tests/list.cpp
+++ b/tests/list.cpp
@@ -23,6 +23,7 @@
 
 #include "binding_context.hpp"
 #include "list.hpp"
+#include "object.hpp"
 #include "object_schema.hpp"
 #include "property.hpp"
 #include "results.hpp"

--- a/tests/object.cpp
+++ b/tests/object.cpp
@@ -1,0 +1,152 @@
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "catch.hpp"
+
+#include "util/test_file.hpp"
+#include "util/index_helpers.hpp"
+
+#include "collection_notifications.hpp"
+#include "object.hpp"
+#include "object_schema.hpp"
+#include "property.hpp"
+#include "schema.hpp"
+
+#include "impl/realm_coordinator.hpp"
+
+#include <realm/group_shared.hpp>
+#include <realm/link_view.hpp>
+
+using namespace realm;
+
+TEST_CASE("object") {
+    InMemoryTestFile config;
+    config.automatic_change_notifications = false;
+    config.cache = false;
+    config.schema = Schema{
+        {"table", {
+            {"value 1", PropertyType::Int},
+            {"value 2", PropertyType::Int},
+        }},
+    };
+    config.schema_version = 0;
+    auto r = Realm::get_shared_realm(config);
+
+    auto& coordinator = *_impl::RealmCoordinator::get_existing_coordinator(config.path);
+
+    auto table = r->read_group().get_table("class_table");
+    r->begin_transaction();
+
+    table->add_empty_row(10);
+    for (int i = 0; i < 10; ++i)
+        table->set_int(0, i, i);
+    r->commit_transaction();
+
+    auto r2 = coordinator.get_realm();
+
+    SECTION("add_notification_block()") {
+        CollectionChangeSet change;
+        Row row = table->get(0);
+
+        auto write = [&](auto&& f) {
+            r->begin_transaction();
+            f();
+            r->commit_transaction();
+
+            advance_and_notify(*r);
+        };
+
+        auto require_change = [&] {
+            auto token = Object(r, *r->schema().find("table"), row).add_notification_block([&](CollectionChangeSet c, std::exception_ptr) {
+                change = c;
+            });
+            advance_and_notify(*r);
+            return token;
+        };
+
+        auto require_no_change = [&] {
+            bool first = true;
+            auto token = Object(r, *r->schema().find("table"), row).add_notification_block([&](CollectionChangeSet, std::exception_ptr) {
+                REQUIRE(first);
+                first = false;
+            });
+            advance_and_notify(*r);
+            return token;
+        };
+
+        SECTION("deleting the object sends a change notification") {
+            auto token = require_change();
+            write([&] { row.move_last_over(); });
+            REQUIRE_INDICES(change.deletions, 0);
+        }
+
+        SECTION("modifying the object sends a change notification") {
+            auto token = require_change();
+
+            write([&] { row.set_int(0, 10); });
+            REQUIRE_INDICES(change.modifications, 0);
+            REQUIRE(change.columns.size() == 1);
+            REQUIRE_INDICES(change.columns[0], 0);
+
+            write([&] { row.set_int(1, 10); });
+            REQUIRE_INDICES(change.modifications, 0);
+            REQUIRE(change.columns.size() == 2);
+            REQUIRE(change.columns[0].empty());
+            REQUIRE_INDICES(change.columns[1], 0);
+        }
+
+        SECTION("modifying a different object") {
+            auto token = require_no_change();
+            write([&] { table->get(1).set_int(0, 10); });
+        }
+
+        SECTION("moving the object") {
+            auto token = require_no_change();
+            write([&] { table->swap_rows(0, 5); });
+        }
+
+        SECTION("subsuming the object") {
+            auto token = require_change();
+            write([&] {
+                table->insert_empty_row(0);
+                table->merge_rows(row.get_index(), 0);
+                row.set_int(0, 10);
+            });
+            REQUIRE(change.columns.size() == 1);
+            REQUIRE_INDICES(change.columns[0], 0);
+        }
+
+        SECTION("multiple write transactions") {
+            auto token = require_change();
+
+            auto r2row = r2->read_group().get_table("class_table")->get(0);
+            r2->begin_transaction();
+            r2row.set_int(0, 1);
+            r2->commit_transaction();
+            r2->begin_transaction();
+            r2row.set_int(1, 2);
+            r2->commit_transaction();
+
+            advance_and_notify(*r);
+            REQUIRE(change.columns.size() == 2);
+            REQUIRE_INDICES(change.columns[0], 0);
+            REQUIRE_INDICES(change.columns[1], 0);
+        }
+    }
+}

--- a/tests/object.cpp
+++ b/tests/object.cpp
@@ -148,5 +148,13 @@ TEST_CASE("object") {
             REQUIRE_INDICES(change.columns[0], 0);
             REQUIRE_INDICES(change.columns[1], 0);
         }
+
+        SECTION("skipping a notification") {
+            auto token = require_no_change();
+            write([&] {
+                row.set_int(0, 1);
+                token.suppress_next();
+            });
+        }
     }
 }

--- a/tests/object.cpp
+++ b/tests/object.cpp
@@ -1,7 +1,6 @@
-
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2016 Realm Inc.
+// Copyright 2017 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -296,6 +296,7 @@ TEST_CASE("SharedRealm: notifications") {
     size_t change_count = 0;
     auto realm = Realm::get_shared_realm(config);
     realm->m_binding_context.reset(new Context{&change_count});
+    realm->m_binding_context->realm = realm;
 
     SECTION("local notifications are sent synchronously") {
         realm->begin_transaction();

--- a/tests/thread_safe_reference.cpp
+++ b/tests/thread_safe_reference.cpp
@@ -21,17 +21,18 @@
 #include "util/test_file.hpp"
 
 #include "list.hpp"
-#include "object_accessor.hpp"
+#include "object.hpp"
 #include "object_schema.hpp"
-#include "property.hpp"
+#include "object_store.hpp"
+#include "results.hpp"
 #include "schema.hpp"
 #include "thread_safe_reference.hpp"
 
 #include <realm/history.hpp>
 #include <realm/util/optional.hpp>
 
-#include <thread>
 #include <future>
+#include <thread>
 
 using namespace realm;
 

--- a/tests/util/index_helpers.hpp
+++ b/tests/util/index_helpers.hpp
@@ -28,6 +28,11 @@
     } \
 } while (0)
 
+#define REQUIRE_COLUMN_INDICES(columns, col, ...) do { \
+    REQUIRE((columns).size() > col); \
+    REQUIRE_INDICES((columns)[col], __VA_ARGS__); \
+} while (0)
+
 #define REQUIRE_MOVES(c, ...) do { \
     auto actual = (c); \
     std::initializer_list<CollectionChangeSet::Move> expected = {__VA_ARGS__}; \


### PR DESCRIPTION
Most of this is just refactoring to merge the two separate sets of transaction log parsing logic, so that the parser for the collection notifiers now (optionally) tracks which columns were modified, and the KVO stuff now uses that parser rather than a separate one.

With that done the object notifier itself is pretty trivial and straightforward.