### PR TITLE
Check all outgoing links for deep change checking

### DIFF
--- a/src/impl/collection_notifier.cpp
+++ b/src/impl/collection_notifier.cpp
@@ -98,12 +98,12 @@ bool DeepChangeChecker::check_outgoing_links(size_t table_ndx,
         return false;
     };
 
-    for (auto const& link : it->links) {
+    auto linked_object_changed = [&](OutgoingLink const& link) {
         if (already_checking(link.col_ndx))
-            continue;
+            return false;
         if (!link.is_list) {
             if (table.is_null_link(link.col_ndx, row_ndx))
-                continue;
+                return false;
             auto dst = table.get_link(link.col_ndx, row_ndx);
             return check_row(*table.get_link_target(link.col_ndx), dst, depth + 1);
         }
@@ -115,9 +115,10 @@ bool DeepChangeChecker::check_outgoing_links(size_t table_ndx,
             if (check_row(target, dst, depth + 1))
                 return true;
         }
-    }
+        return false;
+    };
 
-    return false;
+    return std::any_of(begin(it->links), end(it->links), linked_object_changed);
 }
 
 bool DeepChangeChecker::check_row(Table const& table, size_t idx, size_t depth)
@@ -141,7 +142,7 @@ bool DeepChangeChecker::check_row(Table const& table, size_t idx, size_t depth)
         return false;
 
     bool ret = check_outgoing_links(table_ndx, table, idx, depth);
-    if (!ret && !m_current_path[depth].depth_exceeded)
+    if (!ret && (depth == 0 || !m_current_path[depth - 1].depth_exceeded))
         m_not_modified[table_ndx].add(idx);
     return ret;
 }


### PR DESCRIPTION
Previously it stopped after the first non-null link. It also turned out that the check for exceeding the depth was slightly wrong in a way that was rendered irrelevant by the first bug.

Addresses https://github.com/realm/realm-cocoa/issues/4639.