### PR TITLE
Path from config has been moved, get it from the coordinator's copy

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -212,7 +212,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
                 m_notifier = std::make_unique<ExternalCommitHelper>(*this);
             }
             catch (std::system_error const& ex) {
-                throw RealmFileException(RealmFileException::Kind::AccessError, config.path, ex.code().message(), "");
+                throw RealmFileException(RealmFileException::Kind::AccessError, get_path(), ex.code().message(), "");
             }
         }
         m_weak_realm_notifiers.emplace_back(realm, m_config.cache);


### PR DESCRIPTION
In the interest of keeping the main code path highly optimised, we will still move `config`, but now source the path of the realm file from the coordinator.

This replaces #364 