### PR TITLE
Fix schema validation logic when fetching Realm instances from the cache

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -138,6 +138,9 @@ void RealmCoordinator::set_config(const Realm::Config& config)
         if (m_config.schema_mode != config.schema_mode) {
             throw MismatchedConfigException("Realm at path '%1' already opened with a different schema mode.", config.path);
         }
+        if (config.schema && m_schema_version != ObjectStore::NotVersioned && m_schema_version != config.schema_version) {
+            throw MismatchedConfigException("Realm at path '%1' already opened with different schema version.", config.path);
+        }
 
 #if REALM_ENABLE_SYNC
         if (bool(m_config.sync_config) != bool(config.sync_config)) {
@@ -166,6 +169,10 @@ void RealmCoordinator::set_config(const Realm::Config& config)
 
 std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
 {
+    // realm must be declared before lock so that the mutex is released before
+    // we release the strong reference to realm, as Realm's destructor may want
+    // to acquire the same lock
+    std::shared_ptr<Realm> realm;
     std::unique_lock<std::mutex> lock(m_realm_mutex);
 
     set_config(config);
@@ -174,19 +181,30 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
     auto migration_function = std::move(config.migration_function);
     config.schema = {};
 
-    std::shared_ptr<Realm> realm;
     if (config.cache) {
         AnyExecutionContextID execution_context(config.execution_context);
         for (auto& cached_realm : m_weak_realm_notifiers) {
             if (!cached_realm.is_cached_for_execution_context(execution_context))
                 continue;
-            realm = cached_realm.realm();
             // can be null if we jumped in between ref count hitting zero and
             // unregister_realm() getting the lock
-            if (realm)
-                break;
+            if ((realm = cached_realm.realm())) {
+                // If the file is uninitialized and was opened without a schema,
+                // do the normal schema init
+                if (realm->schema_version() == ObjectStore::NotVersioned)
+                    break;
+
+                // Otherwise if we have a realm schema it needs to be an exact
+                // match (even having the same properties but in different
+                // orders isn't good enough)
+                if (schema && realm->schema() != *schema)
+                    throw MismatchedConfigException("Realm at path '%1' already opened on current thread with different schema.", config.path);
+
+                return realm;
+            }
         }
     }
+
     if (!realm) {
         realm = Realm::make_shared_realm(std::move(config), shared_from_this());
         if (!config.read_only() && !m_notifier && config.automatic_change_notifications) {
@@ -194,7 +212,6 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
                 m_notifier = std::make_unique<ExternalCommitHelper>(*this);
             }
             catch (std::system_error const& ex) {
-                lock.unlock();
                 throw RealmFileException(RealmFileException::Kind::AccessError, config.path, ex.code().message(), "");
             }
         }
@@ -202,11 +219,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
     }
 
     if (schema) {
-        auto old_schema_version = m_schema_version;
         lock.unlock();
-
-        if (old_schema_version != ObjectStore::NotVersioned && old_schema_version != config.schema_version)
-            throw MismatchedConfigException("Realm at path '%1' already opened with different schema version.", config.path);
         realm->update_schema(std::move(*schema), config.schema_version, std::move(migration_function));
     }
 

--- a/src/schema.hpp
+++ b/src/schema.hpp
@@ -63,6 +63,7 @@ public:
     void copy_table_columns_from(Schema const&);
 
     friend bool operator==(Schema const&, Schema const&);
+    friend bool operator!=(Schema const& a, Schema const& b) { return !(a == b); }
 
     using base::iterator;
     using base::const_iterator;

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -268,6 +268,13 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
             REQUIRE(realm1 == realm2);
         }).join();
     }
+
+    SECTION("should not modify the schema when fetching from the cache") {
+        auto realm = Realm::get_shared_realm(config);
+        auto object_schema = &*realm->schema().find("object");
+        Realm::get_shared_realm(config);
+        REQUIRE(object_schema == &*realm->schema().find("object"));
+    }
 }
 
 TEST_CASE("SharedRealm: notifications") {


### PR DESCRIPTION
Make the check stricter (the schema needs to be an exact match and not just compatible), and avoid overwriting the Schema object on the Realm so that pointers to parts of the Schema remain valid.

Fixes #358.