### PR TITLE
Add basic object accessor tests and fix a few bugs

### DIFF
--- a/src/collection_notifications.hpp
+++ b/src/collection_notifications.hpp
@@ -56,7 +56,7 @@ struct CollectionChangeSet {
         size_t from;
         size_t to;
 
-        bool operator==(Move m) const { return from == m.from && to == m.to; }
+        bool operator==(Move m) const noexcept { return from == m.from && to == m.to; }
     };
 
     // Indices which were removed from the _old_ collection
@@ -88,7 +88,7 @@ struct CollectionChangeSet {
     // Per-column version of `modifications`
     std::vector<IndexSet> columns;
 
-    bool empty() const
+    bool empty() const noexcept
     {
         return deletions.empty() && insertions.empty() && modifications.empty()
             && modifications_new.empty() && moves.empty();

--- a/src/index_set.cpp
+++ b/src/index_set.cpp
@@ -141,7 +141,7 @@ ChunkedRangeVector::iterator ChunkedRangeVector::ensure_space(iterator pos)
     return pos;
 }
 
-ChunkedRangeVector::iterator ChunkedRangeVector::erase(iterator pos)
+ChunkedRangeVector::iterator ChunkedRangeVector::erase(iterator pos) noexcept
 {
     auto offset = pos.offset();
     auto& chunk = *pos.m_outer;
@@ -270,13 +270,13 @@ IndexSet::IndexSet(std::initializer_list<size_t> values)
         add(v);
 }
 
-bool IndexSet::contains(size_t index) const
+bool IndexSet::contains(size_t index) const noexcept
 {
     auto it = const_cast<IndexSet*>(this)->find(index);
     return it != end() && it->first <= index;
 }
 
-size_t IndexSet::count(size_t start_index, size_t end_index) const
+size_t IndexSet::count(size_t start_index, size_t end_index) const noexcept
 {
     auto it = const_cast<IndexSet*>(this)->find(start_index);
     const auto end = this->end();
@@ -320,12 +320,12 @@ size_t IndexSet::count(size_t start_index, size_t end_index) const
     return ret;
 }
 
-IndexSet::iterator IndexSet::find(size_t index)
+IndexSet::iterator IndexSet::find(size_t index) noexcept
 {
     return find(index, begin());
 }
 
-IndexSet::iterator IndexSet::find(size_t index, iterator begin)
+IndexSet::iterator IndexSet::find(size_t index, iterator begin) noexcept
 {
     auto it = std::find_if(begin.outer(), m_data.end(),
                            [&](auto const& lft) { return lft.end > index; });
@@ -653,7 +653,7 @@ void IndexSet::remove(realm::IndexSet const& values)
     }
 }
 
