### PR TITLE
Silence some clang static analyzer false-positives

### DIFF
--- a/src/results.cpp
+++ b/src/results.cpp
@@ -367,7 +367,7 @@ util::Optional<Mixed> Results::aggregate(size_t column,
 
 util::Optional<Mixed> Results::max(size_t column)
 {
-    size_t return_ndx;
+    size_t return_ndx = npos;
     auto results = aggregate(column, "max",
                              [&](auto const& table) { return table.maximum_int(column, &return_ndx); },
                              [&](auto const& table) { return table.maximum_float(column, &return_ndx); },
@@ -378,7 +378,7 @@ util::Optional<Mixed> Results::max(size_t column)
 
 util::Optional<Mixed> Results::min(size_t column)
 {
-    size_t return_ndx;
+    size_t return_ndx = npos;
     auto results = aggregate(column, "min",
                              [&](auto const& table) { return table.minimum_int(column, &return_ndx); },
                              [&](auto const& table) { return table.minimum_float(column, &return_ndx); },


### PR DESCRIPTION
CSE warns that `result_ndx` is uninitialized at the point of use due to that it can't see where the variable is assigned to.