### PR TITLE
Add aggregate functions to List

### DIFF
--- a/src/list.cpp
+++ b/src/list.cpp
@@ -201,6 +201,26 @@ Results List::snapshot() const
     return Results(m_realm, m_link_view).snapshot();
 }
 
+util::Optional<Mixed> List::max(size_t column)
+{
+    return Results(m_realm, m_link_view).max(column);
+}
+
+util::Optional<Mixed> List::min(size_t column)
+{
+    return Results(m_realm, m_link_view).min(column);
+}
+
+util::Optional<Mixed> List::sum(size_t column)
+{
+    return Results(m_realm, m_link_view).sum(column);
+}
+
+util::Optional<Mixed> List::average(size_t column)
+{
+    return Results(m_realm, m_link_view).average(column);
+}
+
 // These definitions rely on that LinkViews are interned by core
 bool List::operator==(List const& rgt) const noexcept
 {

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -79,6 +79,16 @@ public:
     // Return a Results representing a snapshot of this List.
     Results snapshot() const;
 
+    // Get the min/max/average/sum of the given column
+    // All but sum() returns none when there are zero matching rows
+    // sum() returns 0, except for when it returns none
+    // Throws UnsupportedColumnTypeException for sum/average on timestamp or non-numeric column
+    // Throws OutOfBoundsIndexException for an out-of-bounds column
+    util::Optional<Mixed> max(size_t column);
+    util::Optional<Mixed> min(size_t column);
+    util::Optional<Mixed> average(size_t column);
+    util::Optional<Mixed> sum(size_t column);
+
     bool operator==(List const& rgt) const noexcept;
 
     NotificationToken add_notification_callback(CollectionChangeCallback cb) &;


### PR DESCRIPTION
Currently just a thin wrapper around calling the Results version on the linkview as that was the simplest thing to implement.