### PR TITLE
Fix issues with metadata and file actions

### DIFF
--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -277,7 +277,7 @@ bool SyncFileManager::remove_realm(const std::string& absolute_path) const
 {
     REALM_ASSERT(absolute_path.length() > 0);
     bool success = true;
-    // Remove the base Realm file (e.g. "example.realm").
+    // Remove the Realm file (e.g. "example.realm").
     success = File::try_remove(absolute_path);
     // Remove the lock file (e.g. "example.realm.lock").
     auto lock_path = util::file_path_by_appending_extension(absolute_path, "lock");
@@ -295,17 +295,17 @@ bool SyncFileManager::remove_realm(const std::string& absolute_path) const
     return success;
 }
 
-bool SyncFileManager::copy_realm_file_to_recovery_directory(const std::string& absolute_path, const std::string& new_name) const
+bool SyncFileManager::copy_realm_file(const std::string& old_path, const std::string& new_path) const
 {
-    REALM_ASSERT(absolute_path.length() > 0);
+    REALM_ASSERT(old_path.length() > 0);
     try {
-        auto new_path = util::file_path_by_appending_component(recovery_directory_path(), new_name);
         if (File::exists(new_path)) {
             return false;
         }
-        File::copy(absolute_path, std::move(new_path));
+        File::copy(old_path, new_path);
     } 
     catch (File::NotFound const&) {
+        return false;
     }
     catch (File::AccessError const&) {
         return false;

--- a/src/sync/impl/sync_file.hpp
+++ b/src/sync/impl/sync_file.hpp
@@ -77,8 +77,8 @@ public:
     /// operation fully succeeds.
     bool remove_realm(const std::string& absolute_path) const;
 
-    /// Copy the Realm file at `absolute_path` to the recovery directory, with the specified `new_name`.
-    bool copy_realm_file_to_recovery_directory(const std::string& absolute_path, const std::string& new_name) const;
+    /// Copy the Realm file at the location `old_path` to the location of `new_path`.
+    bool copy_realm_file(const std::string& old_path, const std::string& new_path) const;
 
     /// Return the path for the metadata Realm files.
     std::string metadata_path() const;

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -36,6 +36,7 @@ class SyncSession;
 class SyncUser;
 class SyncFileManager;
 class SyncMetadataManager;
+class SyncFileActionMetadata;
 
 namespace _impl {
 struct SyncClient;
@@ -144,6 +145,8 @@ private:
     SyncLoggerFactory* m_logger_factory = nullptr;
     ReconnectMode m_client_reconnect_mode = ReconnectMode::normal;
     bool m_client_validate_ssl = true;
+
+    bool run_file_action(const SyncFileActionMetadata&);
 
     // Protects m_users
     mutable std::mutex m_user_mutex;

--- a/tests/sync/sync_test_utils.cpp
+++ b/tests/sync/sync_test_utils.cpp
@@ -60,9 +60,9 @@ std::string tmp_dir() {
     if (dir && *dir)
         return dir;
 #if REALM_ANDROID
-    return "/data/local/tmp";
+    return "/data/local/tmp/";
 #else
-    return "/tmp";
+    return "/tmp/";
 #endif
 }
 


### PR DESCRIPTION
Changes:
- Fixed a bug where the recovery path saved to the file action metadata was not the one expected when the metadata was read back out
- Refactored code that handles file actions into its own method
- Code that handles file actions now properly handles missing original files/a file in the intended path
- Modified some test utility methods for better resilience and easier debugging
- Added a test and fixed other tests

This commit contains code by @nhachicha and @beeender, and replaces https://github.com/realm/realm-object-store/pull/343 and https://github.com/realm/realm-object-store/pull/346