### PR TITLE
Shorten the delay between condition checking in CF's EventLoop::run_until

### DIFF
--- a/tests/util/event_loop.cpp
+++ b/tests/util/event_loop.cpp
@@ -187,7 +187,7 @@ void EventLoop::Impl::run_until(std::function<bool()> predicate)
     ctx.info = &predicate;
     auto observer = adoptCF(CFRunLoopObserverCreate(kCFAllocatorDefault, kCFRunLoopAllActivities,
                                                     true, 0, callback, &ctx));
-    auto timer = adoptCF(CFRunLoopTimerCreateWithHandler(kCFAllocatorDefault, CFAbsoluteTimeGetCurrent(), 0.05, 0, 0,
+    auto timer = adoptCF(CFRunLoopTimerCreateWithHandler(kCFAllocatorDefault, CFAbsoluteTimeGetCurrent(), 0.0005, 0, 0,
                                                          ^(CFRunLoopTimerRef){
         // Do nothing. The timer firing is sufficient to cause our runloop observer to run.
     }));


### PR DESCRIPTION
The condition is now checked every 0.5ms rather than every 50ms. This reduces the time spent within `CFRunLoopRun` during the tests from ~1s to ~20ms. The 0.5ms time was arrived at via trial and error, and produced the lowest overall execution time for the test suite (~1.8s, down from ~4.9s).