### PR TITLE
Fix issue where non-streaming notifiers were called with stale data

### DIFF
--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -552,11 +552,15 @@ void SyncSession::NotifierPackage::update(const Progress& current_progress, bool
                                                                  : current_progress.uploadable;
 }
 
+// PRECONDITION: `update()` must first be called on the same package.
 std::function<void()> SyncSession::NotifierPackage::create_invocation(const Progress& current_progress,
                                                                       bool& is_expired) const
 {
     // It's possible for a non-streaming notifier to not yet have fresh transferrable bytes data.
     // In that case, we don't call it at all.
+    // NOTE: `update()` is always called before `create_invocation()`, and will
+    // set `captured_transferrable` on the notifier package if fresh data has
+    // been received and the package is for a non-streaming notifier.
     if (!is_streaming && !captured_transferrable)
         return [](){ };
 

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -519,16 +519,17 @@ void SyncSession::handle_error(SyncError error)
 }
 
 void SyncSession::handle_progress_update(uint64_t downloaded, uint64_t downloadable,
-                                         uint64_t uploaded, uint64_t uploadable)
+                                         uint64_t uploaded, uint64_t uploadable, bool is_fresh)
 {
     std::vector<std::function<void()>> invocations;
     {
         std::lock_guard<std::mutex> lock(m_progress_notifier_mutex);
         m_current_progress = Progress{uploadable, downloadable, uploaded, downloaded};
+        m_latest_progress_data_is_fresh = is_fresh;
 
         for (auto it = m_notifiers.begin(); it != m_notifiers.end();) {
             auto& package = it->second;
-            package.update(*m_current_progress);
+            package.update(*m_current_progress, is_fresh);
 
             bool should_delete = false;
             invocations.emplace_back(package.create_invocation(*m_current_progress, should_delete));
@@ -542,18 +543,22 @@ void SyncSession::handle_progress_update(uint64_t downloaded, uint64_t downloada
     }
 }
 
-void SyncSession::NotifierPackage::update(const Progress& current_progress)
+void SyncSession::NotifierPackage::update(const Progress& current_progress, bool data_is_fresh)
 {
-    if (is_streaming || captured_transferrable)
+    if (is_streaming || captured_transferrable || !data_is_fresh)
         return;
 
     captured_transferrable = direction == NotifierType::download ? current_progress.downloadable
                                                                  : current_progress.uploadable;
 }
 
-std::function<void()> SyncSession::NotifierPackage::create_invocation(const Progress& current_progress, bool& is_expired) const
+std::function<void()> SyncSession::NotifierPackage::create_invocation(const Progress& current_progress,
+                                                                      bool& is_expired) const
 {
-    REALM_ASSERT(is_streaming || captured_transferrable);
+    // It's possible for a non-streaming notifier to not yet have fresh transferrable bytes data.
+    // In that case, we don't call it at all.
+    if (!is_streaming && !captured_transferrable)
+        return [](){ };
 
     bool is_download = direction == NotifierType::download;
     uint64_t transferred = is_download ? current_progress.downloaded : current_progress.uploaded;
@@ -606,9 +611,10 @@ void SyncSession::create_sync_session()
 
     // Set up the wrapped progress handler callback
     auto wrapped_progress_handler = [this, weak_self](uint_fast64_t downloaded, uint_fast64_t downloadable,
-                                                      uint_fast64_t uploaded, uint_fast64_t uploadable, uint_fast64_t) {
+                                                      uint_fast64_t uploaded, uint_fast64_t uploadable,
+                                                      bool is_fresh) {
         if (auto self = weak_self.lock()) {
-            handle_progress_update(downloaded, downloadable, uploaded, uploadable);
+            handle_progress_update(downloaded, downloadable, uploaded, uploadable, is_fresh);
         }
     };
     m_session->set_progress_handler(std::move(wrapped_progress_handler));
@@ -697,7 +703,7 @@ uint64_t SyncSession::register_progress_notifier(std::function<SyncProgressNotif
             m_notifiers.emplace(token_value, std::move(package));
             return token_value;
         }
-        package.update(*m_current_progress);
+        package.update(*m_current_progress, m_latest_progress_data_is_fresh);
         bool skip_registration = false;
         invocation = package.create_invocation(*m_current_progress, skip_registration);
         if (skip_registration) {

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -188,7 +188,7 @@ public:
 
         static void handle_progress_update(SyncSession& session, uint64_t downloaded, uint64_t downloadable,
                                            uint64_t uploaded, uint64_t uploadable) {
-            session.handle_progress_update(downloaded, downloadable, uploaded, uploadable);
+            session.handle_progress_update(downloaded, downloadable, uploaded, uploadable, true);
         }
     };
 
@@ -209,7 +209,7 @@ private:
 
     void handle_error(SyncError);
     static std::string get_recovery_file_path();
-    void handle_progress_update(uint64_t, uint64_t, uint64_t, uint64_t);
+    void handle_progress_update(uint64_t, uint64_t, uint64_t, uint64_t, bool);
 
     void set_sync_transact_callback(std::function<SyncSessionTransactCallback>);
     void set_error_handler(std::function<SyncSessionErrorHandler>);
@@ -240,12 +240,13 @@ private:
         NotifierType direction;
         util::Optional<uint64_t> captured_transferrable;
 
-        void update(const Progress&);
-        std::function<void()> create_invocation(const Progress&, bool& is_expired) const;
+        void update(const Progress&, bool);
+        std::function<void()> create_invocation(const Progress&, bool&) const;
     };
 
     // A counter used as a token to identify progress notifier callbacks registered on this session.
     uint64_t m_progress_notifier_token = 1;
+    bool m_latest_progress_data_is_fresh;
 
     // Will be `none` until we've received the initial notification from sync.  Note that this
     // happens only once ever during the lifetime of a given `SyncSession`, since these values are

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -190,6 +190,16 @@ public:
                                            uint64_t uploaded, uint64_t uploadable, bool is_fresh=true) {
             session.handle_progress_update(downloaded, downloadable, uploaded, uploadable, is_fresh);
         }
+
+        static bool has_stale_progress(SyncSession& session)
+        {
+            return session.m_current_progress != none && !session.m_latest_progress_data_is_fresh;
+        }
+
+        static bool has_fresh_progress(SyncSession& session)
+        {
+            return session.m_latest_progress_data_is_fresh;
+        }
     };
 
 private:

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -187,8 +187,8 @@ public:
         }
 
         static void handle_progress_update(SyncSession& session, uint64_t downloaded, uint64_t downloadable,
-                                           uint64_t uploaded, uint64_t uploadable) {
-            session.handle_progress_update(downloaded, downloadable, uploaded, uploadable, true);
+                                           uint64_t uploaded, uint64_t uploadable, bool is_fresh=true) {
+            session.handle_progress_update(downloaded, downloadable, uploaded, uploadable, is_fresh);
         }
     };
 

