### PR TITLE
fix for core 2.3.2 change

### DIFF
--- a/src/object_accessor.hpp
+++ b/src/object_accessor.hpp
@@ -193,9 +193,11 @@ void Object::set_property_value_impl(ContextType ctx, const Property &property, 
                 m_row.set_string(column, string_value);
             break;
         }
-        case PropertyType::Data:
-            m_row.set_binary(column, BinaryData(Accessor::to_binary(ctx, value)));
+        case PropertyType::Data: {
+            auto str = Accessor::to_binary(ctx, value);
+            m_row.set_binary(column, BinaryData(str));
             break;
+        }
         case PropertyType::Any:
             m_row.set_mixed(column, Accessor::to_mixed(ctx, value));
             break;


### PR DESCRIPTION
Since object-accessor is not yet tested in object-store this slipped through the cracks.

Needed because of this change: https://github.com/realm/realm-core/commit/4322f25731a9eb44ae133b0a7a57bb547f83d377

@bdash 