### PR TITLE
Fix a retain cycle in the object notifier

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -302,6 +302,14 @@ void RealmCoordinator::clear_all_caches()
     }
 }
 
+void RealmCoordinator::assert_no_open_realms() noexcept
+{
+#ifdef REALM_DEBUG
+    std::lock_guard<std::mutex> lock(s_coordinator_mutex);
+    REALM_ASSERT(s_coordinators_per_path.empty());
+#endif
+}
+
 void RealmCoordinator::wake_up_notifier_worker()
 {
     if (m_notifier) {

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -77,6 +77,9 @@ public:
     // Clears all caches on existing coordinators
     static void clear_all_caches();
 
+    // Verify that there are no Realms open for any paths
+    static void assert_no_open_realms() noexcept;
+
     // Explicit constructor/destructor needed for the unique_ptrs to forward-declared types
     RealmCoordinator();
     ~RealmCoordinator();

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -214,7 +214,7 @@ size_t hash<realm::List>::operator()(realm::List const& list) const
 }
 }
 
-NotificationToken List::add_notification_callback(CollectionChangeCallback cb)
+NotificationToken List::add_notification_callback(CollectionChangeCallback cb) &
 {
     verify_attached();
     if (!m_notifier) {

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -81,7 +81,7 @@ public:
 
     bool operator==(List const& rgt) const noexcept;
 
-    NotificationToken add_notification_callback(CollectionChangeCallback cb);
+    NotificationToken add_notification_callback(CollectionChangeCallback cb) &;
 
     // These are implemented in object_accessor.hpp
     template <typename ValueType, typename ContextType>

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -36,7 +36,7 @@ Object::Object(Object&&) = default;
 Object& Object::operator=(Object const&) = default;
 Object& Object::operator=(Object&&) = default;
 
-NotificationToken Object::add_notification_block(CollectionChangeCallback callback)
+NotificationToken Object::add_notification_block(CollectionChangeCallback callback) &
 {
     if (!m_notifier)
         m_notifier = std::make_shared<_impl::ObjectNotifier>(m_row, m_realm);

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -23,7 +23,18 @@
 
 using namespace realm;
 
+Object::Object(SharedRealm r, ObjectSchema const& s, BasicRowExpr<Table> const& o)
+: m_realm(std::move(r)), m_object_schema(&s), m_row(o) { }
+
+Object::Object(SharedRealm r, ObjectSchema const& s, Row const& o)
+: m_realm(std::move(r)), m_object_schema(&s), m_row(o) { }
+
+Object::Object() = default;
 Object::~Object() = default;
+Object::Object(Object const&) = default;
+Object::Object(Object&&) = default;
+Object& Object::operator=(Object const&) = default;
+Object& Object::operator=(Object&&) = default;
 
 NotificationToken Object::add_notification_block(CollectionChangeCallback callback)
 {

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -69,7 +69,7 @@ public:
 
     bool is_valid() const { return m_row.is_attached(); }
 
-    NotificationToken add_notification_block(CollectionChangeCallback callback);
+    NotificationToken add_notification_block(CollectionChangeCallback callback) &;
 
 private:
     SharedRealm m_realm;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -19,14 +19,13 @@
 #ifndef REALM_OS_OBJECT_HPP
 #define REALM_OS_OBJECT_HPP
 
+#include "impl/collection_notifier.hpp"
 #include "shared_realm.hpp"
 
 #include <realm/row.hpp>
 
 namespace realm {
-class CollectionChangeCallback;
 class ObjectSchema;
-struct NotificationToken;
 
 namespace _impl {
     class ObjectNotifier;
@@ -34,11 +33,14 @@ namespace _impl {
 
 class Object {
 public:
-    Object(SharedRealm r, ObjectSchema const& s, BasicRowExpr<Table> const& o)
-    : m_realm(std::move(r)), m_object_schema(&s), m_row(o) { }
+    Object();
+    Object(SharedRealm r, ObjectSchema const& s, BasicRowExpr<Table> const& o);
+    Object(SharedRealm r, ObjectSchema const& s, Row const& o);
 
-    Object(SharedRealm r, ObjectSchema const& s, Row const& o)
-    : m_realm(std::move(r)), m_object_schema(&s), m_row(o) { }
+    Object(Object const&);
+    Object(Object&&);
+    Object& operator=(Object const&);
+    Object& operator=(Object&&);
 
     ~Object();
 
@@ -73,7 +75,7 @@ private:
     SharedRealm m_realm;
     const ObjectSchema *m_object_schema;
     Row m_row;
-    std::shared_ptr<_impl::ObjectNotifier> m_notifier;
+    _impl::CollectionNotifier::Handle<_impl::ObjectNotifier> m_notifier;
 
     template<typename ValueType, typename ContextType>
     void set_property_value_impl(ContextType ctx, const Property &property, ValueType value, bool try_update);

--- a/src/results.cpp
+++ b/src/results.cpp
@@ -573,7 +573,7 @@ NotificationToken Results::async(std::function<void (std::exception_ptr)> target
     return {m_notifier, m_notifier->add_callback(wrap)};
 }
 
-NotificationToken Results::add_notification_callback(CollectionChangeCallback cb)
+NotificationToken Results::add_notification_callback(CollectionChangeCallback cb) &
 {
     prepare_async();
     return {m_notifier, m_notifier->add_callback(std::move(cb))};

--- a/src/results.hpp
+++ b/src/results.hpp
@@ -181,7 +181,7 @@ public:
     // The query will be run on a background thread and delivered to the callback,
     // and then rerun after each commit (if needed) and redelivered if it changed
     NotificationToken async(std::function<void (std::exception_ptr)> target);
-    NotificationToken add_notification_callback(CollectionChangeCallback cb);
+    NotificationToken add_notification_callback(CollectionChangeCallback cb) &;
 
     bool wants_background_updates() const { return m_wants_background_updates; }
 

--- a/tests/object.cpp
+++ b/tests/object.cpp
@@ -35,6 +35,8 @@
 using namespace realm;
 
 TEST_CASE("object") {
+    _impl::RealmCoordinator::assert_no_open_realms();
+
     InMemoryTestFile config;
     config.automatic_change_notifications = false;
     config.cache = false;
@@ -62,6 +64,7 @@ TEST_CASE("object") {
     SECTION("add_notification_block()") {
         CollectionChangeSet change;
         Row row = table->get(0);
+        Object object(r, *r->schema().find("table"), row);
 
         auto write = [&](auto&& f) {
             r->begin_transaction();
@@ -72,7 +75,7 @@ TEST_CASE("object") {
         };
 
         auto require_change = [&] {
-            auto token = Object(r, *r->schema().find("table"), row).add_notification_block([&](CollectionChangeSet c, std::exception_ptr) {
+            auto token = object.add_notification_block([&](CollectionChangeSet c, std::exception_ptr) {
                 change = c;
             });
             advance_and_notify(*r);
@@ -81,7 +84,7 @@ TEST_CASE("object") {
 
         auto require_no_change = [&] {
             bool first = true;
-            auto token = Object(r, *r->schema().find("table"), row).add_notification_block([&](CollectionChangeSet, std::exception_ptr) {
+            auto token = object.add_notification_block([&](CollectionChangeSet, std::exception_ptr) {
                 REQUIRE(first);
                 first = false;
             });

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -53,6 +53,8 @@ private:
 };
 
 TEST_CASE("notifications: async delivery") {
+    _impl::RealmCoordinator::assert_no_open_realms();
+
     InMemoryTestFile config;
     config.cache = false;
     config.automatic_change_notifications = false;
@@ -635,6 +637,8 @@ TEST_CASE("notifications: async delivery") {
 }
 
 TEST_CASE("notifications: skip") {
+    _impl::RealmCoordinator::assert_no_open_realms();
+
     InMemoryTestFile config;
     config.cache = false;
     config.automatic_change_notifications = false;
@@ -826,6 +830,8 @@ TEST_CASE("notifications: skip") {
 
 #if REALM_PLATFORM_APPLE
 TEST_CASE("notifications: async error handling") {
+    _impl::RealmCoordinator::assert_no_open_realms();
+
     InMemoryTestFile config;
     config.cache = false;
     config.automatic_change_notifications = false;
@@ -983,6 +989,8 @@ TEST_CASE("notifications: async error handling") {
 
 #if REALM_ENABLE_SYNC
 TEST_CASE("notifications: sync") {
+    _impl::RealmCoordinator::assert_no_open_realms();
+
     SyncServer server(false);
     SyncTestFile config(server);
     config.cache = false;
@@ -1025,6 +1033,8 @@ TEST_CASE("notifications: sync") {
 #endif
 
 TEST_CASE("notifications: results") {
+    _impl::RealmCoordinator::assert_no_open_realms();
+
     InMemoryTestFile config;
     config.cache = false;
     config.automatic_change_notifications = false;
@@ -1636,6 +1646,8 @@ TEST_CASE("results: notifications after move") {
 }
 
 TEST_CASE("results: implicit background notifier") {
+    _impl::RealmCoordinator::assert_no_open_realms();
+
     InMemoryTestFile config;
     config.cache = false;
     config.automatic_change_notifications = false;


### PR DESCRIPTION
`unregister()` was never actually being called, so object notifiers would never get destroyed.

Add an assertion to the beginning of some of the test cases that there are no realms already open to catch this sort of thing before we hit the max file open limit.

Fixes #340.