### PR TITLE
Fix a pile of issues exposed by building with VC++ 2015

### DIFF
--- a/src/impl/collection_change_builder.cpp
+++ b/src/impl/collection_change_builder.cpp
@@ -77,7 +77,6 @@ void CollectionChangeBuilder::merge(CollectionChangeBuilder&& c)
                 old.to = it->to;
                 *it = c.moves.back();
                 c.moves.pop_back();
-                ++it;
                 return false;
             }
 

--- a/src/impl/epoll/external_commit_helper.cpp
+++ b/src/impl/epoll/external_commit_helper.cpp
@@ -185,8 +185,7 @@ ExternalCommitHelper::DaemonThread::DaemonThread()
     m_shutdown_read_fd = pipe_fd[0];
     m_shutdown_write_fd = pipe_fd[1];
 
-    struct epoll_event event;
-
+    epoll_event event{};
     event.events = EPOLLIN;
     event.data.fd = m_shutdown_read_fd;
     ret = epoll_ctl(m_epoll_fd, EPOLL_CTL_ADD, m_shutdown_read_fd, &event);
@@ -229,10 +228,10 @@ void ExternalCommitHelper::DaemonThread::add_commit_helper(ExternalCommitHelper*
     REALM_ASSERT(std::this_thread::get_id() != m_thread_id);
 
     std::lock_guard<std::mutex> lock(m_mutex);
-    struct epoll_event event;
 
     m_helpers.push_back(helper);
 
+    epoll_event event{};
     event.events = EPOLLIN | EPOLLET;
     event.data.fd = helper->m_notify_fd;
     int ret = epoll_ctl(m_epoll_fd, EPOLL_CTL_ADD, helper->m_notify_fd, &event);
@@ -251,10 +250,9 @@ void ExternalCommitHelper::DaemonThread::remove_commit_helper(ExternalCommitHelp
 
     m_helpers.erase(std::remove(m_helpers.begin(), m_helpers.end(), helper), m_helpers.end());
 
-    struct epoll_event event;
-
     // In kernel versions before 2.6.9, the EPOLL_CTL_DEL operation required a non-NULL pointer in event, even
     // though this argument is ignored. See man page of epoll_ctl.
+    epoll_event event{};
     epoll_ctl(m_epoll_fd, EPOLL_CTL_DEL, helper->m_notify_fd, &event);
 }
 
@@ -265,7 +263,7 @@ void ExternalCommitHelper::DaemonThread::listen()
     int ret;
 
     while (true) {
-        struct epoll_event ev;
+        epoll_event ev{};
         ret = epoll_wait(m_epoll_fd, &ev, 1, -1);
 
         if (ret == -1 && errno == EINTR) {

--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -483,17 +483,18 @@ public:
         REALM_ASSERT(unordered);
         size_t last_row = prior_num_rows - 1;
 
-        for (auto it = begin(m_info.lists); it != end(m_info.lists); ) {
-            if (it->table_ndx == current_table()) {
-                if (it->row_ndx == row_ndx) {
-                    *it = std::move(m_info.lists.back());
-                    m_info.lists.pop_back();
-                    continue;
-                }
-                if (it->row_ndx == last_row)
-                    it->row_ndx = row_ndx;
+        for (size_t i = 0; i < m_info.lists.size(); ++i) {
+            auto& list = m_info.lists[i];
+            if (list.table_ndx != current_table())
+                continue;
+            if (list.row_ndx == row_ndx) {
+                if (i + 1 < m_info.lists.size())
+                    m_info.lists[i] = std::move(m_info.lists.back());
+                m_info.lists.pop_back();
+                continue;
             }
-            ++it;
+            if (list.row_ndx == last_row)
+                list.row_ndx = row_ndx;
         }
 
         if (auto change = get_change())

--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -342,9 +342,8 @@ void expand_to(std::vector<size_t>& cols, size_t i)
     if (old_size > i)
         return;
 
-    auto new_size = std::max(old_size * 2, i + 1);
-    cols.resize(new_size);
-    std::iota(&cols[old_size], &cols[new_size], old_size == 0 ? 0 : cols[old_size - 1] + 1);
+    cols.resize(std::max(old_size * 2, i + 1));
+    std::iota(begin(cols) + old_size, end(cols), old_size == 0 ? 0 : cols[old_size - 1] + 1);
 }
 
 void adjust_ge(std::vector<size_t>& values, size_t i)

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -202,7 +202,7 @@ void Realm::open_with_config(const Config& config,
             shared_group = std::make_unique<SharedGroup>(*history, options);
         }
     }
-    catch (realm::FileFormatUpgradeRequired const& ex) {
+    catch (realm::FileFormatUpgradeRequired const&) {
         if (config.schema_mode != SchemaMode::ResetFile) {
             translate_file_exception(config.path, config.read_only());
         }

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -556,4 +556,3 @@ TEST_CASE("ShareRealm: realm closed in did_change callback") {
         REQUIRE_FALSE(r1->refresh());
     }
 }
-

--- a/tests/transaction_log_parsing.cpp
+++ b/tests/transaction_log_parsing.cpp
@@ -55,7 +55,7 @@ public:
         m_realm->commit_transaction();
 
         _impl::CollectionChangeBuilder c;
-        _impl::TransactionChangeInfo info;
+        _impl::TransactionChangeInfo info{};
         info.lists.push_back({m_table_ndx, 0, 0, &c});
         info.table_modifications_needed.resize(m_group.size(), true);
         info.table_moves_needed.resize(m_group.size(), true);
@@ -256,7 +256,7 @@ TEST_CASE("Transaction log parsing: schema change reporting") {
         f();
         r->commit_transaction();
 
-        _impl::TransactionChangeInfo info;
+        _impl::TransactionChangeInfo info{};
         info.table_modifications_needed.resize(10, true);
         _impl::transaction::advance(sg, info);
 
@@ -408,7 +408,7 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             f();
             r->commit_transaction();
 
-            _impl::TransactionChangeInfo info;
+            _impl::TransactionChangeInfo info{};
             info.table_modifications_needed = tables_needed;
             info.table_moves_needed = tables_needed;
             _impl::transaction::advance(sg, info);
@@ -1931,7 +1931,7 @@ TEST_CASE("DeepChangeChecker") {
         f();
         r->commit_transaction();
 
-        _impl::TransactionChangeInfo info;
+        _impl::TransactionChangeInfo info{};
         info.table_modifications_needed.resize(g.size(), true);
         info.table_moves_needed.resize(g.size(), true);
         _impl::transaction::advance(sg, info);


### PR DESCRIPTION
I think none of these are currently user-visible bugs; most of them are vc++'s iterator debugging identifying things which are invalid but in practice would always happen to work.