### PR TITLE
Fix resetting of deferred close flag, and add more sync tests

### DIFF
--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -48,7 +48,6 @@ constexpr const char SyncError::c_recovery_file_path_key[];
 ///    * ACTIVE: when the binding successfully refreshes the token
 ///    * INACTIVE: if asked to log out, or if asked to close and the stop policy
 ///                is Immediate.
-///    * DYING: if asked to close and the stop policy is AfterChangesUploaded
 ///    * ERROR: if a fatal error occurs
 ///
 /// ACTIVE: the session is connected to the Realm Object Server and is actively
@@ -87,6 +86,7 @@ constexpr const char SyncError::c_recovery_file_path_key[];
 struct SyncSession::State {
     virtual ~State() { }
 
+    // Move the given session into this state. All state transitions MUST be carried out through this method.
     virtual void enter_state(std::unique_lock<std::mutex>&, SyncSession&) const { }
 
     virtual void refresh_access_token(std::unique_lock<std::mutex>&,
@@ -96,18 +96,20 @@ struct SyncSession::State {
     virtual void bind_with_admin_token(std::unique_lock<std::mutex>&,
                                        SyncSession&, const std::string&, const std::string&) const { }
 
-    /// Returns true iff the lock is still locked when the method returns.
+    // Returns true iff the lock is still locked when the method returns.
     virtual bool access_token_expired(std::unique_lock<std::mutex>&, SyncSession&) const { return true; }
 
     virtual void nonsync_transact_notify(std::unique_lock<std::mutex>&, SyncSession&, sync::Session::version_type) const { }
 
     virtual bool revive_if_needed(std::unique_lock<std::mutex>&, SyncSession&) const { return false; }
 
+    // The user that owns this session has been logged out, and the session should take appropriate action.
     virtual void log_out(std::unique_lock<std::mutex>&, SyncSession&) const { }
 
+    // The session should be closed and moved to `inactive`, in accordance with its stop policy and other state.
     virtual void close(std::unique_lock<std::mutex>&, SyncSession&) const { }
 
-    /// Returns true iff the error has been fully handled and the error handler should immediately return.
+    // Returns true iff the error has been fully handled and the error handler should immediately return.
     virtual bool handle_error(std::unique_lock<std::mutex>&, SyncSession&, const SyncError&) const { return false; }
 
     static const State& waiting_for_access_token;
@@ -118,6 +120,11 @@ struct SyncSession::State {
 };
 
 struct sync_session_states::WaitingForAccessToken : public SyncSession::State {
+    void enter_state(std::unique_lock<std::mutex>&, SyncSession& session) const override
+    {
+        session.m_deferred_close = false;
+    }
+
     void refresh_access_token(std::unique_lock<std::mutex>& lock, SyncSession& session,
                               std::string access_token,
                               const util::Optional<std::string>& server_url) const override
@@ -138,10 +145,15 @@ struct sync_session_states::WaitingForAccessToken : public SyncSession::State {
             session.m_deferred_commit_notification = util::none;
         }
         session.advance_state(lock, active);
+        if (session.m_deferred_close) {
+            session.m_deferred_close = false;
+            session.m_state->close(lock, session);
+        }
     }
 
     void log_out(std::unique_lock<std::mutex>& lock, SyncSession& session) const override
     {
+        session.m_deferred_close = false;
         session.advance_state(lock, inactive);
     }
 
@@ -155,8 +167,18 @@ struct sync_session_states::WaitingForAccessToken : public SyncSession::State {
 
     void close(std::unique_lock<std::mutex>& lock, SyncSession& session) const override
     {
-        // Ignore the sync configuration's stop policy as we're not yet connected.
-        session.advance_state(lock, inactive);
+        switch (session.m_config.stop_policy) {
+            case SyncSessionStopPolicy::Immediately:
+                // Immediately kill the session.
+                session.m_deferred_close = false;
+                session.advance_state(lock, inactive);
+                break;
+            case SyncSessionStopPolicy::LiveIndefinitely:
+            case SyncSessionStopPolicy::AfterChangesUploaded:
+                // Defer handling closing the session until after the login response succeeds.
+                session.m_deferred_close = true;
+                break;
+        }
     }
 };
 

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -148,14 +148,12 @@ struct sync_session_states::WaitingForAccessToken : public SyncSession::State {
         }
         session.advance_state(lock, active);
         if (session.m_deferred_close) {
-            session.m_deferred_close = false;
             session.m_state->close(lock, session);
         }
     }
 
     void log_out(std::unique_lock<std::mutex>& lock, SyncSession& session) const override
     {
-        session.m_deferred_close = false;
         session.advance_state(lock, inactive);
     }
 
@@ -178,7 +176,6 @@ struct sync_session_states::WaitingForAccessToken : public SyncSession::State {
         switch (session.m_config.stop_policy) {
             case SyncSessionStopPolicy::Immediately:
                 // Immediately kill the session.
-                session.m_deferred_close = false;
                 session.advance_state(lock, inactive);
                 break;
             case SyncSessionStopPolicy::LiveIndefinitely:

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -127,9 +127,6 @@ public:
     // Inform the sync session that it should close.
     void close();
 
-    // Inform the sync session that it should close, but only if it is not yet connected.
-    void close_if_connecting();
-
     // Inform the sync session that it should log out.
     void log_out();
 
@@ -274,7 +271,6 @@ private:
     bool m_session_has_been_bound;
 
     util::Optional<int_fast64_t> m_deferred_commit_notification;
-    bool m_deferred_close = false;
 
     // The fully-resolved URL of this Realm, including the server and the path.
     util::Optional<std::string> m_server_url;

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -121,6 +121,9 @@ public:
     // be set.
     void refresh_access_token(std::string access_token, util::Optional<std::string> server_url);
 
+    // FIXME: we need an API to allow the binding to tell sync that the access token fetch failed
+    // or was cancelled, and cannot be retried.
+
     // Give the `SyncSession` an administrator token, and ask it to immediately `bind()` the session.
     void bind_with_admin_token(std::string admin_token, std::string server_url);
 
@@ -271,6 +274,7 @@ private:
     bool m_session_has_been_bound;
 
     util::Optional<int_fast64_t> m_deferred_commit_notification;
+    bool m_deferred_close = false;
 
     // The fully-resolved URL of this Realm, including the server and the path.
     util::Optional<std::string> m_server_url;

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -112,6 +112,7 @@ public:
     bool wait_for_upload_completion_blocking();
 
     // If the sync session is currently `Dying`, ask it to stay alive instead.
+    // If the sync session is currently `WaitingForAccessToken`, cancel any deferred close.
     // If the sync session is currently `Inactive`, recreate it. Otherwise, a no-op.
     static void revive_if_needed(std::shared_ptr<SyncSession> session);
 

--- a/tests/sync/session.cpp
+++ b/tests/sync/session.cpp
@@ -326,13 +326,13 @@ TEST_CASE("sync: SyncSession.close() API", "[sync]") {
 
     auto user = SyncManager::shared().get_user("close-api-tests-user", "not_a_real_token");
 
-    SECTION("Behaves properly when called on session in the 'waiting for token' state") {
+    SECTION("Behaves properly when called on session in the 'waiting for token' state for Immediate") {
         std::atomic<bool> bind_function_called(false);
 
         // Make a session that won't leave the 'waiting for token' state.
         std::string url = server.base_url() + "/test-close-for-waiting-token";
         SyncTestFile config({user, url,
-            SyncSessionStopPolicy::AfterChangesUploaded,
+            SyncSessionStopPolicy::Immediately,
             [&](auto&, auto&, std::shared_ptr<SyncSession>) {
                 bind_function_called = true;
             },

--- a/tests/sync/session.cpp
+++ b/tests/sync/session.cpp
@@ -319,6 +319,66 @@ TEST_CASE("sync: token refreshing", "[sync]") {
     }
 }
 
+TEST_CASE("sync: SyncSession.close() API", "[sync]") {
+    using PublicState = realm::SyncSession::PublicState;
+    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
+    SyncServer server;
+
+    auto user = SyncManager::shared().get_user("close-api-tests-user", "not_a_real_token");
+
+    SECTION("Behaves properly when called on session in the 'waiting for token' state") {
+        std::atomic<bool> bind_function_called(false);
+
+        // Make a session that won't leave the 'waiting for token' state.
+        std::string url = server.base_url() + "/test-close-for-waiting-token";
+        SyncTestFile config({user, url,
+            SyncSessionStopPolicy::AfterChangesUploaded,
+            [&](auto&, auto&, std::shared_ptr<SyncSession>) {
+                bind_function_called = true;
+            },
+            [&](auto, auto) { }
+        });
+        std::shared_ptr<SyncSession> session;
+        {
+            auto realm = Realm::get_shared_realm(config);
+            session = SyncManager::shared().get_session(config.path, *config.sync_config);
+        }
+        REQUIRE(session);
+        EventLoop::main().run_until([&] { return bind_function_called == true; });
+        REQUIRE(session->state() == PublicState::WaitingForAccessToken);
+        session->close();
+        REQUIRE(session_is_inactive(*session));
+        // Test trying to call bind on the session after it's been closed. Should be a no-op.
+        session->refresh_access_token(s_test_token, url);
+        REQUIRE(session_is_inactive(*session));
+    }
+
+    SECTION("Behaves properly when called on session in the 'active' or 'inactive' state") {
+        auto session = sync_session(server, user, "/test-close-for-active",
+                                    [&](auto&, auto&) { return s_test_token; },
+                                    [](auto, auto) { },
+                                    SyncSessionStopPolicy::AfterChangesUploaded);
+        EventLoop::main().run_until([&] { return session_is_active(*session); });
+        REQUIRE(session_is_active(*session));
+        session->close();
+        EventLoop::main().run_until([&] { return session_is_inactive(*session); });
+        REQUIRE(session_is_inactive(*session));
+        // Try closing the session again. This should be a no-op.
+        session->close();
+        REQUIRE(session_is_inactive(*session));
+    }
+
+    SECTION("Behaves properly when called on session in the 'error' state") {
+        auto session = sync_session(server, user, "/test-close-for-error",
+                                    [&](auto&, auto&) { return "NOT A VALID TOKEN"; },
+                                    [](auto, auto) { },
+                                    SyncSessionStopPolicy::AfterChangesUploaded);
+        EventLoop::main().run_until([&] { return session->state() == PublicState::Error; });
+        session->close();
+        REQUIRE(session->state() == PublicState::Error);
+    }
+}
+
 TEST_CASE("sync: error handling", "[sync]") {
     using ProtocolError = realm::sync::ProtocolError;
     auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });


### PR DESCRIPTION
Changes:
- ~Removed support for 'deferred close'; sessions will immediately close even if waiting for the access token~
- Fixed an issue where the 'deferred close' flag was not properly reset in some cases when transitioning out of 'waiting for token'
- Removed an unused `SyncSession` API
- Added tests to ensure that `SyncSession.close()` works no matter what state the session is in

cc @nhachicha 