### PR TITLE
read schema from realm when opening a realm from a custom version

### DIFF
--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -204,6 +204,8 @@ void Realm::Internal::begin_read(Realm& realm, VersionID version_id)
 {
     REALM_ASSERT(!realm.m_group);
     realm.m_group = &const_cast<Group&>(realm.m_shared_group->begin_read(version_id));
+    realm.m_schema_version = ObjectStore::get_schema_version(*realm.m_group);
+    realm.m_schema = ObjectStore::schema_from_group(*realm.m_group);
     realm.add_schema_change_handler();
 }
 

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -259,6 +259,7 @@ public:
         friend class _impl::ResultsNotifier;
         friend class ThreadSafeReferenceBase;
         friend class GlobalNotifier;
+        friend class TestHelper;
 
         // ResultsNotifier and ListNotifier need access to the SharedGroup
         // to be able to call the handover functions, which are not very wrappable

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -33,20 +33,22 @@
 #include <realm/group.hpp>
 
 namespace realm {
-    class TestHelper {
-    public:
-        static realm::VersionID realm_version(SharedRealm &shared_realm) {
-            Realm &realm = *(shared_realm.get());
-            auto &shared_group = realm::Realm::Internal::get_shared_group(realm);
-            return shared_group->get_version_of_current_transaction();
-        }
+class TestHelper {
+public:
+    static realm::VersionID realm_version(SharedRealm &shared_realm) {
+        Realm &realm = *(shared_realm.get());
+        auto &shared_group = realm::Realm::Internal::get_shared_group(realm);
+        shared_group->begin_read();
+        shared_group->pin_version();
+        return shared_group->get_version_of_current_transaction();
+    }
 
-        static void begin_read(SharedRealm &shared_realm, VersionID version) {
-            Realm::Internal::begin_read(*shared_realm, version);
-        }
+    static void begin_read(SharedRealm &shared_realm, VersionID version) {
+        Realm::Internal::begin_read(*shared_realm, version);
+    }
 
 
-    };
+};
 }
 
 using namespace realm;


### PR DESCRIPTION
Right now we can end up with a realm with a schema referencing non-existent objects which can lead to assertion failures.

@bdash 
