### PR TITLE
Adding gcc 4.9 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.2.0)
 if(REALM_PLATFORM STREQUAL "Android")
     # This must be before project()
     set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/CMake/android.toolchain.cmake")
-    set(ANDROID_ABI "x86_64" CACHE STRING "")
+    set(ANDROID_ABI "x86" CACHE STRING "")
     set(ANDROID_NATIVE_API_LEVEL "android-16" CACHE STRING "")
 endif()
 

--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -23,6 +23,7 @@
 
 #include <iomanip>
 #include <sstream>
+#include <system_error>
 
 #if WIN32
 #include <io.h>
@@ -200,7 +201,15 @@ std::string create_timestamped_template(const std::string& prefix, int wildcard_
     wildcard_count = std::min(WILDCARD_MAX, std::max(WILDCARD_MIN, wildcard_count));
     std::time_t time = std::time(nullptr);
     std::stringstream stream;
-    stream << prefix << "-" << std::put_time(std::localtime(&time), "%Y%m%d-%H%M%S") << "-" << std::string(wildcard_count, 'X');
+    stream << prefix << "-";
+#if __GNUC__ < 5
+    char s[16];
+    strftime(s, 16, "%Y%m%d-%H%M%S", std::localtime(&time));
+    stream << s;
+#else
+    stream << std::put_time(std::localtime(&time), "%Y%m%d-%H%M%S");
+#endif
+    stream << "-" << std::string(wildcard_count, 'X');
     return stream.str();
 }
 

--- a/tests/sync/session.cpp
+++ b/tests/sync/session.cpp
@@ -335,19 +335,37 @@ TEST_CASE("sync: error handling", "[sync]") {
         CHECK(idx != std::string::npos);
         if (just_before->tm_year == just_after->tm_year) {
             std::stringstream stream;
+#if __GNUC__ < 5
+            char s[5];
+            strftime(s, 5, "%Y", just_after);
+            stream << s;
+#else
             stream << std::put_time(just_after, "%Y");
+#endif
             idx = recovery_path.find(stream.str());
             CHECK(idx != std::string::npos);
         }
         if (just_before->tm_mon == just_after->tm_mon) {
             std::stringstream stream;
+#if __GNUC__ < 5
+            char s[3];
+            strftime(s, 3, "%m", just_after);
+            stream << s;
+#else
             stream << std::put_time(just_after, "%m");
+#endif
             idx = recovery_path.find(stream.str());
             CHECK(idx != std::string::npos);
         }
         if (just_before->tm_yday == just_after->tm_yday) {
             std::stringstream stream;
+#if __GNUC__ < 5
+            char s[3];
+            strftime(s, 3, "%d", just_after);
+            stream << s;
+#else
             stream << std::put_time(just_after, "%d");
+#endif
             idx = recovery_path.find(stream.str());
             CHECK(idx != std::string::npos);
         }


### PR DESCRIPTION
`std::put_time` is not supported by GCC 4.9. This is a hack to get around it.

See also http://stackoverflow.com/questions/14136833/stdput-time-implementation-status-in-gcc
