### PR TITLE
Fix a move-related issue

### DIFF
--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -299,8 +299,11 @@ void Realm::update_schema(Schema schema, uint64_t version, MigrationFunction mig
 
             case SchemaMode::Additive:
                 if (required_changes.empty()) {
-                    set_schema(std::move(schema), version);
-                    return version == m_schema_version;
+                    if (version == m_schema_version) {
+                        set_schema(std::move(schema), version);
+                        return true;
+                    }
+                    return false;
                 }
                 ObjectStore::verify_valid_additive_changes(required_changes);
                 return false;

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -1137,6 +1137,23 @@ TEST_CASE("migration: Additive") {
         REQUIRE(realm3->schema().find("object")->persisted_properties[0].table_column == 1);
         REQUIRE(realm3->schema().find("object")->persisted_properties[1].table_column == 2);
     }
+
+    SECTION("increasing schema version without modifying schema properly leaves the schema untouched") {
+        TestFile config1;
+        config1.schema = schema;
+        config1.schema_mode = SchemaMode::Additive;
+        config1.schema_version = 0;
+
+        auto realm1 = Realm::get_shared_realm(config1);
+        REQUIRE(realm1->schema().size() == 1);
+        Schema schema1 = realm1->schema();
+        realm1->close();
+
+        auto config2 = config1;
+        config2.schema_version = 1;
+        auto realm2 = Realm::get_shared_realm(config2);
+        REQUIRE(realm2->schema() == schema1);
+    }
 }
 
 TEST_CASE("migration: Manual") {


### PR DESCRIPTION
`schema` is captured from the enclosing scope by reference, and the only condition in which it's safe to move a value out of it is if the lambda returns `true` (and the enclosing function immediately returns). Otherwise, we attempt to use `schema` afterwards, causing issues since it no longer contains the values we expect.

- [x] This change needs a test