### PR TITLE
Allow completion handlers to be registered before binding

### DIFF
--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -169,8 +169,6 @@ struct sync_session_states::WaitingForAccessToken : public SyncSession::State {
             session.m_deferred_commit_notification = util::none;
         }
 
-        // Move the session into `active`. Note that we may then immediately
-        // change state again if the session needs to be closed.
         session.advance_state(lock, active);
         if (session.m_deferred_close) {
             session.m_state->close(lock, session);

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -577,7 +577,7 @@ void SyncSession::create_sync_session()
 {
     REALM_ASSERT(!m_session);
     sync::Session::Config session_config;
-    session_config.changeset_cooker = m_config.transformer;
+    session_config.changeset_cooker = m_config.transformer.get();
     m_session = std::make_unique<sync::Session>(m_client.client, m_realm_path, session_config);
 
     // The next time we get a token, call `bind()` instead of `refresh()`.

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -577,7 +577,7 @@ void SyncSession::create_sync_session()
 {
     REALM_ASSERT(!m_session);
     sync::Session::Config session_config;
-    session_config.changeset_cooker = m_config.transformer.get();
+    session_config.changeset_cooker = m_config.transformer;
     m_session = std::make_unique<sync::Session>(m_client.client, m_realm_path, session_config);
 
     // The next time we get a token, call `bind()` instead of `refresh()`.

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -32,6 +32,8 @@ using namespace realm;
 using namespace realm::_impl;
 using namespace realm::_impl::sync_session_states;
 
+using SessionWaiterPointer = void(sync::Session::*)(std::function<void(std::error_code)>);
+
 constexpr const char SyncError::c_original_file_path_key[];
 constexpr const char SyncError::c_recovery_file_path_key[];
 

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -685,18 +685,6 @@ bool SyncSession::wait_for_download_completion(std::function<void(std::error_cod
     return m_state->wait_for_completion(*this, std::move(callback), &sync::Session::async_wait_for_download_completion);
 }
 
-bool SyncSession::wait_for_upload_completion_blocking()
-{
-    // TODO: get rid of this completely?
-    std::unique_lock<std::mutex> lock(m_state_mutex);
-    if (m_state == &State::active || m_state == &State::dying) {
-        REALM_ASSERT(m_session);
-        m_session->wait_for_upload_complete_or_client_stopped();
-        return true;
-    }
-    return false;
-}
-
 uint64_t SyncSession::register_progress_notifier(std::function<SyncProgressNotifierCallback> notifier,
                                                  NotifierType direction, bool is_streaming)
 {

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -49,7 +49,6 @@ namespace sync {
 class Session;
 }
 
-using SessionWaiterPointer = void(sync::Session::*)(std::function<void(std::error_code)>);
 using SyncSessionTransactCallback = void(VersionID old_version, VersionID new_version);
 using SyncProgressNotifierCallback = void(uint64_t transferred_bytes, uint64_t transferrable_bytes);
 
@@ -213,9 +212,6 @@ private:
     SyncSession(_impl::SyncClient&, std::string realm_path, SyncConfig);
     // }
 
-    bool can_wait_for_network_completion() const;
-    bool can_queue_for_network_completion() const;
-
     void handle_error(SyncError);
     static std::string get_recovery_file_path();
     void handle_progress_update(uint64_t, uint64_t, uint64_t, uint64_t);
@@ -279,7 +275,7 @@ private:
 
     // For storing wait-for-completion requests if the session isn't yet ready to handle them.
     struct CompletionWaitPackage {
-        SessionWaiterPointer waiter;
+        void(sync::Session::*waiter)(std::function<void(std::error_code)>);
         std::function<void(std::error_code)> callback;
     };
     std::vector<CompletionWaitPackage> m_completion_wait_packages;

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -49,6 +49,7 @@ namespace sync {
 class Session;
 }
 
+using SessionWaiterPointer = void(sync::Session::*)(std::function<void(std::error_code)>);
 using SyncSessionTransactCallback = void(VersionID old_version, VersionID new_version);
 using SyncProgressNotifierCallback = void(uint64_t transferred_bytes, uint64_t transferrable_bytes);
 
@@ -276,13 +277,9 @@ private:
     std::string m_realm_path;
     _impl::SyncClient& m_client;
 
-    enum class CompletionWaitType {
-        Upload, Download, Sync,
-    };
-
     // For storing wait-for-completion requests if the session isn't yet ready to handle them.
     struct CompletionWaitPackage {
-        CompletionWaitType type;
+        SessionWaiterPointer waiter;
         std::function<void(std::error_code)> callback;
     };
     std::vector<CompletionWaitPackage> m_completion_wait_packages;

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -108,11 +108,6 @@ public:
     // this method does nothing.
     void unregister_progress_notifier(uint64_t);
 
-    // Wait for any pending uploads to complete, blocking the calling thread.
-    // Returns `false` if the method did not attempt to wait, either because the
-    // session is in an error state or because it hasn't yet been `bind()`ed.
-    bool wait_for_upload_completion_blocking();
-
     // If the sync session is currently `Dying`, ask it to stay alive instead.
     // If the sync session is currently `WaitingForAccessToken`, cancel any deferred close.
     // If the sync session is currently `Inactive`, recreate it. Otherwise, a no-op.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ if(REALM_ENABLE_SYNC)
         sync/metadata.cpp
         sync/session/session.cpp
         sync/session/progress_notifications.cpp
+        sync/session/wait_for_completion.cpp
         sync/sync_manager.cpp
         sync/sync_test_utils.cpp
         sync/user.cpp

--- a/tests/sync/session/wait_for_completion.cpp
+++ b/tests/sync/session/wait_for_completion.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////
 //
-// Copyright 2016 Realm Inc.
+// Copyright 2017 Realm Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -68,9 +68,9 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
         EventLoop::main().run_until([&] { return login_handler_called == true; });
         REQUIRE(session);
         REQUIRE(handler_called == false);
-        // Spin the loop many times.
+        // Spin the loop a few times.
         std::atomic<int> spin_count(0);
-        EventLoop::main().run_until([&] { spin_count++; return spin_count > 100; });
+        EventLoop::main().run_until([&] { spin_count++; return spin_count > 2; });
         REQUIRE(handler_called == false);
         // Now bind the session
         session->refresh_access_token(s_test_token, server.base_url() + server_path);
@@ -92,9 +92,9 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
         REQUIRE(session->wait_for_download_completion([&](auto) {
             handler_called = true;
         }));
-        // Spin the loop many times.
+        // Spin the loop a few times.
         std::atomic<int> spin_count(0);
-        EventLoop::main().run_until([&] { spin_count++; return spin_count > 100; });
+        EventLoop::main().run_until([&] { spin_count++; return spin_count > 2; });
         REQUIRE(handler_called == false);
         // Log the user back in
         user = SyncManager::shared().get_user(user_id, "not_a_real_token_either");
@@ -182,9 +182,9 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
         EventLoop::main().run_until([&] { return login_handler_called == true; });
         REQUIRE(session);
         REQUIRE(handler_called == false);
-        // Spin the loop many times.
+        // Spin the loop a few times.
         std::atomic<int> spin_count(0);
-        EventLoop::main().run_until([&] { spin_count++; return spin_count > 100; });
+        EventLoop::main().run_until([&] { spin_count++; return spin_count > 2; });
         REQUIRE(handler_called == false);
         // Now bind the session
         session->refresh_access_token(s_test_token, server.base_url() + server_path);
@@ -206,9 +206,9 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
         REQUIRE(session->wait_for_upload_completion([&](auto) {
             handler_called = true;
         }));
-        // Spin the loop many times.
+        // Spin the loop a few times.
         std::atomic<int> spin_count(0);
-        EventLoop::main().run_until([&] { spin_count++; return spin_count > 100; });
+        EventLoop::main().run_until([&] { spin_count++; return spin_count > 2; });
         REQUIRE(handler_called == false);
         // Log the user back in
         user = SyncManager::shared().get_user(user_id, "not_a_real_token_either");

--- a/tests/sync/session/wait_for_completion.cpp
+++ b/tests/sync/session/wait_for_completion.cpp
@@ -1,0 +1,256 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2016 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "catch.hpp"
+
+#include "sync/session/session_util.hpp"
+
+#include "util/event_loop.hpp"
+
+#include <realm/util/scope_exit.hpp>
+
+using namespace realm;
+using namespace realm::util;
+
+TEST_CASE("SyncSession: async_wait_for_download()", "[sync]") {
+    if (!EventLoop::has_implementation())
+        return;
+
+    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
+    SyncServer server;
+    // Disable file-related functionality and metadata functionality for testing purposes.
+    SyncManager::shared().configure_file_system(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
+
+    std::atomic<bool> handler_called(false);
+
+    SECTION("works properly when called after the session is bound") {
+        auto user = SyncManager::shared().get_user("user-async-wait-download-1", "not_a_real_token");
+        auto session = sync_session(server, user, "/async-wait-download-1",
+                                    [](const std::string&, const std::string&) { return s_test_token; },
+                                    [](auto, auto) { });
+        EventLoop::main().run_until([&] { return sessions_are_active(*session); });
+        // Register the download-completion notification
+        CHECK(session->wait_for_download_completion([&](auto) {
+            handler_called = true;
+        }));
+        EventLoop::main().run_until([&] { return handler_called == true; });
+    }
+
+    SECTION("works properly when called on a session waiting for its access token") {
+        auto user = SyncManager::shared().get_user("user-async-wait-download-2", "not_a_real_token");
+        std::atomic<bool> login_handler_called(false);
+        auto server_path = "/async-wait-download-2";
+        std::shared_ptr<SyncSession> session = full_control_sync_session(server, user, server_path,
+                                                                         [&](auto, auto, std::shared_ptr<SyncSession> s){
+                                                                             session = std::move(s);
+                                                                             login_handler_called = true;
+                                                                         },
+                                                                         [](auto, auto) { });
+        // Register the download-completion notification
+        REQUIRE(session->wait_for_download_completion([&](auto) {
+            handler_called = true;
+        }));
+        EventLoop::main().run_until([&] { return login_handler_called == true; });
+        REQUIRE(session);
+        REQUIRE(handler_called == false);
+        // Spin the loop many times.
+        std::atomic<int> spin_count(0);
+        EventLoop::main().run_until([&] { spin_count++; return spin_count > 100; });
+        REQUIRE(handler_called == false);
+        // Now bind the session
+        session->refresh_access_token(s_test_token, server.base_url() + server_path);
+        EventLoop::main().run_until([&] { return sessions_are_active(*session); });
+        EventLoop::main().run_until([&] { return handler_called == true; });
+    }
+
+    SECTION("works properly when called on a logged-out session") {
+        const auto user_id = "user-async-wait-download-3";
+        auto user = SyncManager::shared().get_user(user_id, "not_a_real_token");
+        auto session = sync_session(server, user, "/user-async-wait-download-3",
+                                    [](auto&, auto&) { return s_test_token; },
+                                    [](auto, auto) { });
+        EventLoop::main().run_until([&] { return sessions_are_active(*session); });
+        // Log the user out, and wait for the sessions to log out.
+        user->log_out();
+        EventLoop::main().run_until([&] { return sessions_are_inactive(*session); });
+        // Register the download-completion notification
+        REQUIRE(session->wait_for_download_completion([&](auto) {
+            handler_called = true;
+        }));
+        // Spin the loop many times.
+        std::atomic<int> spin_count(0);
+        EventLoop::main().run_until([&] { spin_count++; return spin_count > 100; });
+        REQUIRE(handler_called == false);
+        // Log the user back in
+        user = SyncManager::shared().get_user(user_id, "not_a_real_token_either");
+        EventLoop::main().run_until([&] { return sessions_are_active(*session); });
+        // Now, wait for the completion handler to be called.
+        EventLoop::main().run_until([&] { return handler_called == true; });
+    }
+
+    SECTION("aborts properly when queued and the session errors out") {
+        using ProtocolError = realm::sync::ProtocolError;
+        auto user = SyncManager::shared().get_user("user-async-wait-download-4", "not_a_real_token");
+        std::atomic<bool> login_handler_called(false);
+        std::atomic<int> error_count(0);
+        auto server_path = "/async-wait-download-4";
+        std::shared_ptr<SyncSession> session = full_control_sync_session(server, user, server_path,
+                                                                         [&](auto, auto, std::shared_ptr<SyncSession> s){
+                                                                             session = std::move(s);
+                                                                             login_handler_called = true;
+                                                                         },
+                                                                         [&](auto, auto) { ++error_count; });
+        // Register the download-completion notification
+        REQUIRE(session->wait_for_download_completion([&](std::error_code error) {
+            REQUIRE(error == util::error::operation_aborted);
+            handler_called = true;
+        }));
+        EventLoop::main().run_until([&] { return login_handler_called == true; });
+        REQUIRE(handler_called == false);
+        // Now trigger an error
+        std::error_code code = std::error_code{static_cast<int>(ProtocolError::bad_syntax), realm::sync::protocol_error_category()};
+        SyncSession::OnlyForTesting::handle_error(*session, {code, "Not a real error message", true});
+        EventLoop::main().run_until([&] { return error_count > 0; });
+        REQUIRE(handler_called == true);
+    }
+
+    SECTION("properly rejects any callbacks when session is errored") {
+        auto user = SyncManager::shared().get_user("user-async-wait-download-5", "not_a_real_token");
+        std::atomic<int> error_count(0);
+        auto session = sync_session(server, user, "/test",
+                                    [](const std::string&, const std::string&) { return "this is not a valid access token"; },
+                                    [&](auto, auto) { ++error_count; });
+
+        EventLoop::main().run_until([&] { return error_count > 0; });
+        REQUIRE(!session->wait_for_download_completion([](auto) { }));
+    }
+}
+
+TEST_CASE("SyncSession: async_wait_for_upload()", "[sync]") {
+    if (!EventLoop::has_implementation())
+        return;
+
+    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
+    SyncServer server;
+    // Disable file-related functionality and metadata functionality for testing purposes.
+    SyncManager::shared().configure_file_system(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
+
+    std::atomic<bool> handler_called(false);
+
+    SECTION("works properly when called after the session is bound") {
+        auto user = SyncManager::shared().get_user("user-async-wait-upload-1", "not_a_real_token");
+        auto session = sync_session(server, user, "/async-wait-upload-1",
+                                    [](const std::string&, const std::string&) { return s_test_token; },
+                                    [](auto, auto) { });
+        EventLoop::main().run_until([&] { return sessions_are_active(*session); });
+        // Register the upload-completion notification
+        CHECK(session->wait_for_upload_completion([&](auto) {
+            handler_called = true;
+        }));
+        EventLoop::main().run_until([&] { return handler_called == true; });
+    }
+
+    SECTION("works properly when called on a session waiting for its access token") {
+        auto user = SyncManager::shared().get_user("user-async-wait-upload-2", "not_a_real_token");
+        std::atomic<bool> login_handler_called(false);
+        auto server_path = "/async-wait-upload-2";
+        std::shared_ptr<SyncSession> session = full_control_sync_session(server, user, server_path,
+                                                                         [&](auto, auto, std::shared_ptr<SyncSession> s){
+                                                                             session = std::move(s);
+                                                                             login_handler_called = true;
+                                                                         },
+                                                                         [](auto, auto) { });
+        // Register the upload-completion notification
+        REQUIRE(session->wait_for_upload_completion([&](auto) {
+            handler_called = true;
+        }));
+        EventLoop::main().run_until([&] { return login_handler_called == true; });
+        REQUIRE(session);
+        REQUIRE(handler_called == false);
+        // Spin the loop many times.
+        std::atomic<int> spin_count(0);
+        EventLoop::main().run_until([&] { spin_count++; return spin_count > 100; });
+        REQUIRE(handler_called == false);
+        // Now bind the session
+        session->refresh_access_token(s_test_token, server.base_url() + server_path);
+        EventLoop::main().run_until([&] { return sessions_are_active(*session); });
+        EventLoop::main().run_until([&] { return handler_called == true; });
+    }
+
+    SECTION("works properly when called on a logged-out session") {
+        const auto user_id = "user-async-wait-upload-3";
+        auto user = SyncManager::shared().get_user(user_id, "not_a_real_token");
+        auto session = sync_session(server, user, "/user-async-wait-upload-3",
+                                    [](auto&, auto&) { return s_test_token; },
+                                    [](auto, auto) { });
+        EventLoop::main().run_until([&] { return sessions_are_active(*session); });
+        // Log the user out, and wait for the sessions to log out.
+        user->log_out();
+        EventLoop::main().run_until([&] { return sessions_are_inactive(*session); });
+        // Register the upload-completion notification
+        REQUIRE(session->wait_for_upload_completion([&](auto) {
+            handler_called = true;
+        }));
+        // Spin the loop many times.
+        std::atomic<int> spin_count(0);
+        EventLoop::main().run_until([&] { spin_count++; return spin_count > 100; });
+        REQUIRE(handler_called == false);
+        // Log the user back in
+        user = SyncManager::shared().get_user(user_id, "not_a_real_token_either");
+        EventLoop::main().run_until([&] { return sessions_are_active(*session); });
+        // Now, wait for the completion handler to be called.
+        EventLoop::main().run_until([&] { return handler_called == true; });
+    }
+
+    SECTION("aborts properly when queued and the session errors out") {
+        using ProtocolError = realm::sync::ProtocolError;
+        auto user = SyncManager::shared().get_user("user-async-wait-upload-4", "not_a_real_token");
+        std::atomic<bool> login_handler_called(false);
+        std::atomic<int> error_count(0);
+        auto server_path = "/async-wait-upload-4";
+        std::shared_ptr<SyncSession> session = full_control_sync_session(server, user, server_path,
+                                                                         [&](auto, auto, std::shared_ptr<SyncSession> s){
+                                                                             session = std::move(s);
+                                                                             login_handler_called = true;
+                                                                         },
+                                                                         [&](auto, auto) { ++error_count; });
+        // Register the upload-completion notification
+        REQUIRE(session->wait_for_upload_completion([&](std::error_code error) {
+            REQUIRE(error == util::error::operation_aborted);
+            handler_called = true;
+        }));
+        EventLoop::main().run_until([&] { return login_handler_called == true; });
+        REQUIRE(handler_called == false);
+        // Now trigger an error
+        std::error_code code = std::error_code{static_cast<int>(ProtocolError::bad_syntax), realm::sync::protocol_error_category()};
+        SyncSession::OnlyForTesting::handle_error(*session, {code, "Not a real error message", true});
+        EventLoop::main().run_until([&] { return error_count > 0; });
+        REQUIRE(handler_called == true);
+    }
+
+    SECTION("properly rejects any callbacks when session is errored") {
+        auto user = SyncManager::shared().get_user("user-async-wait-upload-5", "not_a_real_token");
+        std::atomic<int> error_count(0);
+        auto session = sync_session(server, user, "/test",
+                                    [](const std::string&, const std::string&) { return "this is not a valid access token"; },
+                                    [&](auto, auto) { ++error_count; });
+
+        EventLoop::main().run_until([&] { return error_count > 0; });
+        REQUIRE(!session->wait_for_upload_completion([](auto) { }));
+    }
+}

--- a/tests/sync/session/wait_for_completion.cpp
+++ b/tests/sync/session/wait_for_completion.cpp
@@ -27,7 +27,7 @@
 using namespace realm;
 using namespace realm::util;
 
-TEST_CASE("SyncSession: async_wait_for_download()", "[sync]") {
+TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
     if (!EventLoop::has_implementation())
         return;
 
@@ -55,12 +55,12 @@ TEST_CASE("SyncSession: async_wait_for_download()", "[sync]") {
         auto user = SyncManager::shared().get_user("user-async-wait-download-2", "not_a_real_token");
         std::atomic<bool> login_handler_called(false);
         auto server_path = "/async-wait-download-2";
-        std::shared_ptr<SyncSession> session = full_control_sync_session(server, user, server_path,
-                                                                         [&](auto, auto, std::shared_ptr<SyncSession> s){
-                                                                             session = std::move(s);
-                                                                             login_handler_called = true;
-                                                                         },
-                                                                         [](auto, auto) { });
+        std::shared_ptr<SyncSession> session = sync_session_with_bind_handler(server, user, server_path,
+                                                                              [&](auto, auto, std::shared_ptr<SyncSession> s){
+                                                                                  session = std::move(s);
+                                                                                  login_handler_called = true;
+                                                                              },
+                                                                              [](auto, auto) { });
         // Register the download-completion notification
         REQUIRE(session->wait_for_download_completion([&](auto) {
             handler_called = true;
@@ -109,12 +109,12 @@ TEST_CASE("SyncSession: async_wait_for_download()", "[sync]") {
         std::atomic<bool> login_handler_called(false);
         std::atomic<int> error_count(0);
         auto server_path = "/async-wait-download-4";
-        std::shared_ptr<SyncSession> session = full_control_sync_session(server, user, server_path,
-                                                                         [&](auto, auto, std::shared_ptr<SyncSession> s){
-                                                                             session = std::move(s);
-                                                                             login_handler_called = true;
-                                                                         },
-                                                                         [&](auto, auto) { ++error_count; });
+        std::shared_ptr<SyncSession> session = sync_session_with_bind_handler(server, user, server_path,
+                                                                              [&](auto, auto, std::shared_ptr<SyncSession> s){
+                                                                                  session = std::move(s);
+                                                                                  login_handler_called = true;
+                                                                              },
+                                                                              [&](auto, auto) { ++error_count; });
         // Register the download-completion notification
         REQUIRE(session->wait_for_download_completion([&](std::error_code error) {
             REQUIRE(error == util::error::operation_aborted);
@@ -141,7 +141,7 @@ TEST_CASE("SyncSession: async_wait_for_download()", "[sync]") {
     }
 }
 
-TEST_CASE("SyncSession: async_wait_for_upload()", "[sync]") {
+TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
     if (!EventLoop::has_implementation())
         return;
 
@@ -169,12 +169,12 @@ TEST_CASE("SyncSession: async_wait_for_upload()", "[sync]") {
         auto user = SyncManager::shared().get_user("user-async-wait-upload-2", "not_a_real_token");
         std::atomic<bool> login_handler_called(false);
         auto server_path = "/async-wait-upload-2";
-        std::shared_ptr<SyncSession> session = full_control_sync_session(server, user, server_path,
-                                                                         [&](auto, auto, std::shared_ptr<SyncSession> s){
-                                                                             session = std::move(s);
-                                                                             login_handler_called = true;
-                                                                         },
-                                                                         [](auto, auto) { });
+        std::shared_ptr<SyncSession> session = sync_session_with_bind_handler(server, user, server_path,
+                                                                              [&](auto, auto, std::shared_ptr<SyncSession> s){
+                                                                                  session = std::move(s);
+                                                                                  login_handler_called = true;
+                                                                              },
+                                                                              [](auto, auto) { });
         // Register the upload-completion notification
         REQUIRE(session->wait_for_upload_completion([&](auto) {
             handler_called = true;
@@ -223,12 +223,12 @@ TEST_CASE("SyncSession: async_wait_for_upload()", "[sync]") {
         std::atomic<bool> login_handler_called(false);
         std::atomic<int> error_count(0);
         auto server_path = "/async-wait-upload-4";
-        std::shared_ptr<SyncSession> session = full_control_sync_session(server, user, server_path,
-                                                                         [&](auto, auto, std::shared_ptr<SyncSession> s){
-                                                                             session = std::move(s);
-                                                                             login_handler_called = true;
-                                                                         },
-                                                                         [&](auto, auto) { ++error_count; });
+        std::shared_ptr<SyncSession> session = sync_session_with_bind_handler(server, user, server_path,
+                                                                              [&](auto, auto, std::shared_ptr<SyncSession> s){
+                                                                                  session = std::move(s);
+                                                                                  login_handler_called = true;
+                                                                              },
+                                                                              [&](auto, auto) { ++error_count; });
         // Register the upload-completion notification
         REQUIRE(session->wait_for_upload_completion([&](std::error_code error) {
             REQUIRE(error == util::error::operation_aborted);


### PR DESCRIPTION
Changes:
- Completion handlers registered before binding are now queued instead of being silently dropped

To do:
- [x] Tests