### PR TITLE
Avoid beginning unnecessary write transactions in Additive schema mode

### DIFF
--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -415,20 +415,24 @@ void ObjectStore::verify_no_migration_required(std::vector<SchemaChange> const& 
     verify_no_errors<SchemaMismatchException>(verifier, changes);
 }
 
-void ObjectStore::verify_valid_additive_changes(std::vector<SchemaChange> const& changes)
+bool ObjectStore::verify_valid_additive_changes(std::vector<SchemaChange> const& changes, bool update_indexes)
 {
     using namespace schema_change;
     struct Verifier : SchemaDifferenceExplainer {
         using SchemaDifferenceExplainer::operator();
 
+        bool index_changes = false;
+        bool other_changes = false;
+
         // Additive mode allows adding things, extra columns, and adding/removing indexes
-        void operator()(AddTable) { }
-        void operator()(AddProperty) { }
+        void operator()(AddTable) { other_changes = true; }
+        void operator()(AddProperty) { other_changes = true; }
         void operator()(RemoveProperty) { }
-        void operator()(AddIndex) { }
-        void operator()(RemoveIndex) { }
+        void operator()(AddIndex) { index_changes = true; }
+        void operator()(RemoveIndex) { index_changes = true; }
     } verifier;
     verify_no_errors<InvalidSchemaChangeException>(verifier, changes);
+    return verifier.other_changes || (verifier.index_changes && update_indexes);
 }
 
 static void apply_non_migration_changes(Group& group, std::vector<SchemaChange> const& changes)
@@ -488,7 +492,8 @@ static void apply_additive_changes(Group& group, std::vector<SchemaChange> const
 {
     using namespace schema_change;
     struct Applier {
-        Applier(Group& group, bool update_indexes) : group{group}, table{group}, update_indexes{update_indexes} { }
+        Applier(Group& group, bool update_indexes)
+        : group{group}, table{group}, update_indexes{update_indexes} { }
         Group& group;
         TableHelper table;
         bool update_indexes;

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -62,7 +62,9 @@ public:
 
     // check if any of the schema changes in the list are forbidden in
     // additive-only mode, and if any are throw an exception
-    static void verify_valid_additive_changes(std::vector<SchemaChange> const& changes);
+    // returns true if any of the changes are not no-ops
+    static bool verify_valid_additive_changes(std::vector<SchemaChange> const& changes,
+                                              bool update_indexes=false);
 
     // check if changes is empty, and throw an exception if not
     static void verify_no_changes_required(std::vector<SchemaChange> const& changes);

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -1154,6 +1154,22 @@ TEST_CASE("migration: Additive") {
         auto realm2 = Realm::get_shared_realm(config2);
         REQUIRE(realm2->schema() == schema1);
     }
+
+    SECTION("update_schema() does not begin a write transaction when extra columns are present") {
+        realm->begin_transaction();
+
+        auto realm2 = Realm::get_shared_realm(config);
+        // will deadlock if it tries to start a write transaction
+        realm2->update_schema(remove_property(schema, "object", "value"));
+    }
+
+    SECTION("update_schema() does not begin a write transaction when indexes are changed without bumping schema version") {
+        realm->begin_transaction();
+
+        auto realm2 = Realm::get_shared_realm(config);
+        // will deadlock if it tries to start a write transaction
+        realm->update_schema(set_indexed(schema, "object", "value 2", true));
+    }
 }
 
 TEST_CASE("migration: Manual") {


### PR DESCRIPTION
`schema.compare()` can return a non-empty array and yet still not require a write transaction in Additive mode if all of the differences are that the Realm file has extra columns or index changes that wouldn't be applied anyway due to the schema version not changing.