### PR TITLE
Fix an issue with session progress notifications

### DIFF
--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -423,14 +423,15 @@ void SyncSession::handle_progress_update(uint64_t downloaded, uint64_t downloada
     std::vector<std::function<void()>> invocations;
     {
         std::lock_guard<std::mutex> lock(m_progress_notifier_mutex);
-        m_initial_notification_has_been_received = true;
-        m_current_uploadable = uploadable;
-        m_current_downloadable = downloadable;
-        m_current_downloaded = downloaded;
-        m_current_uploaded = uploaded;
+        m_current_progress = Progress{uploadable, downloadable, uploaded, downloaded};
+
         for (auto it = m_notifiers.begin(); it != m_notifiers.end();) {
+            auto& package = it->second;
+            package.update(*m_current_progress);
+
             bool should_delete = false;
-            invocations.emplace_back(create_notifier_invocation(it->second, should_delete));
+            invocations.emplace_back(package.create_invocation(*m_current_progress, should_delete));
+
             it = (should_delete ? m_notifiers.erase(it) : std::next(it));
         }
     }
@@ -440,26 +441,31 @@ void SyncSession::handle_progress_update(uint64_t downloaded, uint64_t downloada
     }
 }
 
-// Create a notifier invocation.
-// Precondition: all four download/upload status member variables have been set to their most up-to-date values.
-std::function<void()> SyncSession::create_notifier_invocation(NotifierPackage& package, bool& is_expired)
+void SyncSession::NotifierPackage::update(const Progress& current_progress)
 {
-    uint64_t transferred = (package.direction == NotifierType::download ? m_current_downloaded : m_current_uploaded);
+    if (is_streaming || captured_transferrable)
+        return;
+
+    captured_transferrable = direction == NotifierType::download ? current_progress.downloadable
+                                                                 : current_progress.uploadable;
+}
+
+std::function<void()> SyncSession::NotifierPackage::create_invocation(const Progress& current_progress, bool& is_expired) const
+{
+    REALM_ASSERT(is_streaming || captured_transferrable);
+
+    bool is_download = direction == NotifierType::download;
+    uint64_t transferred = is_download ? current_progress.downloaded : current_progress.uploaded;
     uint64_t transferrable;
-    if (package.is_streaming) {
-        transferrable = (package.direction == NotifierType::download ? m_current_downloadable : m_current_uploadable);
+    if (is_streaming) {
+        transferrable = is_download ? current_progress.downloadable : current_progress.uploadable;
     } else {
-        if (!package.captured_transferrable) {
-            transferrable = (package.direction == NotifierType::download ? m_current_downloadable : m_current_uploadable);
-            package.captured_transferrable = transferrable;
-        } else {
-            transferrable = *package.captured_transferrable;
-        }
+        transferrable = *captured_transferrable;
     }
     // A notifier is expired if at least as many bytes have been transferred
     // as were originally considered transferrable.
-    is_expired = !package.is_streaming && transferred >= *package.captured_transferrable;
-    return [=](){
+    is_expired = !is_streaming && transferred >= *captured_transferrable;
+    return [=, package=*this](){
         package.notifier(transferred, transferrable);
     };
 }
@@ -621,20 +627,15 @@ uint64_t SyncSession::register_progress_notifier(std::function<SyncProgressNotif
     {
         std::lock_guard<std::mutex> lock(m_progress_notifier_mutex);
         token_value = m_progress_notifier_token++;
-        util::Optional<uint64_t> current_transferrable = none;
-        if (m_initial_notification_has_been_received) {
-            current_transferrable = (direction == NotifierType::download
-                                     ? m_current_downloadable
-                                     : m_current_uploadable);
-        }
-        NotifierPackage package{std::move(notifier), is_streaming, direction, std::move(current_transferrable)};
-        if (!m_initial_notification_has_been_received) {
+        NotifierPackage package{std::move(notifier), is_streaming, direction};
+        if (!m_current_progress) {
             // Simply register the package, since we have no data yet.
             m_notifiers.emplace(token_value, std::move(package));
             return token_value;
         }
+        package.update(*m_current_progress);
         bool skip_registration = false;
-        invocation = create_notifier_invocation(package, skip_registration);
+        invocation = package.create_invocation(*m_current_progress, skip_registration);
         if (skip_registration) {
             token_value = 0;
         } else {

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -224,18 +224,28 @@ private:
         std::function<SyncProgressNotifierCallback> notifier;
         bool is_streaming;
         NotifierType direction;
-        uint64_t captured_transferrable;
+        util::Optional<uint64_t> captured_transferrable;
     };
     // A counter used as a token to identify progress notifier callbacks registered on this session.
     uint64_t m_progress_notifier_token = 1;
     // How many bytes are uploadable or downloadable.
-    uint64_t m_current_uploadable;
-    uint64_t m_current_downloadable;
-    uint64_t m_current_uploaded;
-    uint64_t m_current_downloaded;
+    uint64_t m_current_uploadable = 0;
+    uint64_t m_current_downloadable = 0;
+    uint64_t m_current_uploaded = 0;
+    uint64_t m_current_downloaded = 0;
+
+    // Whether we've received the initial notification from sync and initialized the
+    // progress state variables. Note that this happens only once ever during the
+    // lifetime of a given `SyncSession`, since these values are expected to
+    // semi-monotonically increase, and a lower-bounds estimate is still useful in the
+    // event more up-to-date information isn't yet available.
+    // FIXME: If we support transparent client reset in the future, we might need to
+    // reset the progress state variables if the Realm is rolled back.
+    bool m_initial_notification_has_been_received;
+
     std::unordered_map<uint64_t, NotifierPackage> m_notifiers;
 
-    std::function<void()> create_notifier_invocation(const NotifierPackage&, bool&);
+    std::function<void()> create_notifier_invocation(NotifierPackage&, bool&);
 
     mutable std::mutex m_state_mutex;
     mutable std::mutex m_progress_notifier_mutex;

--- a/tests/sync/session.cpp
+++ b/tests/sync/session.cpp
@@ -418,7 +418,7 @@ TEST_CASE("sync: progress notification", "[sync]") {
         session->wait_for_download_completion([&](auto) { download_did_complete = true; });
         EventLoop::main().run_until([&] { return download_did_complete.load(); });
         std::atomic<bool> upload_did_complete(false);
-        session->wait_for_download_completion([&](auto) { upload_did_complete = true; });
+        session->wait_for_upload_completion([&](auto) { upload_did_complete = true; });
         EventLoop::main().run_until([&] { return upload_did_complete.load(); });
 
         REQUIRE(!session->is_in_error_state());
@@ -461,7 +461,7 @@ TEST_CASE("sync: progress notification", "[sync]") {
         session->wait_for_download_completion([&](auto) { download_did_complete = true; });
         EventLoop::main().run_until([&] { return download_did_complete.load(); });
         std::atomic<bool> upload_did_complete(false);
-        session->wait_for_download_completion([&](auto) { upload_did_complete = true; });
+        session->wait_for_upload_completion([&](auto) { upload_did_complete = true; });
         EventLoop::main().run_until([&] { return upload_did_complete.load(); });
 
         REQUIRE(!session->is_in_error_state());
@@ -636,7 +636,7 @@ TEST_CASE("sync: progress notification", "[sync]") {
         session->wait_for_download_completion([&](auto) { download_did_complete = true; });
         EventLoop::main().run_until([&] { return download_did_complete.load(); });
         std::atomic<bool> upload_did_complete(false);
-        session->wait_for_download_completion([&](auto) { upload_did_complete = true; });
+        session->wait_for_upload_completion([&](auto) { upload_did_complete = true; });
         EventLoop::main().run_until([&] { return upload_did_complete.load(); });
 
         REQUIRE(!session->is_in_error_state());

--- a/tests/sync/session.cpp
+++ b/tests/sync/session.cpp
@@ -261,7 +261,7 @@ TEST_CASE("sync: log-in", "[sync]") {
 
         EventLoop::main().perform([&] {
             session->wait_for_download_completion([](auto) {
-                fprintf(stderr, "Download completed.\n");
+                // Nothing to do here.
             });
         });
 

--- a/tests/util/event_loop.cpp
+++ b/tests/util/event_loop.cpp
@@ -178,9 +178,6 @@ void EventLoop::Impl::run_until(std::function<bool()> predicate)
 {
     REALM_ASSERT(m_loop.get() == CFRunLoopGetCurrent());
 
-    if (predicate())
-        return;
-
     auto callback = [](CFRunLoopObserverRef, CFRunLoopActivity, void* info) {
         if ((*static_cast<std::function<bool()>*>(info))()) {
             CFRunLoopStop(CFRunLoopGetCurrent());


### PR DESCRIPTION
Changes:
- `SyncSession` now tracks whether the initial sync progress update has happened yet, and manages notifications registered by the binding accordingly
- Session progress notification tests now wait for pending uploads and downloads, to avoid `handle_notifications()` being "spuriously" called by the actual sync client during tests
- Removed use of `check_status()` so we can get useful line numbers should the tests fail