-size_t IndexSet::shift(size_t index) const
+size_t IndexSet::shift(size_t index) const noexcept
 {
     // FIXME: optimize
     for (auto range : *this) {
@@ -664,13 +664,13 @@ size_t IndexSet::shift(size_t index) const
     return index;
 }
 
-size_t IndexSet::unshift(size_t index) const
+size_t IndexSet::unshift(size_t index) const noexcept
 {
     REALM_ASSERT_DEBUG(!contains(index));
     return index - count(0, index);
 }
 
-void IndexSet::clear()
+void IndexSet::clear() noexcept
 {
     m_data.clear();
 }

--- a/src/index_set.hpp
+++ b/src/index_set.hpp
@@ -44,23 +44,23 @@ public:
     ChunkedRangeVectorIterator(OuterIterator outer, OuterIterator end, value_type* inner)
     : m_outer(outer), m_end(end), m_inner(inner) { }
 
-    reference operator*() const { return *m_inner; }
-    pointer operator->() const { return m_inner; }
+    reference operator*() const noexcept { return *m_inner; }
+    pointer operator->() const noexcept { return m_inner; }
 
-    template<typename Other> bool operator==(Other const& it) const;
-    template<typename Other> bool operator!=(Other const& it) const;
+    template<typename Other> bool operator==(Other const& it) const noexcept;
+    template<typename Other> bool operator!=(Other const& it) const noexcept;
 
-    ChunkedRangeVectorIterator& operator++();
-    ChunkedRangeVectorIterator operator++(int);
+    ChunkedRangeVectorIterator& operator++() noexcept;
+    ChunkedRangeVectorIterator operator++(int) noexcept;
 
-    ChunkedRangeVectorIterator& operator--();
-    ChunkedRangeVectorIterator operator--(int);
+    ChunkedRangeVectorIterator& operator--() noexcept;
+    ChunkedRangeVectorIterator operator--(int) noexcept;
 
     // Advance directly to the next outer block
-    void next_chunk();
+    void next_chunk() noexcept;
 
-    OuterIterator outer() const { return m_outer; }
-    size_t offset() const { return m_inner - &m_outer->data[0]; }
+    OuterIterator outer() const noexcept { return m_outer; }
+    size_t offset() const noexcept { return m_inner - &m_outer->data[0]; }
 
 private:
     OuterIterator m_outer;
@@ -105,17 +105,17 @@ struct ChunkedRangeVector {
     static const size_t max_size = 4096 / sizeof(std::pair<size_t, size_t>);
 #endif
 
-    iterator begin() { return empty() ? end() : iterator(m_data.begin(), m_data.end(), &m_data[0].data[0]); }
-    iterator end() { return iterator(m_data.end(), m_data.end(), nullptr); }
-    const_iterator begin() const { return cbegin(); }
-    const_iterator end() const { return cend(); }
-    const_iterator cbegin() const { return empty() ? cend() : const_iterator(m_data.cbegin(), m_data.end(), &m_data[0].data[0]); }
-    const_iterator cend() const { return const_iterator(m_data.end(), m_data.end(), nullptr); }
+    iterator begin() noexcept { return empty() ? end() : iterator(m_data.begin(), m_data.end(), &m_data[0].data[0]); }
+    iterator end() noexcept { return iterator(m_data.end(), m_data.end(), nullptr); }
+    const_iterator begin() const noexcept { return cbegin(); }
+    const_iterator end() const noexcept { return cend(); }
+    const_iterator cbegin() const noexcept { return empty() ? cend() : const_iterator(m_data.cbegin(), m_data.end(), &m_data[0].data[0]); }
+    const_iterator cend() const noexcept { return const_iterator(m_data.end(), m_data.end(), nullptr); }
 
     bool empty() const noexcept { return m_data.empty(); }
 
     iterator insert(iterator pos, value_type value);
-    iterator erase(iterator pos);
+    iterator erase(iterator pos) noexcept;
     void push_back(value_type value);
     iterator ensure_space(iterator pos);
 
@@ -139,10 +139,10 @@ public:
     IndexSet(std::initializer_list<size_t>);
 
     // Check if the index set contains the given index
-    bool contains(size_t index) const;
+    bool contains(size_t index) const noexcept;
 
     // Counts the number of indices in the set in the given range
-    size_t count(size_t start_index=0, size_t end_index=-1) const;
+    size_t count(size_t start_index=0, size_t end_index=-1) const noexcept;
 
     // Add an index to the set, doing nothing if it's already present
     void add(size_t index);
@@ -181,22 +181,22 @@ public:
     void remove(IndexSet const&);
 
     // Shift an index by inserting each of the indexes in this set
-    size_t shift(size_t index) const;
+    size_t shift(size_t index) const noexcept;
     // Shift an index by deleting each of the indexes in this set
-    size_t unshift(size_t index) const;
+    size_t unshift(size_t index) const noexcept;
 
     // Remove all indexes from the set
-    void clear();
+    void clear() noexcept;
 
     // An iterator over the individual indices in the set rather than the ranges
     class IndexIterator : public std::iterator<std::forward_iterator_tag, size_t> {
     public:
         IndexIterator(IndexSet::const_iterator it) : m_iterator(it) { }
-        size_t operator*() const { return m_iterator->first + m_offset; }
-        bool operator==(IndexIterator const& it) const { return m_iterator == it.m_iterator; }
-        bool operator!=(IndexIterator const& it) const { return m_iterator != it.m_iterator; }
+        size_t operator*() const noexcept { return m_iterator->first + m_offset; }
+        bool operator==(IndexIterator const& it) const noexcept { return m_iterator == it.m_iterator; }
+        bool operator!=(IndexIterator const& it) const noexcept { return m_iterator != it.m_iterator; }
 
-        IndexIterator& operator++()
+        IndexIterator& operator++() noexcept
         {
             ++m_offset;
             if (m_iterator->first + m_offset == m_iterator->second) {
@@ -206,7 +206,7 @@ public:
             return *this;
         }
 
-        IndexIterator operator++(int)
+        IndexIterator operator++(int) noexcept
         {
             auto value = *this;
             ++*this;
@@ -224,21 +224,21 @@ public:
         using iterator = IndexIterator;
         using const_iterator = iterator;
 
-        const_iterator begin() const { return m_index_set.begin(); }
-        const_iterator end() const { return m_index_set.end(); }
+        const_iterator begin() const noexcept { return m_index_set.begin(); }
+        const_iterator end() const noexcept { return m_index_set.end(); }
 
         IndexIteratableAdaptor(IndexSet const& is) : m_index_set(is) { }
     private:
         IndexSet const& m_index_set;
     };
 
-    IndexIteratableAdaptor as_indexes() const { return *this; }
+    IndexIteratableAdaptor as_indexes() const noexcept { return *this; }
 
 private:
     // Find the range which contains the index, or the first one after it if
     // none do
-    iterator find(size_t index);
-    iterator find(size_t index, iterator it);
+    iterator find(size_t index) noexcept;
+    iterator find(size_t index, iterator it) noexcept;
     // Insert the index before the given position, combining existing ranges as
     // applicable
     // returns inserted position
@@ -252,7 +252,7 @@ private:
 namespace util {
 // This was added in C++14 but is missing from libstdc++ 4.9
 template<typename Iterator>
-std::reverse_iterator<Iterator> make_reverse_iterator(Iterator it)
+std::reverse_iterator<Iterator> make_reverse_iterator(Iterator it) noexcept
 {
     return std::reverse_iterator<Iterator>(it);
 }
@@ -262,20 +262,20 @@ std::reverse_iterator<Iterator> make_reverse_iterator(Iterator it)
 namespace _impl {
 template<typename T>
 template<typename OtherIterator>
-inline bool ChunkedRangeVectorIterator<T>::operator==(OtherIterator const& it) const
+inline bool ChunkedRangeVectorIterator<T>::operator==(OtherIterator const& it) const noexcept
 {
     return m_outer == it.outer() && m_inner == it.operator->();
 }
 
 template<typename T>
 template<typename OtherIterator>
-inline bool ChunkedRangeVectorIterator<T>::operator!=(OtherIterator const& it) const
+inline bool ChunkedRangeVectorIterator<T>::operator!=(OtherIterator const& it) const noexcept
 {
     return !(*this == it);
 }
 
 template<typename T>
-inline ChunkedRangeVectorIterator<T>& ChunkedRangeVectorIterator<T>::operator++()
+inline ChunkedRangeVectorIterator<T>& ChunkedRangeVectorIterator<T>::operator++() noexcept
 {
     ++m_inner;
     if (offset() == m_outer->data.size())
@@ -284,7 +284,7 @@ inline ChunkedRangeVectorIterator<T>& ChunkedRangeVectorIterator<T>::operator++(
 }
 
 template<typename T>
-inline ChunkedRangeVectorIterator<T> ChunkedRangeVectorIterator<T>::operator++(int)
+inline ChunkedRangeVectorIterator<T> ChunkedRangeVectorIterator<T>::operator++(int) noexcept
 {
     auto value = *this;
     ++*this;
@@ -292,7 +292,7 @@ inline ChunkedRangeVectorIterator<T> ChunkedRangeVectorIterator<T>::operator++(i
 }
 
 template<typename T>
-inline ChunkedRangeVectorIterator<T>& ChunkedRangeVectorIterator<T>::operator--()
+inline ChunkedRangeVectorIterator<T>& ChunkedRangeVectorIterator<T>::operator--() noexcept
 {
     if (!m_inner || m_inner == &m_outer->data.front()) {
         --m_outer;
@@ -305,7 +305,7 @@ inline ChunkedRangeVectorIterator<T>& ChunkedRangeVectorIterator<T>::operator--(
 }
 
 template<typename T>
-inline ChunkedRangeVectorIterator<T> ChunkedRangeVectorIterator<T>::operator--(int)
+inline ChunkedRangeVectorIterator<T> ChunkedRangeVectorIterator<T>::operator--(int) noexcept
 {
     auto value = *this;
     --*this;
@@ -313,7 +313,7 @@ inline ChunkedRangeVectorIterator<T> ChunkedRangeVectorIterator<T>::operator--(i
 }
 
 template<typename T>
-inline void ChunkedRangeVectorIterator<T>::next_chunk()
+inline void ChunkedRangeVectorIterator<T>::next_chunk() noexcept
 {
     ++m_outer;
     m_inner = m_outer != m_end ? &m_outer->data[0] : nullptr;

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -20,8 +20,34 @@
 
 #include "impl/object_notifier.hpp"
 #include "impl/realm_coordinator.hpp"
+#include "object_schema.hpp"
+#include "util/format.hpp"
 
 using namespace realm;
+
+InvalidatedObjectException::InvalidatedObjectException(const std::string& object_type)
+: std::logic_error("Accessing object of type " + object_type + " which has been invalidated or deleted")
+, object_type(object_type)
+{}
+
+InvalidPropertyException::InvalidPropertyException(const std::string& object_type, const std::string& property_name)
+: std::logic_error(util::format("Property '%1.%2' does not exist", object_type, property_name))
+, object_type(object_type), property_name(property_name)
+{}
+
+MissingPropertyValueException::MissingPropertyValueException(const std::string& object_type, const std::string& property_name)
+: std::logic_error(util::format("Missing value for property '%1.%2'", object_type, property_name))
+, object_type(object_type), property_name(property_name)
+{}
+
+MissingPrimaryKeyException::MissingPrimaryKeyException(const std::string& object_type)
+: std::logic_error(util::format("'%1' does not have a primary key defined", object_type))
+, object_type(object_type)
+{}
+
+ReadOnlyPropertyException::ReadOnlyPropertyException(const std::string& object_type, const std::string& property_name)
+: std::logic_error(util::format("Cannot modify read-only property '%1.%2'", object_type, property_name))
+, object_type(object_type), property_name(property_name) {}
 
 Object::Object(SharedRealm r, ObjectSchema const& s, BasicRowExpr<Table> const& o)
 : m_realm(std::move(r)), m_object_schema(&s), m_row(o) { }
@@ -42,4 +68,21 @@ NotificationToken Object::add_notification_block(CollectionChangeCallback callba
         m_notifier = std::make_shared<_impl::ObjectNotifier>(m_row, m_realm);
     _impl::RealmCoordinator::register_notifier(m_notifier);
     return {m_notifier, m_notifier->add_callback(std::move(callback))};
+}
+
+void Object::verify_attached() const
+{
+    m_realm->verify_thread();
+    if (!m_row.is_attached()) {
+        throw InvalidatedObjectException(m_object_schema->name);
+    }
+}
+
+Property const& Object::property_for_name(std::string const& prop_name) const
+{
+    auto prop = m_object_schema->property_for_name(prop_name);
+    if (!prop) {
+        throw InvalidPropertyException(m_object_schema->name, prop_name);
+    }
+    return *prop;
 }

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -79,7 +79,7 @@ private:
 
 
     template<typename ValueType, typename ContextType>
-    void set_property_value_impl(ContextType ctx, const Property &property, ValueType value, bool try_update);
+    void set_property_value_impl(ContextType ctx, const Property &property, ValueType value, bool try_update, bool is_default=false);
     template<typename ValueType, typename ContextType>
     ValueType get_property_value_impl(ContextType ctx, const Property &property);
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -77,6 +77,7 @@ private:
     Row m_row;
     _impl::CollectionNotifier::Handle<_impl::ObjectNotifier> m_notifier;
 
+
     template<typename ValueType, typename ContextType>
     void set_property_value_impl(ContextType ctx, const Property &property, ValueType value, bool try_update);
     template<typename ValueType, typename ContextType>
@@ -86,7 +87,36 @@ private:
     static size_t get_for_primary_key_impl(ContextType ctx, Table const& table,
                                            const Property &primary_prop, ValueType primary_value);
 
-    inline void verify_attached();
+    void verify_attached() const;
+    Property const& property_for_name(std::string const& prop_name) const;
+};
+
+struct InvalidatedObjectException : public std::logic_error {
+    InvalidatedObjectException(const std::string& object_type);
+    const std::string object_type;
+};
+
+struct InvalidPropertyException : public std::logic_error {
+    InvalidPropertyException(const std::string& object_type, const std::string& property_name);
+    const std::string object_type;
+    const std::string property_name;
+};
+
+struct MissingPropertyValueException : public std::logic_error {
+    MissingPropertyValueException(const std::string& object_type, const std::string& property_name);
+    const std::string object_type;
+    const std::string property_name;
+};
+
+struct MissingPrimaryKeyException : public std::logic_error {
+    MissingPrimaryKeyException(const std::string& object_type);
+    const std::string object_type;
+};
+
+struct ReadOnlyPropertyException : public std::logic_error {
+    ReadOnlyPropertyException(const std::string& object_type, const std::string& property_name);
+    const std::string object_type;
+    const std::string property_name;
 };
 } // namespace realm
 

--- a/src/object_accessor.hpp
+++ b/src/object_accessor.hpp
@@ -194,8 +194,8 @@ void Object::set_property_value_impl(ContextType ctx, const Property &property, 
             break;
         }
         case PropertyType::Data: {
-            auto str = Accessor::to_binary(ctx, value);
-            m_row.set_binary(column, BinaryData(str));
+            auto data = Accessor::to_binary(ctx, value);
+            m_row.set_binary(column, BinaryData(data));
             break;
         }
         case PropertyType::Any:
@@ -272,7 +272,7 @@ ValueType Object::get_property_value_impl(ContextType ctx, const Property &prope
         case PropertyType::Array:
             return Accessor::from_list(ctx, List(m_realm, static_cast<LinkViewRef>(m_row.get_linklist(column))));
         case PropertyType::LinkingObjects: {
-            auto target_object_schema = m_realm->config().schema->find(property.object_type);
+            auto target_object_schema = m_realm->schema().find(property.object_type);
             auto link_property = target_object_schema->property_for_name(property.link_origin_property_name);
             TableRef table = ObjectStore::table_for_object_type(m_realm->read_group(), target_object_schema->name);
             auto tv = m_row.get_table()->get_backlink_view(m_row.get_index(), table.get(), link_property->table_column);

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -48,8 +48,15 @@ ObjectSchema::ObjectSchema() = default;
 ObjectSchema::~ObjectSchema() = default;
 
 ObjectSchema::ObjectSchema(std::string name, std::initializer_list<Property> persisted_properties)
+: ObjectSchema(std::move(name), persisted_properties, {})
+{
+}
+
+ObjectSchema::ObjectSchema(std::string name, std::initializer_list<Property> persisted_properties,
+                           std::initializer_list<Property> computed_properties)
 : name(std::move(name))
 , persisted_properties(persisted_properties)
+, computed_properties(computed_properties)
 {
     for (auto const& prop : persisted_properties) {
         if (prop.is_primary) {

--- a/src/object_schema.hpp
+++ b/src/object_schema.hpp
@@ -34,6 +34,8 @@ class ObjectSchema {
 public:
     ObjectSchema();
     ObjectSchema(std::string name, std::initializer_list<Property> persisted_properties);
+    ObjectSchema(std::string name, std::initializer_list<Property> persisted_properties,
+                 std::initializer_list<Property> computed_properties);
     ~ObjectSchema();
 
     // create object schema from existing table

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,7 @@
 include_directories(../external/catch/single_include .)
 
 set(HEADERS
+    util/any.hpp
     util/event_loop.hpp
     util/index_helpers.hpp
     util/test_file.hpp

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -31,24 +31,7 @@
 
 using namespace realm;
 
-#define VERIFY_SCHEMA(r) do { \
-    for (auto&& object_schema : (r).schema()) { \
-        auto table = ObjectStore::table_for_object_type((r).read_group(), object_schema.name); \
-        REQUIRE(table); \
-        CAPTURE(object_schema.name) \
-        std::string primary_key = ObjectStore::get_primary_key_for_object((r).read_group(), object_schema.name); \
-        REQUIRE(primary_key == object_schema.primary_key); \
-        for (auto&& prop : object_schema.persisted_properties) { \
-            size_t col = table->get_column_index(prop.name); \
-            CAPTURE(prop.name) \
-            REQUIRE(col != npos); \
-            REQUIRE(col == prop.table_column); \
-            REQUIRE(table->get_column_type(col) == static_cast<int>(prop.type)); \
-            REQUIRE(table->has_search_index(col) == prop.requires_index()); \
-            REQUIRE(prop.is_primary == (prop.name == primary_key)); \
-        } \
-    } \
-} while (0)
+#define VERIFY_SCHEMA(r) verify_schema((r), __LINE__)
 
 #define REQUIRE_UPDATE_SUCCEEDS(r, s, version) do { \
     REQUIRE_NOTHROW((r).update_schema(s, version)); \
@@ -69,6 +52,27 @@ using namespace realm;
 } while (0)
 
 namespace {
+void verify_schema(Realm& r, int line)
+{
+    CAPTURE(line);
+    for (auto&& object_schema : r.schema()) {
+        auto table = ObjectStore::table_for_object_type(r.read_group(), object_schema.name);
+        REQUIRE(table);
+        CAPTURE(object_schema.name)
+        std::string primary_key = ObjectStore::get_primary_key_for_object(r.read_group(), object_schema.name);
+        REQUIRE(primary_key == object_schema.primary_key);
+        for (auto&& prop : object_schema.persisted_properties) {
+            size_t col = table->get_column_index(prop.name);
+            CAPTURE(prop.name)
+            REQUIRE(col != npos);
+            REQUIRE(col == prop.table_column);
+            REQUIRE(table->get_column_type(col) == static_cast<int>(prop.type));
+            REQUIRE(table->has_search_index(col) == prop.requires_index());
+            REQUIRE(prop.is_primary == (prop.name == primary_key));
+        }
+    }
+}
+
 // Helper functions for modifying Schema objects, mostly for the sake of making
 // it clear what exactly is different about the 2+ schema objects used in
 // various tests

--- a/tests/object.cpp
+++ b/tests/object.cpp
@@ -439,6 +439,7 @@ TEST_CASE("object") {
         auto linking = any_cast<Results>(linkobj.get_property_value<util::Any>(&d, "origin"));
         REQUIRE(linking.size() == 1);
 
+        REQUIRE_THROWS(obj.set_property_value(&d, "pk", util::Any(5LL), false));
         REQUIRE_THROWS(obj.set_property_value(&d, "not a property", util::Any(5LL), false));
 
         r->commit_transaction();

--- a/tests/transaction_log_parsing.cpp
+++ b/tests/transaction_log_parsing.cpp
@@ -1273,7 +1273,7 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
                 }
             }
 
-            bool modified(size_t index, size_t col) const
+            bool modified(size_t index, size_t col) const noexcept
             {
                 auto it = std::find_if(begin(m_result), end(m_result),
                                        [=](auto&& change) { return (void *)(uintptr_t)index == change.info; });
@@ -1282,12 +1282,12 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
                 return it->changes[col].kind != BindingContext::ColumnInfo::Kind::None;
             }
 
-            bool invalidated(size_t index) const
+            bool invalidated(size_t index) const noexcept
             {
                 return std::find(begin(m_invalidated), end(m_invalidated), (void *)(uintptr_t)index) != end(m_invalidated);
             }
 
-            bool has_array_change(size_t index, size_t col, ColumnInfo::Kind kind, IndexSet values) const
+            bool has_array_change(size_t index, size_t col, ColumnInfo::Kind kind, IndexSet values) const noexcept
             {
                 auto& changes = m_result[index].changes;
                 if (changes.size() <= col)
@@ -1297,7 +1297,7 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
                                                          values.as_indexes().begin(), values.as_indexes().end());
             }
 
-            size_t initial_column_index(size_t index, size_t col) const
+            size_t initial_column_index(size_t index, size_t col) const noexcept
             {
                 auto it = std::find_if(begin(m_result), end(m_result),
                                        [=](auto&& change) { return (void *)(uintptr_t)index == change.info; });

--- a/tests/util/any.hpp
+++ b/tests/util/any.hpp
@@ -1,0 +1,155 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2017 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include <typeinfo>
+#include <type_traits>
+#include <stdexcept>
+
+namespace realm {
+namespace util {
+
+// A naive implementation of C++17's std::any
+// This does not perform the small-object optimization or make any particular
+// attempt at being performant
+class Any final {
+public:
+    // Constructors
+
+    Any() = default;
+    Any(Any&&) noexcept = default;
+    ~Any() = default;
+    Any& operator=(Any&&) noexcept = default;
+
+    Any(Any const& rhs)
+    : m_value(rhs.m_value ? rhs.m_value->copy() : nullptr)
+    {
+    }
+
+    template<typename T, typename = typename std::enable_if<!std::is_same<typename std::decay<T>::type, Any>::value>::type>
+    Any(T&& value)
+    : m_value(std::make_unique<Value<typename std::decay<T>::type>>(std::forward<T>(value)))
+    {
+    }
+
+    Any& operator=(Any const& rhs)
+    {
+        m_value = rhs.m_value ? rhs.m_value->copy() : nullptr;
+        return *this;
+    }
+
+    template<typename T, typename = typename std::enable_if<!std::is_same<typename std::decay<T>::type, Any>::value>::type>
+    Any& operator=(T&& value)
+    {
+        m_value = std::make_unique<Value<typename std::decay<T>::type>>(std::forward<T>(value));
+        return *this;
+    }
+
+    // Modifiers
+
+    void reset() noexcept { m_value.reset(); }
+    void swap(Any& rhs) noexcept { std::swap(m_value, rhs.m_value); }
+
+    // Observers
+
+    bool has_value() const noexcept { return m_value != nullptr; }
+    std::type_info const& type() const noexcept { return m_value ? m_value->type() : typeid(void); }
+
+private:
+    struct ValueBase {
+        virtual ~ValueBase() noexcept { }
+        virtual std::type_info const& type() const noexcept = 0;
+        virtual std::unique_ptr<ValueBase> copy() const = 0;
+    };
+    template<typename T>
+    struct Value : ValueBase {
+        T value;
+        template<typename U> Value(U&& v) : value(std::forward<U>(v)) { }
+
+        std::type_info const& type() const noexcept override { return typeid(T); }
+        std::unique_ptr<ValueBase> copy() const override
+        {
+            return std::make_unique<Value<T>>(value);
+        }
+    };
+    std::unique_ptr<ValueBase> m_value;
+
+    template<typename T>
+    friend const T* any_cast(const Any* operand) noexcept;
+    template<typename T>
+    friend T* any_cast(Any* operand) noexcept;
+
+    template<typename T>
+    const T* cast() const noexcept
+    {
+        return &static_cast<Value<T>*>(m_value.get())->value;
+    }
+
+    template<typename T>
+    T* cast() noexcept
+    {
+        return &static_cast<Value<T>*>(m_value.get())->value;
+    }
+};
+
+template<typename T>
+T any_cast(Any const& value)
+{
+    auto ptr = any_cast<typename std::add_const<typename std::remove_reference<T>::type>::type>(&value);
+    if (!ptr)
+        throw std::bad_cast();
+    return *ptr;
+}
+
+template<typename T>
+T any_cast(Any& value)
+{
+    auto ptr = any_cast<typename std::remove_reference<T>::type>(&value);
+    if (!ptr)
+        throw std::bad_cast();
+    return *ptr;
+}
+
+template<typename T>
+T any_cast(Any&& value)
+{
+    auto ptr = any_cast<typename std::remove_reference<T>::type>(&value);
+    if (!ptr)
+        throw std::bad_cast();
+    return std::move(*ptr);
+}
+
+template<typename T>
+T* any_cast(Any* value) noexcept
+{
+    return value && value->type() == typeid(T) ? value->cast<T>() : nullptr;
+}
+
+template<typename T>
+const T* any_cast(const Any* value) noexcept
+{
+    return value && value->type() == typeid(T) ? value->cast<T>() : nullptr;
+}
+} // namespace util
+} // namespace realm
+
+namespace std {
+inline void swap(realm::util::Any& lhs, realm::util::Any& rhs) noexcept
+{
+    lhs.swap(rhs);
+}
+} // namespace std

--- a/tests/util/test_file.cpp
+++ b/tests/util/test_file.cpp
@@ -95,9 +95,10 @@ SyncTestFile::SyncTestFile(const SyncConfig& sync_config)
     schema_mode = SchemaMode::Additive;
 }
 
-SyncTestFile::SyncTestFile(SyncServer& server)
+SyncTestFile::SyncTestFile(SyncServer& server, std::string name)
 {
-    auto name = path.substr(path.rfind('/') + 1);
+    if (name.empty())
+        name = path.substr(path.rfind('/') + 1);
     auto url = server.url_for_realm(name);
 
     sync_config = std::make_shared<SyncConfig>(SyncConfig{
@@ -151,15 +152,20 @@ SyncServer::SyncServer(bool start_immediately)
 
 SyncServer::~SyncServer()
 {
-    m_server.stop();
-    if (m_thread.joinable())
-        m_thread.join();
+    stop();
 }
 
 void SyncServer::start()
 {
     REALM_ASSERT(!m_thread.joinable());
     m_thread = std::thread([this]{ m_server.run(); });
+}
+
+void SyncServer::stop()
+{
+    m_server.stop();
+    if (m_thread.joinable())
+        m_thread.join();
 }
 
 std::string SyncServer::url_for_realm(StringData realm_name) const

--- a/tests/util/test_file.hpp
+++ b/tests/util/test_file.hpp
@@ -74,6 +74,7 @@ public:
     ~SyncServer();
 
     void start();
+    void stop();
 
     std::string url_for_realm(realm::StringData realm_name) const;
     std::string base_url() const { return m_url; }
@@ -86,7 +87,7 @@ private:
 
 struct SyncTestFile : TestFile {
     SyncTestFile(const realm::SyncConfig&);
-    SyncTestFile(SyncServer& server);
+    SyncTestFile(SyncServer& server, std::string name="");
 };
 
 #endif // REALM_ENABLE_SYNC


### PR DESCRIPTION
The object accessor code was never updated to reflect sync's requirements (no setting the PK after creating objects and default values have to be explicitly flagged for them to be merged correctly).

Quite a bit more is still needed here (this doesn't fully cover the object accessor code and even the parts that are covered aren't particularly thorough), but it's better than nothing.