### PR TITLE
Temp. solution of https://github.com/realm/realm-java/issues/3651

### DIFF
--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -50,14 +50,12 @@ const size_t c_zeroRowIndex = 0;
 const char c_object_table_prefix[] = "class_";
 
 void create_metadata_tables(Group& group) {
-    TableRef table = group.get_or_add_table(c_primaryKeyTableName);
-    if (table->get_column_count() == 0) {
-        table->add_column(type_String, c_primaryKeyObjectClassColumnName);
-        table->add_column(type_String, c_primaryKeyPropertyNameColumnName);
-    }
-    table->add_search_index(table->get_column_index(c_primaryKeyObjectClassColumnName));
-
-    table = group.get_or_add_table(c_metadataTableName);
+    // FIXME: the order of the creation of the two tables seems to
+    // matter for some Android devices. The reason is unclear, and
+    // further investigation is required.
+    // See https://github.com/realm/realm-java/issues/3651
+    
+    TableRef table = group.get_or_add_table(c_metadataTableName);
     if (table->get_column_count() == 0) {
         table->add_column(type_Int, c_versionColumnName);
 
@@ -65,6 +63,13 @@ void create_metadata_tables(Group& group) {
         table->add_empty_row();
         table->set_int(c_versionColumnIndex, c_zeroRowIndex, ObjectStore::NotVersioned);
     }
+
+    table = group.get_or_add_table(c_primaryKeyTableName);
+    if (table->get_column_count() == 0) {
+        table->add_column(type_String, c_primaryKeyObjectClassColumnName);
+        table->add_column(type_String, c_primaryKeyPropertyNameColumnName);
+    }
+    table->add_search_index(table->get_column_index(c_primaryKeyObjectClassColumnName));
 }
 
 void set_schema_version(Group& group, uint64_t version) {


### PR DESCRIPTION
We have a crash on a number of Android devices. We cannot trigger the crash in any unit tests (Realm Object Store or Realm Java) but only in the Realm Java's intro-example (and users' apps). During debugging sessions, I have found that swapping the order to the creation of the metadata and primary key tables "fixes" the issue.

As it crashes deep in Realm Core, the origin of the bug is still unclear.

Realm Java is getting some heat from the community for not releasing this temp. solution. The Realm Java team (with help from the Realm Core team) will continue the investigation after the merge of this PR.

See https://github.com/realm/realm-java/issues/3651