### PR TITLE
Checking realm is_closed in advance_to_latest

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -754,6 +754,11 @@ bool RealmCoordinator::advance_to_latest(Realm& realm)
 
     auto version = sg->get_version_of_current_transaction();
     transaction::advance(sg, realm.m_binding_context.get(), notifiers);
+
+    // Realm could be closed in the callbacks.
+    if (realm.is_closed())
+        return false;
+
     return version != sg->get_version_of_current_transaction();
 }
 

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -543,5 +543,17 @@ TEST_CASE("ShareRealm: realm closed in did_change callback") {
 
         r1->notify();
     }
+
+    SECTION("refresh") {
+        r1->m_binding_context.reset(new Context());
+
+        auto r2 = Realm::get_shared_realm(config);
+        r2->begin_transaction();
+        r2->read_group().get_table("class_object")->add_empty_row(1);
+        r2->commit_transaction();
+        r2.reset();
+
+        REQUIRE_FALSE(r1->refresh());
+    }
 }
 


### PR DESCRIPTION
Realm could be closed in callbacks. If that happened, Realm::refresh()
crashed.