### PR TITLE
copy_realm_to_recovery should take path as param

### DIFF
--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -295,11 +295,10 @@ bool SyncFileManager::remove_realm(const std::string& absolute_path) const
     return success;
 }
 
-bool SyncFileManager::copy_realm_file_to_recovery_directory(const std::string& absolute_path, const std::string& new_name) const
+bool SyncFileManager::copy_realm_file_to_recovery_directory(const std::string& absolute_path, const std::string& new_path) const
 {
     REALM_ASSERT(absolute_path.length() > 0);
     try {
-        auto new_path = util::file_path_by_appending_component(recovery_directory_path(), new_name);
         if (File::exists(new_path)) {
             return false;
         }

--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -302,7 +302,7 @@ bool SyncFileManager::copy_realm_file_to_recovery_directory(const std::string& a
         if (File::exists(new_path)) {
             return false;
         }
-        File::copy(absolute_path, std::move(new_path));
+        File::copy(absolute_path, new_path);
     } 
     catch (File::NotFound const&) {
     }

--- a/src/sync/impl/sync_file.hpp
+++ b/src/sync/impl/sync_file.hpp
@@ -77,8 +77,8 @@ public:
     /// operation fully succeeds.
     bool remove_realm(const std::string& absolute_path) const;
 
-    /// Copy the Realm file at `absolute_path` to the recovery directory, with the specified `new_name`.
-    bool copy_realm_file_to_recovery_directory(const std::string& absolute_path, const std::string& new_name) const;
+    /// Copy the Realm file at `absolute_path` to the new recovery path.
+    bool copy_realm_file_to_recovery_directory(const std::string& absolute_path, const std::string& new_path) const;
 
     /// Return the path for the metadata Realm files.
     std::string metadata_path() const;


### PR DESCRIPTION
The full path has been saved in the file_actions,
copy_realm_file_to_recovery_directory doesn't have to append the name to
the recovery path -- it will cause a File::NotFound thrown always.