--- a/tests/sync/session/session.cpp
+++ b/tests/sync/session/session.cpp
@@ -101,8 +101,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
                                      [](auto&, auto&) { return s_test_token; },
                                      [](auto, auto) { });
         // Run the runloop many iterations to see if the sessions spuriously bind.
-        std::atomic<int> run_count(0);
-        EventLoop::main().run_until([&] { run_count++; return run_count >= 100; });
+        spin_runloop();
         REQUIRE(sessions_are_inactive(*session1));
         REQUIRE(sessions_are_inactive(*session2));
         REQUIRE(user->all_sessions().size() == 0);
@@ -128,8 +127,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
         user->log_out();
         REQUIRE(user->state() == SyncUser::State::LoggedOut);
         // Run the runloop many iterations to see if the sessions spuriously rebind.
-        std::atomic<int> run_count(0);
-        EventLoop::main().run_until([&] { run_count++; return run_count >= 100; });
+        spin_runloop();
         REQUIRE(sessions_are_inactive(*session1));
         REQUIRE(sessions_are_inactive(*session2));
         REQUIRE(user->all_sessions().size() == 0);

--- a/tests/sync/session/session_util.hpp
+++ b/tests/sync/session/session_util.hpp
@@ -18,6 +18,7 @@
 
 #include "sync/sync_test_utils.hpp"
 
