### PR TITLE
Fix skipping notifications for transactions with no relevant changes

### DIFF
--- a/src/impl/collection_notifier.cpp
+++ b/src/impl/collection_notifier.cpp
@@ -286,6 +286,12 @@ void CollectionNotifier::prepare_handover()
     m_sg_version = m_sg->get_version_of_current_transaction();
     do_prepare_handover(*m_sg);
     m_has_run = true;
+
+#ifdef REALM_DEBUG
+    std::lock_guard<std::mutex> lock(m_callback_mutex);
+    for (auto& callback : m_callbacks)
+        REALM_ASSERT(!callback.skip_next);
+#endif
 }
 
 void CollectionNotifier::before_advance()

--- a/src/impl/results_notifier.cpp
+++ b/src/impl/results_notifier.cpp
@@ -167,6 +167,10 @@ void ResultsNotifier::do_prepare_handover(SharedGroup& sg)
         // object and bump its version to the current SG version
         if (m_tv_handover)
             m_tv_handover->version = sg.get_version_of_current_transaction();
+
+        // add_changes() needs to be called even if there are no changes to
+        // clear the skip flag on the callbacks
+        add_changes({});
         return;
     }
 

--- a/tests/object.cpp
+++ b/tests/object.cpp
@@ -155,5 +155,21 @@ TEST_CASE("object") {
                 token.suppress_next();
             });
         }
+
+        SECTION("skipping only effects the current transaction even if no notification would occur anyway") {
+            auto token = require_change();
+
+            // would not produce a notification even if it wasn't skipped because no changes were made
+            write([&] {
+                token.suppress_next();
+            });
+            REQUIRE(change.empty());
+
+            // should now produce a notification
+            write([&] {
+                row.set_int(0, 1);
+            });
+            REQUIRE_INDICES(change.modifications, 0);
+        }
     }
 }

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -822,6 +822,25 @@ TEST_CASE("notifications: skip") {
         REQUIRE(calls3 == 1);
         REQUIRE(calls4 == 1);
     }
+
+    SECTION("skipping only effects the current transaction even if no notification would occur anyway") {
+        advance_and_notify(*r);
+        REQUIRE(calls1 == 1);
+
+        // would not produce a notification even if it wasn't skipped because no changes were made
+        r->begin_transaction();
+        token1.suppress_next();
+        r->commit_transaction();
+        advance_and_notify(*r);
+        REQUIRE(calls1 == 1);
+
+        // should now produce a notification
+        r->begin_transaction();
+        table->add_empty_row();
+        r->commit_transaction();
+        advance_and_notify(*r);
+        REQUIRE(calls1 == 2);
+    }
 }
 
 #if REALM_PLATFORM_APPLE


### PR DESCRIPTION
The skip flag was only cleared if a notification would actually have been delivered, which resulted in the *next* transaction's notification being skipped if a transaction did not actually do anything which would produce a notification.

Reported by https://github.com/realm/realm-cocoa/issues/4558.