### PR TITLE
Rework the ownership of SyncSession so that it's always managed by a shared_ptr

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,7 +56,7 @@ def doDockerBuild(String flavor, Boolean withCoverage, Boolean enableSync) {
       sshagent(['realm-ci-ssh']) {
         image.inside("-v /etc/passwd:/etc/passwd:ro -v ${env.HOME}:${env.HOME} -v ${env.SSH_AUTH_SOCK}:${env.SSH_AUTH_SOCK} -e HOME=${env.HOME}") {
           if(withCoverage) {
-            sh "./workflow/test_coverage.sh ${sync} && mv coverage.build ${label}.build"
+            sh "rm -rf coverage.build ${label}.build && ./workflow/test_coverage.sh ${sync} && mv coverage.build ${label}.build"
           } else {
             sh "./workflow/build.sh ${flavor} ${sync}"
           }

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -207,18 +207,18 @@ void SyncManager::reset_for_testing()
 #if REALM_ASSERTIONS_ENABLED
             // Callers of `SyncManager::reset_for_testing` should ensure there are no active sessions
             // prior to calling `reset_for_testing`.
-            auto no_active_sessions = std::all_of(m_active_sessions.begin(), m_active_sessions.end(), [](auto& element){
-                return element.second.expired();
+            auto no_active_sessions = std::none_of(m_sessions.begin(), m_sessions.end(), [](auto& element){
+                return element.second->existing_external_reference();
             });
             REALM_ASSERT(no_active_sessions);
 #endif
 
-            // Destroy any remaining inactive sessions.
+            // Destroy any inactive sessions.
             // FIXME: We shouldn't have any inactive sessions at this point! Sessions are expected to
             // remain inactive until their final upload completes, at which point they are unregistered
             // and destroyed. Our call to `sync::Client::stop` above aborts all uploads, so all sessions
             // should have already been destroyed.
-            m_inactive_sessions.clear();
+            m_sessions.clear();
         }
 
         // Destroy the client now that we have no remaining sessions.
@@ -370,86 +370,58 @@ std::string SyncManager::recovery_directory_path() const
 std::shared_ptr<SyncSession> SyncManager::get_existing_active_session(const std::string& path) const
 {
     std::lock_guard<std::mutex> lock(m_session_mutex);
-    return get_existing_active_session_locked(path);
-}
-
-std::shared_ptr<SyncSession> SyncManager::get_existing_active_session_locked(const std::string& path) const
-{
-    REALM_ASSERT(!m_session_mutex.try_lock());
-    auto it = m_active_sessions.find(path);
-    if (it == m_active_sessions.end()) {
-        return nullptr;
-    }
-    if (auto session = it->second.lock()) {
-        return session;
+    if (auto session = get_existing_session_locked(path)) {
+        if (auto external_reference = session->existing_external_reference())
+            return external_reference;
     }
     return nullptr;
 }
 
-std::unique_ptr<SyncSession> SyncManager::get_existing_inactive_session_locked(const std::string& path)
+std::shared_ptr<SyncSession> SyncManager::get_existing_session_locked(const std::string& path) const
 {
     REALM_ASSERT(!m_session_mutex.try_lock());
-    auto it = m_inactive_sessions.find(path);
-    if (it == m_inactive_sessions.end()) {
+    auto it = m_sessions.find(path);
+    if (it == m_sessions.end()) {
         return nullptr;
     }
-    auto ret = std::move(it->second);
-    m_inactive_sessions.erase(it);
-    return ret;
+    return it->second;
 }
 
 std::shared_ptr<SyncSession> SyncManager::get_session(const std::string& path, const SyncConfig& sync_config)
 {
     auto& client = get_sync_client(); // Throws
 
-    // The session is declared outside the scope of the lock so that if an exception is thrown
-    // it'll be destroyed after the lock has been dropped. This avoids deadlocking when
-    // dropped_last_reference_to_session attempts to lock the mutex.
-    std::shared_ptr<SyncSession> shared_session;
-
     std::lock_guard<std::mutex> lock(m_session_mutex);
-    if (auto session = get_existing_active_session_locked(path)) {
-        return session;
+    if (auto session = get_existing_session_locked(path)) {
+        sync_config.user->register_session(session);
+        return session->external_reference();
     }
 
-    std::unique_ptr<SyncSession> session = get_existing_inactive_session_locked(path);
-    bool session_is_new = false;
-    if (!session) {
-        session_is_new = true;
-        session.reset(new SyncSession(client, path, sync_config));
-    }
+    std::shared_ptr<SyncSession> shared_session(new SyncSession(client, path, sync_config));
+    m_sessions[path] = shared_session;
 
-    auto session_deleter = [this](SyncSession *session) { dropped_last_reference_to_session(session); };
-    shared_session = std::shared_ptr<SyncSession>(session.release(), std::move(session_deleter));
-    m_active_sessions[path] = shared_session;
-    if (session_is_new) {
-        sync_config.user->register_session(shared_session);
-    } else {
-        SyncSession::revive_if_needed(shared_session);
-    }
-    return shared_session;
-}
+    // Create the external reference immediately to ensure that the session will become
+    // inactive if an exception is thrown in the following code.
+    auto external_reference = shared_session->external_reference();
 
-void SyncManager::dropped_last_reference_to_session(SyncSession* session)
-{
-    {
-        std::lock_guard<std::mutex> lock(m_session_mutex);
-        auto path = session->path();
-        REALM_ASSERT_DEBUG(m_active_sessions.count(path));
-        m_active_sessions.erase(path);
-        m_inactive_sessions[path].reset(session);
-    }
-    session->close();
+    sync_config.user->register_session(shared_session);
+
+    return external_reference;
 }
 
 void SyncManager::unregister_session(const std::string& path)
 {
     std::lock_guard<std::mutex> lock(m_session_mutex);
-    if (m_active_sessions.count(path))
+    auto it = m_sessions.find(path);
+    REALM_ASSERT(it != m_sessions.end());
+
+    // If the session has an active external reference, leave it be. This will happen if the session
+    // moves to an inactive state while still externally reference, for instance, as a result of
+    // the session's user being logged out.
+    if (it->second->existing_external_reference())
         return;
-    auto it = m_inactive_sessions.find(path);
-    REALM_ASSERT(it != m_inactive_sessions.end());
-    m_inactive_sessions.erase(path);
+
+    m_sessions.erase(path);
 }
 
 SyncClient& SyncManager::get_sync_client() const

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -154,20 +154,17 @@ private:
 
     mutable std::unique_ptr<_impl::SyncClient> m_sync_client;
 
-    // Protects m_sessions
-    mutable std::mutex m_session_mutex;
-
     // Protects m_file_manager and m_metadata_manager
     mutable std::mutex m_file_system_mutex;
     std::unique_ptr<SyncFileManager> m_file_manager;
     std::unique_ptr<SyncMetadataManager> m_metadata_manager;
 
-    // Active sessions are sessions which the client code holds a strong
-    // reference to. When the last strong reference is released, the session is
-    // moved to inactive sessions. Inactive sessions are promoted back to active
-    // sessions until the session itself calls unregister_session to remove
-    // itself from inactive sessions once it's done with whatever async cleanup
-    // it needs to do.
+    // Protects m_sessions
+    mutable std::mutex m_session_mutex;
+
+    // Map of sessions by path name.
+    // Sessions remove themselves from this map by calling `unregister_session` once they're
+    // inactive and have performed any necessary cleanup work.
     std::unordered_map<std::string, std::shared_ptr<SyncSession>> m_sessions;
 };
 

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -121,7 +121,6 @@ public:
 
 private:
     using ReconnectMode = sync::Client::ReconnectMode;
-    void dropped_last_reference_to_session(SyncSession*);
 
     // Stop tracking the session for the given path if it is inactive.
     // No-op if the session is either still active or in the active sessions list
@@ -135,8 +134,7 @@ private:
     _impl::SyncClient& get_sync_client() const;
     std::unique_ptr<_impl::SyncClient> create_sync_client() const;
 
-    std::shared_ptr<SyncSession> get_existing_active_session_locked(const std::string& path) const;
-    std::unique_ptr<SyncSession> get_existing_inactive_session_locked(const std::string& path);
+    std::shared_ptr<SyncSession> get_existing_session_locked(const std::string& path) const;
 
     mutable std::mutex m_mutex;
 
@@ -156,7 +154,7 @@ private:
 
     mutable std::unique_ptr<_impl::SyncClient> m_sync_client;
 
-    // Protects m_active_sessions and m_inactive_sessions
+    // Protects m_sessions
     mutable std::mutex m_session_mutex;
 
     // Protects m_file_manager and m_metadata_manager
@@ -170,8 +168,7 @@ private:
     // sessions until the session itself calls unregister_session to remove
     // itself from inactive sessions once it's done with whatever async cleanup
     // it needs to do.
-    std::unordered_map<std::string, std::weak_ptr<SyncSession>> m_active_sessions;
-    std::unordered_map<std::string, std::unique_ptr<SyncSession>> m_inactive_sessions;
+    std::unordered_map<std::string, std::shared_ptr<SyncSession>> m_sessions;
 };
 
 } // namespace realm

--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -118,7 +118,7 @@ void SyncUser::update_refresh_token(std::string token)
     // Note that we do this after releasing the lock, since the session may
     // need to access protected User state in the process of binding itself.
     for (auto& session : sessions_to_revive) {
-        SyncSession::revive_if_needed(session);
+        session->revive_if_needed();
     }
 }
 
@@ -181,7 +181,7 @@ void SyncUser::register_session(std::shared_ptr<SyncSession> session)
                 session->bind_with_admin_token(m_refresh_token, session->config().realm_url);
             } else {
                 lock.unlock();
-                SyncSession::revive_if_needed(std::move(session));
+                session->revive_if_needed();
             }
             break;
         case State::LoggedOut:


### PR DESCRIPTION
Ownership of a `SyncSession` was previously managed by a `shared_ptr` for as long as there were external references to it. When all external references were dropped and the `SyncSession` became inactive, it was transferred to a `unique_ptr` held by the `SyncManager`. This transfer proved problematic as it meant that the `weak_ptr`s that `SyncSession` used internally to refer to itself from callbacks expired, making it impossible to correctly handle the callbacks.

The new approach is for `SyncSession` to always be managed by a `shared_ptr`. To detect when external references to the `SyncSession` have gone away, we tie the lifetime of the external references to a separate object (by way of `shared_ptr`'s aliasing constructor) and use the destruction of this object to signal that the `SyncSession` has become inactive. Since the `SyncSession` is always managed by a `shared_ptr` any `weak_ptr`s continue to work as expected for the complete duration of the session's lifecycle.

This has the secondary benefit of removing the need to track active and inactive sessions separately in `SyncManager`.

Fixes #379.