+#include "util/event_loop.hpp"
 #include "util/test_file.hpp"
 
 #include "sync/sync_config.hpp"
@@ -48,6 +49,11 @@ template <typename... S>
 bool sessions_are_inactive(const SyncSession& session, const S&... s)
 {
     return sessions_are_inactive(session) && sessions_are_inactive(s...);
+}
+
+inline void spin_runloop(int count=2)
+{
+    EventLoop::main().run_until([count, spin_count=0]() mutable { spin_count++; return spin_count > count; });
 }
 
 // Identical to `sync_session(...)`, but takes a bind-session callback that is

--- a/tests/sync/session/wait_for_completion.cpp
+++ b/tests/sync/session/wait_for_completion.cpp
@@ -68,9 +68,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
         EventLoop::main().run_until([&] { return login_handler_called == true; });
         REQUIRE(session);
         REQUIRE(handler_called == false);
-        // Spin the loop a few times.
-        std::atomic<int> spin_count(0);
-        EventLoop::main().run_until([&] { spin_count++; return spin_count > 2; });
+        spin_runloop();
         REQUIRE(handler_called == false);
         // Now bind the session
         session->refresh_access_token(s_test_token, server.base_url() + server_path);
@@ -92,9 +90,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
         REQUIRE(session->wait_for_download_completion([&](auto) {
             handler_called = true;
         }));
-        // Spin the loop a few times.
-        std::atomic<int> spin_count(0);
-        EventLoop::main().run_until([&] { spin_count++; return spin_count > 2; });
+        spin_runloop();
         REQUIRE(handler_called == false);
         // Log the user back in
         user = SyncManager::shared().get_user(user_id, "not_a_real_token_either");
@@ -182,9 +178,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
         EventLoop::main().run_until([&] { return login_handler_called == true; });
         REQUIRE(session);
         REQUIRE(handler_called == false);
-        // Spin the loop a few times.
-        std::atomic<int> spin_count(0);
-        EventLoop::main().run_until([&] { spin_count++; return spin_count > 2; });
+        spin_runloop();
         REQUIRE(handler_called == false);
         // Now bind the session
         session->refresh_access_token(s_test_token, server.base_url() + server_path);
@@ -206,9 +200,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
         REQUIRE(session->wait_for_upload_completion([&](auto) {
             handler_called = true;
         }));
-        // Spin the loop a few times.
-        std::atomic<int> spin_count(0);
-        EventLoop::main().run_until([&] { spin_count++; return spin_count > 2; });
+        spin_runloop();
         REQUIRE(handler_called == false);
         // Log the user back in
         user = SyncManager::shared().get_user(user_id, "not_a_real_token_either");

--- a/tests/util/event_loop.hpp
+++ b/tests/util/event_loop.hpp
@@ -16,8 +16,8 @@
  *
  **************************************************************************/
 
-#ifndef REALM_EVENT_LOOP_HPP
-#define REALM_EVENT_LOOP_HPP
+#ifndef REALM_OS_TESTS_UTIL_EVENT_LOOP_HPP
+#define REALM_OS_TESTS_UTIL_EVENT_LOOP_HPP
 
 #include <functional>
 #include <memory>
@@ -53,4 +53,4 @@ private:
 } // namespace util
 } // namespace realm
 
-#endif  // REALM_EVENT_LOOP_HPP
+#endif  // REALM_OS_TESTS_UTIL_EVENT_LOOP_HPP

--- a/tests/util/event_loop.hpp
+++ b/tests/util/event_loop.hpp
@@ -16,6 +16,9 @@
  *
  **************************************************************************/
 
+#ifndef REALM_EVENT_LOOP_HPP
+#define REALM_EVENT_LOOP_HPP
+
 #include <functional>
 #include <memory>
 
@@ -49,3 +52,5 @@ private:
 
 } // namespace util
 } // namespace realm
+
+#endif  // REALM_EVENT_LOOP_HPP


### PR DESCRIPTION
Fixes https://github.com/realm/realm-object-store/issues/382

To do:
- [x] Tests. Would like to wait until #385 is merged, since that PR cleans up and refactors the sync tests