### PR TITLE
Properly initialize KVOAdapter::track_all

### DIFF
--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -55,7 +55,8 @@ private:
 };
 
 KVOAdapter::KVOAdapter(std::vector<BindingContext::ObserverState>& observers, BindingContext* context)
-: m_context(context)
+: _impl::TransactionChangeInfo{}
+, m_context(context)
 , m_observers(observers)
 {
     if (m_observers.empty())


### PR DESCRIPTION
Using list-initialization for the base class zero-initializes the member variables, while the default constructor does not.

Fixes #344.