### PR TITLE
Do not move a variable we will use later (fixes path in exception).

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -206,7 +206,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
     }
 
     if (!realm) {
-        realm = Realm::make_shared_realm(std::move(config), shared_from_this());
+        realm = Realm::make_shared_realm(config, shared_from_this());
         if (!config.read_only() && !m_notifier && config.automatic_change_notifications) {
             try {
                 m_notifier = std::make_unique<ExternalCommitHelper>(*this);


### PR DESCRIPTION
The `config.path` would otherwise be empty if we throw the exception below.