### PR TITLE
Properly distinguish between admin users and users wrapping admin tokens

### DIFF
--- a/src/sync/impl/sync_metadata.cpp
+++ b/src/sync/impl/sync_metadata.cpp
@@ -209,9 +209,7 @@ SyncUserMetadata::SyncUserMetadata(Schema schema, SharedRealm realm, RowExpr row
 , m_row(row)
 { }
 
-SyncUserMetadata::SyncUserMetadata(const SyncMetadataManager& manager,
-                                   std::string identity,
-                                   bool make_if_absent)
+SyncUserMetadata::SyncUserMetadata(const SyncMetadataManager& manager, std::string identity, bool make_if_absent)
 : m_schema(manager.m_user_schema)
 {
     // Open the Realm.
@@ -242,7 +240,7 @@ SyncUserMetadata::SyncUserMetadata(const SyncMetadataManager& manager,
     }
     m_row = table->get(row_idx);
     if (make_if_absent) {
-        // User existed in the table, but had been marked for deletion.
+        // User existed in the table, but had been marked for deletion. Unmark it.
         m_realm->begin_transaction();
         table->set_bool(m_schema.idx_marked_for_removal, row_idx, false);
         m_realm->commit_transaction();

--- a/src/sync/impl/sync_metadata.cpp
+++ b/src/sync/impl/sync_metadata.cpp
@@ -62,7 +62,7 @@ Property make_primary_key_property(const char* name)
     return p;
 }
 
-inline Schema make_schema()
+Schema make_schema()
 {
     return Schema{
         {c_sync_userMetadata, {

--- a/src/sync/impl/sync_metadata.cpp
+++ b/src/sync/impl/sync_metadata.cpp
@@ -98,14 +98,7 @@ SyncMetadataManager::SyncMetadataManager(std::string path,
     config.path = std::move(path);
     std::tie(config.schema, config.schema_version) = schema.value_or(std::pair<Schema, uint64_t>(make_schema(),
                                                                                                  SCHEMA_VERSION));
-    config.schema_mode = SchemaMode::Manual;
-    config.migration_function = [](SharedRealm old_realm, SharedRealm realm, Schema&) {
-        if (old_realm->schema_version() < 1) {
-            // Add `UserMetadata.user_is_admin` property.
-            TableRef table = ObjectStore::table_for_object_type(realm->read_group(), c_sync_userMetadata);
-            table->add_column(realm::DataType::type_Bool, StringData(c_sync_user_is_admin));
-        }
-    };
+    config.schema_mode = SchemaMode::Automatic;
 #if REALM_PLATFORM_APPLE
     if (should_encrypt && !encryption_key) {
         encryption_key = keychain::metadata_realm_encryption_key();

--- a/src/sync/impl/sync_metadata.hpp
+++ b/src/sync/impl/sync_metadata.hpp
@@ -173,24 +173,18 @@ public:
 
     Realm::Config get_configuration() const;
 
-    int schema_version() const noexcept
-    {
-        return m_schema_version;
-    }
-
     /// Construct the metadata manager.
     ///
     /// If the platform supports it, setting `should_encrypt` to `true` and not specifying an encryption key will make
     /// the object store handle generating and persisting an encryption key for the metadata database. Otherwise, an
     /// exception will be thrown.
+    /// `schema` is only for testing purposes, and should never be set explicitly in production code.
     SyncMetadataManager(std::string path,
                         bool should_encrypt,
                         util::Optional<std::vector<char>> encryption_key=none,
-                        int schema_version=1);
+                        util::Optional<std::pair<Schema, uint64_t>> schema=none);
 
 private:
-    int m_schema_version;
-
     SyncUserMetadataResults get_users(bool marked) const;
 
     Realm::Config m_metadata_config;

--- a/src/sync/impl/sync_metadata.hpp
+++ b/src/sync/impl/sync_metadata.hpp
@@ -178,11 +178,9 @@ public:
     /// If the platform supports it, setting `should_encrypt` to `true` and not specifying an encryption key will make
     /// the object store handle generating and persisting an encryption key for the metadata database. Otherwise, an
     /// exception will be thrown.
-    /// `schema` is only for testing purposes, and should never be set explicitly in production code.
     SyncMetadataManager(std::string path,
                         bool should_encrypt,
-                        util::Optional<std::vector<char>> encryption_key=none,
-                        util::Optional<std::pair<Schema, uint64_t>> schema=none);
+                        util::Optional<std::vector<char>> encryption_key=none);
 
 private:
     SyncUserMetadataResults get_users(bool marked) const;

--- a/src/sync/impl/sync_metadata.hpp
+++ b/src/sync/impl/sync_metadata.hpp
@@ -48,7 +48,9 @@ public:
     util::Optional<std::string> server_url() const;
     util::Optional<std::string> user_token() const;
 
-    void set_state(util::Optional<std::string> server_url, util::Optional<std::string> user_token);
+    void set_state(util::Optional<std::string> server_url,
+                   util::Optional<std::string> user_token);
+    void set_is_admin(bool);
 
     // Remove the user from the metadata database.
     void remove();
@@ -64,7 +66,7 @@ public:
     // set operations are no-ops and all get operations cause an assert to fail.
     //
     // If `make_if_absent` is true and the user was previously marked for deletion, it will be unmarked.
-    SyncUserMetadata(const SyncMetadataManager&, std::string, util::Optional<bool> is_admin_user, bool make_if_absent=true);
+    SyncUserMetadata(const SyncMetadataManager&, std::string, bool make_if_absent=true);
 
     SyncUserMetadata(Schema schema, SharedRealm realm, RowExpr row);
 

--- a/src/sync/impl/sync_metadata.hpp
+++ b/src/sync/impl/sync_metadata.hpp
@@ -40,9 +40,11 @@ public:
         size_t idx_marked_for_removal;
         size_t idx_user_token;
         size_t idx_auth_server_url;
+        size_t idx_user_is_admin;
     };
 
     std::string identity() const;
+    bool is_admin() const;
     util::Optional<std::string> server_url() const;
     util::Optional<std::string> user_token() const;
 
@@ -62,7 +64,7 @@ public:
     // set operations are no-ops and all get operations cause an assert to fail.
     //
     // If `make_if_absent` is true and the user was previously marked for deletion, it will be unmarked.
-    SyncUserMetadata(const SyncMetadataManager& manager, std::string identity, bool make_if_absent=true);
+    SyncUserMetadata(const SyncMetadataManager&, std::string, util::Optional<bool> is_admin_user, bool make_if_absent=true);
 
     SyncUserMetadata(Schema schema, SharedRealm realm, RowExpr row);
 
@@ -170,6 +172,10 @@ public:
 
     Realm::Config get_configuration() const;
 
+    int schema_version() const noexcept
+    {
+        return m_schema_version;
+    }
 
     /// Construct the metadata manager.
     ///
@@ -178,9 +184,12 @@ public:
     /// exception will be thrown.
     SyncMetadataManager(std::string path,
                         bool should_encrypt,
-                        util::Optional<std::vector<char>> encryption_key=none);
+                        util::Optional<std::vector<char>> encryption_key=none,
+                        int schema_version=1);
 
 private:
+    int m_schema_version;
+
     SyncUserMetadataResults get_users(bool marked) const;
 
     Realm::Config m_metadata_config;

--- a/src/sync/impl/sync_metadata.hpp
+++ b/src/sync/impl/sync_metadata.hpp
@@ -48,8 +48,7 @@ public:
     util::Optional<std::string> server_url() const;
     util::Optional<std::string> user_token() const;
 
-    void set_state(util::Optional<std::string> server_url,
-                   util::Optional<std::string> user_token);
+    void set_state(util::Optional<std::string> server_url, util::Optional<std::string> user_token);
     void set_is_admin(bool);
 
     // Remove the user from the metadata database.

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -44,6 +44,7 @@ void SyncManager::configure_file_system(const std::string& base_file_path,
         std::string identity;
         std::string user_token;
         util::Optional<std::string> server_url;
+        SyncUserAdminMode admin_mode;
     };
 
     std::vector<UserCreationData> users_to_add;
@@ -106,8 +107,14 @@ void SyncManager::configure_file_system(const std::string& base_file_path,
             auto user_token = user_data.user_token();
             auto identity = user_data.identity();
             auto server_url = user_data.server_url();
+            bool is_admin = user_data.is_admin();
             if (user_token) {
-                UserCreationData data = { std::move(identity), std::move(*user_token), std::move(server_url) };
+                UserCreationData data = {
+                    std::move(identity),
+                    std::move(*user_token),
+                    std::move(server_url),
+                    is_admin ? SyncUserAdminMode::MarkedAsAdmin : SyncUserAdminMode::None
+                };
                 users_to_add.emplace_back(std::move(data));
             }
         }
@@ -135,7 +142,8 @@ void SyncManager::configure_file_system(const std::string& base_file_path,
         for (auto& user_data : users_to_add) {
             m_users.insert({ user_data.identity, std::make_shared<SyncUser>(user_data.user_token,
                                                                             user_data.identity,
-                                                                            user_data.server_url) });
+                                                                            user_data.server_url,
+                                                                            user_data.admin_mode) });
         }
     }
 }
@@ -294,13 +302,13 @@ bool SyncManager::perform_metadata_update(std::function<void(const SyncMetadataM
 std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& identity,
                                                 std::string refresh_token,
                                                 util::Optional<std::string> auth_server_url,
-                                                bool is_admin)
+                                                SyncUserAdminMode admin_mode)
 {
     std::lock_guard<std::mutex> lock(m_user_mutex);
     auto it = m_users.find(identity);
     if (it == m_users.end()) {
         // No existing user.
-        auto new_user = std::make_shared<SyncUser>(std::move(refresh_token), identity, auth_server_url, is_admin);
+        auto new_user = std::make_shared<SyncUser>(std::move(refresh_token), identity, auth_server_url, admin_mode);
         m_users.insert({ identity, new_user });
         return new_user;
     } else {
@@ -308,7 +316,8 @@ std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& identity,
         if (auth_server_url && *auth_server_url != user->server_url()) {
             throw std::invalid_argument("Cannot retrieve an existing user specifying a different auth server.");
         }
-        if (is_admin != user->is_admin()) {
+        if ((admin_mode == SyncUserAdminMode::WrapsAdminToken || user->admin_mode() == SyncUserAdminMode::WrapsAdminToken)
+            && admin_mode != user->admin_mode()) {
             throw std::invalid_argument("Cannot retrieve an existing user with a different admin status.");
         }
         if (user->state() == SyncUser::State::Error) {

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -301,13 +301,13 @@ bool SyncManager::perform_metadata_update(std::function<void(const SyncMetadataM
 std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& identity,
                                                 std::string refresh_token,
                                                 util::Optional<std::string> auth_server_url,
-                                                bool should_persist)
+                                                bool do_not_persist)
 {
     std::lock_guard<std::mutex> lock(m_user_mutex);
     auto it = m_users.find(identity);
     if (it == m_users.end()) {
         // No existing user.
-        auto new_user = std::make_shared<SyncUser>(std::move(refresh_token), identity, auth_server_url, should_persist);
+        auto new_user = std::make_shared<SyncUser>(std::move(refresh_token), identity, auth_server_url, !do_not_persist);
         m_users.insert({ identity, new_user });
         return new_user;
     } else {

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -106,7 +106,7 @@ public:
     std::shared_ptr<SyncUser> get_user(const std::string& identity,
                                        std::string refresh_token,
                                        util::Optional<std::string> auth_server_url=none,
-                                       SyncUserAdminMode admin_mode = SyncUserAdminMode::None);
+                                       bool should_persist=true);
     // Get an existing user for a given identity, if one exists and is logged in.
     std::shared_ptr<SyncUser> get_existing_logged_in_user(const std::string& identity) const;
     // Get all the users that are logged in and not errored out.

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -21,6 +21,8 @@
 
 #include "shared_realm.hpp"
 
+#include "sync_user.hpp"
+
 #include <realm/sync/client.hpp>
 #include <realm/util/logger.hpp>
 #include <realm/util/optional.hpp>
@@ -104,7 +106,7 @@ public:
     std::shared_ptr<SyncUser> get_user(const std::string& identity,
                                        std::string refresh_token,
                                        util::Optional<std::string> auth_server_url=none,
-                                       bool is_admin=false);
+                                       SyncUserAdminMode admin_mode = SyncUserAdminMode::None);
     // Get an existing user for a given identity, if one exists and is logged in.
     std::shared_ptr<SyncUser> get_existing_logged_in_user(const std::string& identity) const;
     // Get all the users that are logged in and not errored out.

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -106,7 +106,7 @@ public:
     std::shared_ptr<SyncUser> get_user(const std::string& identity,
                                        std::string refresh_token,
                                        util::Optional<std::string> auth_server_url=none,
-                                       bool should_persist=true);
+                                       bool do_not_persist=false);
     // Get an existing user for a given identity, if one exists and is logged in.
     std::shared_ptr<SyncUser> get_existing_logged_in_user(const std::string& identity) const;
     // Get all the users that are logged in and not errored out.

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -106,7 +106,7 @@ public:
     std::shared_ptr<SyncUser> get_user(const std::string& identity,
                                        std::string refresh_token,
                                        util::Optional<std::string> auth_server_url=none,
-                                       bool do_not_persist=false);
+                                       SyncUser::TokenType token_type=SyncUser::TokenType::Normal);
     // Get an existing user for a given identity, if one exists and is logged in.
     std::shared_ptr<SyncUser> get_existing_logged_in_user(const std::string& identity) const;
     // Get all the users that are logged in and not errored out.

--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -24,26 +24,21 @@
 
 namespace realm {
 
-SyncUser::SyncUser(std::string refresh_token,
-                   std::string identity,
-                   util::Optional<std::string> server_url, bool should_persist)
+SyncUser::SyncUser(std::string refresh_token, std::string identity,
+                   util::Optional<std::string> server_url, TokenType token_type)
 : m_state(State::Active)
 , m_server_url(server_url.value_or(""))
-, m_should_persist(should_persist)
+, m_token_type(token_type)
 , m_refresh_token(std::move(refresh_token))
 , m_identity(std::move(identity))
 {
-    bool is_admin = false;
-    if (should_persist) {
-        SyncManager::shared().perform_metadata_update([this, &is_admin, server_url=std::move(server_url)](const auto& manager) {
+    if (token_type == TokenType::Normal) {
+        SyncManager::shared().perform_metadata_update([this, server_url=std::move(server_url)](const auto& manager) {
             auto metadata = SyncUserMetadata(manager, m_identity);
             metadata.set_state(server_url, m_refresh_token);
-            is_admin = metadata.is_admin();
+            m_is_admin = metadata.is_admin();
         });
-    } else {
-        is_admin = true;
     }
-    m_is_admin = is_admin;
 }
 
 std::vector<std::shared_ptr<SyncSession>> SyncUser::all_sessions()
@@ -111,7 +106,7 @@ void SyncUser::update_refresh_token(std::string token)
             }
         }
         // Update persistent user metadata.
-        if (m_should_persist) {
+        if (m_token_type != TokenType::Admin) {
             SyncManager::shared().perform_metadata_update([=](const auto& manager) {
                 auto metadata = SyncUserMetadata(manager, m_identity);
                 metadata.set_state(m_server_url, token);
@@ -128,8 +123,8 @@ void SyncUser::update_refresh_token(std::string token)
 
 void SyncUser::log_out()
 {
-    if (!m_should_persist) {
-        // Ephemeral users cannot be logged out.
+    if (m_token_type == TokenType::Admin) {
+        // Admin-token users cannot be logged out.
         return;
     }
     std::lock_guard<std::mutex> lock(m_mutex);
@@ -153,9 +148,9 @@ void SyncUser::log_out()
     });
 }
 
-void SyncUser::update_admin_status(bool is_admin)
+void SyncUser::set_is_admin(bool is_admin)
 {
-    if (!m_should_persist) {
+    if (m_token_type == TokenType::Admin) {
         return;
     }
     m_is_admin = is_admin;
@@ -192,7 +187,7 @@ void SyncUser::register_session(std::shared_ptr<SyncSession> session)
             // Immediately ask the session to come online.
             m_sessions[path] = session;
             // FIXME: `SyncUser`s shouldn't even wrap admin tokens; the bindings should do that.
-            if (!m_should_persist) {
+            if (m_token_type == TokenType::Admin) {
                 session->bind_with_admin_token(m_refresh_token, session->config().realm_url);
             } else {
                 lock.unlock();

--- a/tests/sync/metadata.cpp
+++ b/tests/sync/metadata.cpp
@@ -48,6 +48,8 @@ TEST_CASE("sync_metadata: migration", "[sync") {
             REQUIRE(user_metadata.is_valid());
             CHECK(user_metadata.identity() == identity);
             CHECK(!user_metadata.is_admin());
+            user_metadata.set_is_admin(true);
+            CHECK(user_metadata.is_admin());
         }
     }
 }

--- a/tests/sync/metadata.cpp
+++ b/tests/sync/metadata.cpp
@@ -73,17 +73,20 @@ TEST_CASE("sync_metadata: migration", "[sync") {
     };
 
     SECTION("properly upgrades from v0 to v1") {
-        // Open v0 metadata
+        // Open v0 metadata (create a Realm directly)
         {
-            SyncMetadataManager manager(metadata_path, false, none, std::pair<Schema, uint64_t>(v0_schema, 0));
-            auto user_metadata = SyncUserMetadata(manager, identity);
-            CHECK(user_metadata.identity() == identity);
-            CHECK(!user_metadata.is_admin());
+            Realm::Config config;
+            config.path = metadata_path;
+            config.schema = v0_schema;
+            config.schema_version = 0;
+            config.schema_mode = SchemaMode::Additive;
+            auto realm = Realm::get_shared_realm(std::move(config));
+            REQUIRE(realm);
         }
         // Open v1 metadata
         {
-            SyncMetadataManager manager(metadata_path, false, none, none);
-            auto user_metadata = SyncUserMetadata(manager, identity, false);
+            SyncMetadataManager manager(metadata_path, false, none);
+            auto user_metadata = SyncUserMetadata(manager, identity);
             REQUIRE(user_metadata.is_valid());
             CHECK(user_metadata.identity() == identity);
             CHECK(!user_metadata.is_admin());

--- a/tests/sync/metadata.cpp
+++ b/tests/sync/metadata.cpp
@@ -37,17 +37,17 @@ TEST_CASE("sync_metadata: migration", "[sync") {
         // Open v0 metadata
         {
             SyncMetadataManager manager(metadata_path, false, none, 0);
-            auto user_metadata = SyncUserMetadata(manager, identity, true);
+            auto user_metadata = SyncUserMetadata(manager, identity);
             CHECK(user_metadata.identity() == identity);
             CHECK(!user_metadata.is_admin());
         }
         // Open v1 metadata
         {
             SyncMetadataManager manager(metadata_path, false, none, 1);
-            auto user_metadata = SyncUserMetadata(manager, identity, true, false);
+            auto user_metadata = SyncUserMetadata(manager, identity, false);
             REQUIRE(user_metadata.is_valid());
             CHECK(user_metadata.identity() == identity);
-            CHECK(user_metadata.is_admin());
+            CHECK(!user_metadata.is_admin());
         }
     }
 }
@@ -58,29 +58,31 @@ TEST_CASE("sync_metadata: user metadata", "[sync]") {
 
     SECTION("can be properly constructed") {
         const auto identity = "testcase1a";
-        auto user_metadata = SyncUserMetadata(manager, identity, true);
+        auto user_metadata = SyncUserMetadata(manager, identity);
         REQUIRE(user_metadata.identity() == identity);
         REQUIRE(user_metadata.server_url() == none);
         REQUIRE(user_metadata.user_token() == none);
-        REQUIRE(user_metadata.is_admin());
+        REQUIRE(!user_metadata.is_admin());
     }
 
     SECTION("properly reflects setting state") {
         const auto identity = "testcase1b";
         const std::string sample_url = "https://realm.example.org";
         const std::string sample_token = "this_is_a_user_token";
-        auto user_metadata = SyncUserMetadata(manager, identity, false);
+        auto user_metadata = SyncUserMetadata(manager, identity);
         user_metadata.set_state(sample_url, sample_token);
         REQUIRE(user_metadata.identity() == identity);
         REQUIRE(user_metadata.server_url() == sample_url);
         REQUIRE(user_metadata.user_token() == sample_token);
+        user_metadata.set_is_admin(true);
+        REQUIRE(user_metadata.is_admin());
     }
 
     SECTION("can be properly re-retrieved from the same manager") {
         const auto identity = "testcase1c";
         const std::string sample_url = "https://realm.example.org";
         const std::string sample_token = "this_is_a_user_token";
-        auto first = SyncUserMetadata(manager, identity, false);
+        auto first = SyncUserMetadata(manager, identity);
         first.set_state(sample_url, sample_token);
         // Get a second instance of the user metadata for the same identity.
         auto second = SyncUserMetadata(manager, identity, false);
@@ -93,9 +95,8 @@ TEST_CASE("sync_metadata: user metadata", "[sync]") {
         const auto identity = "testcase1d";
         const std::string sample_url_1 = "https://realm.example.org";
         const std::string sample_token_1 = "this_is_a_user_token";
-        auto first = SyncUserMetadata(manager, identity, true);
-        CHECK(first.is_admin());
-        auto second = SyncUserMetadata(manager, identity, false);
+        auto first = SyncUserMetadata(manager, identity);
+        auto second = SyncUserMetadata(manager, identity);
         CHECK(!first.is_admin());
         first.set_state(sample_url_1, sample_token_1);
         REQUIRE(first.identity() == identity);
@@ -120,7 +121,7 @@ TEST_CASE("sync_metadata: user metadata", "[sync]") {
 
     SECTION("can be removed") {
         const auto identity = "testcase1e";
-        auto user_metadata = SyncUserMetadata(manager, identity, false);
+        auto user_metadata = SyncUserMetadata(manager, identity);
         REQUIRE(user_metadata.is_valid());
         user_metadata.remove();
         REQUIRE(!user_metadata.is_valid());
@@ -132,14 +133,14 @@ TEST_CASE("sync_metadata: user metadata", "[sync]") {
 
         SECTION("with no prior metadata for the identifier") {
             const auto identity = "testcase1g1";
-            auto user_metadata = SyncUserMetadata(manager, identity, false, false);
+            auto user_metadata = SyncUserMetadata(manager, identity, false);
             REQUIRE(!user_metadata.is_valid());
         }
         SECTION("with valid prior metadata for the identifier") {
             const auto identity = "testcase1g2";
             auto first = SyncUserMetadata(manager, identity, true);
             first.set_state(sample_url, sample_token);
-            auto second = SyncUserMetadata(manager, identity, false, false);
+            auto second = SyncUserMetadata(manager, identity, false);
             REQUIRE(second.is_valid());
             REQUIRE(second.identity() == identity);
             REQUIRE(second.server_url() == sample_url);
@@ -148,10 +149,10 @@ TEST_CASE("sync_metadata: user metadata", "[sync]") {
         }
         SECTION("with invalid prior metadata for the identifier") {
             const auto identity = "testcase1g3";
-            auto first = SyncUserMetadata(manager, identity, false);
+            auto first = SyncUserMetadata(manager, identity);
             first.set_state(sample_url, sample_token);
             first.mark_for_removal();
-            auto second = SyncUserMetadata(manager, identity, none, false);
+            auto second = SyncUserMetadata(manager, identity, false);
             REQUIRE(!second.is_valid());
         }
     }
@@ -165,9 +166,9 @@ TEST_CASE("sync_metadata: user metadata APIs", "[sync]") {
         const auto identity1 = "testcase2a1";
         const auto identity2 = "testcase2a2";
         const auto identity3 = "testcase2a3";
-        auto first = SyncUserMetadata(manager, identity1, true);
-        auto second = SyncUserMetadata(manager, identity2, false);
-        auto third = SyncUserMetadata(manager, identity3, none);
+        auto first = SyncUserMetadata(manager, identity1);
+        auto second = SyncUserMetadata(manager, identity2);
+        auto third = SyncUserMetadata(manager, identity3);
         auto unmarked_users = manager.all_unmarked_users();
         REQUIRE(unmarked_users.size() == 3);
         REQUIRE(results_contains_user(unmarked_users, identity1));
@@ -263,13 +264,13 @@ TEST_CASE("sync_metadata: results", "[sync]") {
         auto results = manager.all_unmarked_users();
         REQUIRE(results.size() == 0);
         // Add users, one at a time.
-        auto first = SyncUserMetadata(manager, identity1, false);
+        auto first = SyncUserMetadata(manager, identity1);
         REQUIRE(results.size() == 1);
         REQUIRE(results_contains_user(results, identity1));
-        auto second = SyncUserMetadata(manager, identity2, true);
+        auto second = SyncUserMetadata(manager, identity2);
         REQUIRE(results.size() == 2);
         REQUIRE(results_contains_user(results, identity2));
-        auto third = SyncUserMetadata(manager, identity3, false);
+        auto third = SyncUserMetadata(manager, identity3);
         REQUIRE(results.size() == 3);
         REQUIRE(results_contains_user(results, identity3));
     }
@@ -279,9 +280,9 @@ TEST_CASE("sync_metadata: results", "[sync]") {
         const auto identity2 = "testcase3b2";
         const auto identity3 = "testcase3b3";
         auto results = manager.all_unmarked_users();
-        auto first = SyncUserMetadata(manager, identity1, true);
-        auto second = SyncUserMetadata(manager, identity2, true);
-        auto third = SyncUserMetadata(manager, identity3, false);
+        auto first = SyncUserMetadata(manager, identity1);
+        auto second = SyncUserMetadata(manager, identity2);
+        auto third = SyncUserMetadata(manager, identity3);
         REQUIRE(results.size() == 3);
         REQUIRE(results_contains_user(results, identity1));
         REQUIRE(results_contains_user(results, identity2));
@@ -306,14 +307,15 @@ TEST_CASE("sync_metadata: persistence across metadata manager instances", "[sync
         const std::string sample_url = "https://realm.example.org";
         const std::string sample_token = "this_is_a_user_token";
         SyncMetadataManager first_manager(metadata_path, false);
-        auto first = SyncUserMetadata(first_manager, identity, true);
+        auto first = SyncUserMetadata(first_manager, identity);
         first.set_state(sample_url, sample_token);
+        first.set_is_admin(true);
         REQUIRE(first.identity() == identity);
         REQUIRE(first.server_url() == sample_url);
         REQUIRE(first.user_token() == sample_token);
         REQUIRE(first.is_admin());
         SyncMetadataManager second_manager(metadata_path, false);
-        auto second = SyncUserMetadata(second_manager, identity, none, false);
+        auto second = SyncUserMetadata(second_manager, identity, false);
         REQUIRE(second.identity() == identity);
         REQUIRE(second.server_url() == sample_url);
         REQUIRE(second.user_token() == sample_token);
@@ -339,13 +341,13 @@ TEST_CASE("sync_metadata: encryption", "[sync]") {
         std::vector<char> key = make_test_encryption_key(10);
         const auto identity = "testcase5a";
         SyncMetadataManager manager(metadata_path, true, key);
-        auto user_metadata = SyncUserMetadata(manager, identity, false);
+        auto user_metadata = SyncUserMetadata(manager, identity);
         REQUIRE(user_metadata.identity() == identity);
         REQUIRE(user_metadata.server_url() == none);
         REQUIRE(user_metadata.user_token() == none);
         // Reopen the metadata file with the same key.
         SyncMetadataManager manager_2(metadata_path, true, key);
-        auto user_metadata_2 = SyncUserMetadata(manager_2, identity, false, false);
+        auto user_metadata_2 = SyncUserMetadata(manager_2, identity, false);
         REQUIRE(user_metadata_2.identity() == identity);
         REQUIRE(user_metadata_2.is_valid());
     }

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -186,14 +186,14 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
         const std::string identity_2 = "bar-1";
         const std::string identity_3 = "baz-1";
         // First, create a few users and add them to the metadata.
-        auto u1 = SyncUserMetadata(manager, identity_1, false);
+        auto u1 = SyncUserMetadata(manager, identity_1);
         u1.set_state(url_1, token_1);
-        auto u2 = SyncUserMetadata(manager, identity_2, true);
+        auto u2 = SyncUserMetadata(manager, identity_2);
         u2.set_state(url_2, token_2);
-        auto u3 = SyncUserMetadata(manager, identity_3, false);
+        auto u3 = SyncUserMetadata(manager, identity_3);
         u3.set_state(url_3, token_3);
         // The fourth user is an "invalid" user: no token, so shouldn't show up.
-        auto u_invalid = SyncUserMetadata(manager, "invalid_user", false);
+        auto u_invalid = SyncUserMetadata(manager, "invalid_user");
         REQUIRE(manager.all_unmarked_users().size() == 4);
 
         SECTION("they should be added to the active users list when metadata is enabled") {
@@ -226,12 +226,12 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
         create_dummy_realm(user_dir_3 + "bar");
         create_dummy_realm(user_dir_3 + "baz");
         // Create the user metadata.
-        auto u1 = SyncUserMetadata(manager, identity_1, false);
+        auto u1 = SyncUserMetadata(manager, identity_1);
         u1.mark_for_removal();
-        auto u2 = SyncUserMetadata(manager, identity_2, false);
+        auto u2 = SyncUserMetadata(manager, identity_2);
         u2.mark_for_removal();
         // Don't mark this user for deletion.
-        auto u3 = SyncUserMetadata(manager, identity_3, true);
+        auto u3 = SyncUserMetadata(manager, identity_3);
         u3.set_state(url_3, token_3);
 
         SECTION("they should be cleaned up if metadata is enabled") {

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -146,7 +146,7 @@ TEST_CASE("sync_manager: user state management", "[sync]") {
 
     SECTION("should contain admin-token users if such users are created.") {
         SyncManager::shared().get_user(identity_2, token_2, url_2);
-        SyncManager::shared().get_user(identity_3, token_3, none, true);
+        SyncManager::shared().get_user(identity_3, token_3, none, SyncUserAdminMode::WrapsAdminToken);
         auto users = SyncManager::shared().all_logged_in_users();
         REQUIRE(users.size() == 2);
         CHECK(validate_user_in_vector(users, identity_2, url_2, token_2));
@@ -185,14 +185,14 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
         const std::string identity_2 = "bar-1";
         const std::string identity_3 = "baz-1";
         // First, create a few users and add them to the metadata.
-        auto u1 = SyncUserMetadata(manager, identity_1);
+        auto u1 = SyncUserMetadata(manager, identity_1, false);
         u1.set_state(url_1, token_1);
-        auto u2 = SyncUserMetadata(manager, identity_2);
+        auto u2 = SyncUserMetadata(manager, identity_2, true);
         u2.set_state(url_2, token_2);
-        auto u3 = SyncUserMetadata(manager, identity_3);
+        auto u3 = SyncUserMetadata(manager, identity_3, false);
         u3.set_state(url_3, token_3);
         // The fourth user is an "invalid" user: no token, so shouldn't show up.
-        auto u_invalid = SyncUserMetadata(manager, "invalid_user");
+        auto u_invalid = SyncUserMetadata(manager, "invalid_user", false);
         REQUIRE(manager.all_unmarked_users().size() == 4);
 
         SECTION("they should be added to the active users list when metadata is enabled") {
@@ -225,12 +225,12 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
         create_dummy_realm(user_dir_3 + "bar");
         create_dummy_realm(user_dir_3 + "baz");
         // Create the user metadata.
-        auto u1 = SyncUserMetadata(manager, identity_1);
+        auto u1 = SyncUserMetadata(manager, identity_1, false);
         u1.mark_for_removal();
-        auto u2 = SyncUserMetadata(manager, identity_2);
+        auto u2 = SyncUserMetadata(manager, identity_2, false);
         u2.mark_for_removal();
         // Don't mark this user for deletion.
-        auto u3 = SyncUserMetadata(manager, identity_3);
+        auto u3 = SyncUserMetadata(manager, identity_3, true);
         u3.set_state(url_3, token_3);
 
         SECTION("they should be cleaned up if metadata is enabled") {

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -145,8 +145,9 @@ TEST_CASE("sync_manager: user state management", "[sync]") {
     }
 
     SECTION("should contain admin-token users if such users are created.") {
+        // FIXME: once we refactor how admin-token users they should no longer be persisted.
         SyncManager::shared().get_user(identity_2, token_2, url_2);
-        SyncManager::shared().get_user(identity_3, token_3, none, SyncUserAdminMode::WrapsAdminToken);
+        SyncManager::shared().get_user(identity_3, token_3, none, false);
         auto users = SyncManager::shared().all_logged_in_users();
         REQUIRE(users.size() == 2);
         CHECK(validate_user_in_vector(users, identity_2, url_2, token_2));

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -147,7 +147,7 @@ TEST_CASE("sync_manager: user state management", "[sync]") {
     SECTION("should contain admin-token users if such users are created.") {
         // FIXME: once we refactor how admin-token users they should no longer be persisted.
         SyncManager::shared().get_user(identity_2, token_2, url_2);
-        SyncManager::shared().get_user(identity_3, token_3, none, true);
+        SyncManager::shared().get_user(identity_3, token_3, none, SyncUser::TokenType::Admin);
         auto users = SyncManager::shared().all_logged_in_users();
         REQUIRE(users.size() == 2);
         CHECK(validate_user_in_vector(users, identity_2, url_2, token_2));

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -147,7 +147,7 @@ TEST_CASE("sync_manager: user state management", "[sync]") {
     SECTION("should contain admin-token users if such users are created.") {
         // FIXME: once we refactor how admin-token users they should no longer be persisted.
         SyncManager::shared().get_user(identity_2, token_2, url_2);
-        SyncManager::shared().get_user(identity_3, token_3, none, false);
+        SyncManager::shared().get_user(identity_3, token_3, none, true);
         auto users = SyncManager::shared().all_logged_in_users();
         REQUIRE(users.size() == 2);
         CHECK(validate_user_in_vector(users, identity_2, url_2, token_2));

--- a/tests/sync/user.cpp
+++ b/tests/sync/user.cpp
@@ -49,7 +49,7 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
     }
 
     SECTION("properly creates a new wraps-admin-token user") {
-        auto user = SyncManager::shared().get_user(identity, token, server_url, true);
+        auto user = SyncManager::shared().get_user(identity, token, server_url, SyncUser::TokenType::Admin);
         REQUIRE(user);
         // The expected state for a newly created user:
         REQUIRE(user->is_admin());
@@ -63,7 +63,7 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
         auto user = SyncManager::shared().get_user(identity, token, server_url);
         REQUIRE(user);
         REQUIRE(!user->is_admin());
-        user->update_admin_status(true);
+        user->set_is_admin(true);
         REQUIRE(user->is_admin());
     }
 
@@ -157,7 +157,7 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         const std::string token = "token-1";
         const std::string server_url = "https://realm.example.org/1/";
         auto user = SyncManager::shared().get_user(identity, token, server_url);
-        user->update_admin_status(true);
+        user->set_is_admin(true);
         // Now try to pull the user out of the shadow manager directly.
         auto metadata = SyncUserMetadata(manager, identity, false);
         REQUIRE(metadata.is_valid());
@@ -170,7 +170,7 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         const std::string identity = "test_identity_1a";
         const std::string token = "token-1a";
         const std::string server_url = "https://realm.example.org/1a/";
-        auto user = SyncManager::shared().get_user(identity, token, server_url, true);
+        auto user = SyncManager::shared().get_user(identity, token, server_url, SyncUser::TokenType::Admin);
         // Now try to pull the user out of the shadow manager directly.
         auto metadata = SyncUserMetadata(manager, identity, false);
         REQUIRE(!metadata.is_valid());
@@ -182,7 +182,7 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         const std::string server_url = "https://realm.example.org/2/";
         // Create the user and validate it.
         auto first = SyncManager::shared().get_user(identity, token, server_url);
-        first->update_admin_status(true);
+        first->set_is_admin(true);
         auto first_metadata = SyncUserMetadata(manager, identity, false);
         REQUIRE(first_metadata.is_valid());
         REQUIRE(first_metadata.user_token() == token);
@@ -191,7 +191,7 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         // Update the user.
         auto second = SyncManager::shared().get_user(identity, token_2, server_url);
         auto second_metadata = SyncUserMetadata(manager, identity, false);
-        second->update_admin_status(false);
+        second->set_is_admin(false);
         REQUIRE(second_metadata.is_valid());
         REQUIRE(second_metadata.user_token() == token_2);
         REQUIRE(!second_metadata.is_admin());

--- a/tests/sync/user.cpp
+++ b/tests/sync/user.cpp
@@ -182,6 +182,7 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         const std::string server_url = "https://realm.example.org/2/";
         // Create the user and validate it.
         auto first = SyncManager::shared().get_user(identity, token, server_url);
+        first->update_admin_status(true);
         auto first_metadata = SyncUserMetadata(manager, identity, false);
         REQUIRE(first_metadata.is_valid());
         REQUIRE(first_metadata.user_token() == token);
@@ -190,6 +191,7 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         // Update the user.
         auto second = SyncManager::shared().get_user(identity, token_2, server_url);
         auto second_metadata = SyncUserMetadata(manager, identity, false);
+        second->update_admin_status(false);
         REQUIRE(second_metadata.is_valid());
         REQUIRE(second_metadata.user_token() == token_2);
         REQUIRE(!second_metadata.is_admin());

--- a/tests/sync/user.cpp
+++ b/tests/sync/user.cpp
@@ -157,8 +157,9 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         const std::string token = "token-1";
         const std::string server_url = "https://realm.example.org/1/";
         auto user = SyncManager::shared().get_user(identity, token, server_url);
+        user->update_admin_status(true);
         // Now try to pull the user out of the shadow manager directly.
-        auto metadata = SyncUserMetadata(manager, identity, true);
+        auto metadata = SyncUserMetadata(manager, identity, false);
         REQUIRE(metadata.is_valid());
         REQUIRE(metadata.server_url() == server_url);
         REQUIRE(metadata.user_token() == token);
@@ -181,7 +182,7 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         const std::string server_url = "https://realm.example.org/2/";
         // Create the user and validate it.
         auto first = SyncManager::shared().get_user(identity, token, server_url);
-        auto first_metadata = SyncUserMetadata(manager, identity, true);
+        auto first_metadata = SyncUserMetadata(manager, identity, false);
         REQUIRE(first_metadata.is_valid());
         REQUIRE(first_metadata.user_token() == token);
         REQUIRE(first_metadata.is_admin());

--- a/tests/sync/user.cpp
+++ b/tests/sync/user.cpp
@@ -49,7 +49,7 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
     }
 
     SECTION("properly creates a new wraps-admin-token user") {
-        auto user = SyncManager::shared().get_user(identity, token, server_url, false);
+        auto user = SyncManager::shared().get_user(identity, token, server_url, true);
         REQUIRE(user);
         // The expected state for a newly created user:
         REQUIRE(user->is_admin());
@@ -170,7 +170,7 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         const std::string identity = "test_identity_1a";
         const std::string token = "token-1a";
         const std::string server_url = "https://realm.example.org/1a/";
-        auto user = SyncManager::shared().get_user(identity, token, server_url, false);
+        auto user = SyncManager::shared().get_user(identity, token, server_url, true);
         // Now try to pull the user out of the shadow manager directly.
         auto metadata = SyncUserMetadata(manager, identity, false);
         REQUIRE(!metadata.is_valid());


### PR DESCRIPTION
Required for https://github.com/realm/realm-cocoa/pull/4699

Changes:
- Replaced 'is admin' flag with an enum member to distinguish between users that wrap an admin token, and ones that are marked by the server as admins
- Updated user metadata to store the 'is admin' flag
- Updated APIs exposed to bindings to allow a user's admin status to be specified or read out
- Updated tests and user creation code

To do:
- [x] Once object store tests aren't broken, ensure all tests pass
- [x] Write a test to ensure migrating from metadata v0 to v1 works fine
- [x] Write a few more tests to exercise `is_admin` updating logic