### PR TITLE
Fix a bunch of issues with Realms with non-constant schema

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -234,15 +234,16 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm()
     return get_realm(m_config);
 }
 
-const Schema* RealmCoordinator::get_schema() const noexcept
+void RealmCoordinator::cache_schema(Schema const& new_schema, uint64_t new_schema_version)
 {
-    return m_schema_version == uint64_t(-1) ? nullptr : &m_schema;
+    m_cached_schema = new_schema;
+    m_schema_version = new_schema_version;
 }
 
-void RealmCoordinator::update_schema(Schema const& schema, uint64_t schema_version)
+void RealmCoordinator::set_schema_version(uint64_t new_schema_version)
 {
-    m_schema = schema;
-    m_schema_version = schema_version;
+    m_cached_schema = util::none;
+    m_schema_version = new_schema_version;
 }
 
 RealmCoordinator::RealmCoordinator() = default;

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -57,16 +57,34 @@ public:
 
     Realm::Config get_config() const { return m_config; }
 
-    const Schema* get_schema() const noexcept { return m_cached_schema ? &*m_cached_schema : nullptr; }
     uint64_t get_schema_version() const noexcept { return m_schema_version; }
     const std::string& get_path() const noexcept { return m_config.path; }
     const std::vector<char>& get_encryption_key() const noexcept { return m_config.encryption_key; }
     bool is_in_memory() const noexcept { return m_config.in_memory; }
 
+    // To avoid having to re-read and validate the file's schema every time a
+    // new read transaction is begun, RealmCoordinator maintains a cache of the
+    // most recently seen file schema and the range of transaction versions
+    // which it applies to. Note that this schema may not be identical to that
+    // of any Realm instances managed by this coordinator, as individual Realms
+    // may only be using a subset of it.
+
+    // Get the latest cached schema and the transaction version which is applies
+    // to. Returns false if there is no cached schema.
+    bool get_cached_schema(Schema& schema, uint64_t& schema_version, uint64_t& transaction) const noexcept;
+
+    // Cache the state of the schema at the given transaction version
+    void cache_schema(Schema const& new_schema, uint64_t new_schema_version,
+                      uint64_t transaction_version);
+    // If there is a schema cached for transaction version `previous`, report
+    // that it is still valid at transaction version `next`
+    void advance_schema_cache(uint64_t previous, uint64_t next);
+    void clear_schema_cache_and_set_schema_version(uint64_t new_schema_version);
+
+
     // Asynchronously call notify() on every Realm instance for this coordinator's
     // path, including those in other processes
     void send_commit_notifications(Realm&);
-    
     void wake_up_notifier_worker();
 
     // Clear the weak Realm cache for all paths
@@ -91,10 +109,6 @@ public:
     // Called by m_notifier when there's a new commit to send notifications for
     void on_change();
 
-    // Update the cached schema
-    void cache_schema(Schema const& new_schema, uint64_t new_schema_version);
-    void set_schema_version(uint64_t new_schema_version);
-
     static void register_notifier(std::shared_ptr<CollectionNotifier> notifier);
 
     // Advance the Realm to the most recent transaction version which all async
@@ -109,6 +123,7 @@ public:
     // Deliver any notifications which are ready for the Realm's version
     void process_available_async(Realm& realm);
 
+    // Register a function which is called whenever sync makes a write to the Realm
     void set_transaction_callback(std::function<void(VersionID, VersionID)>);
 
     // Deliver notifications for the Realm, blocking if some aren't ready yet
@@ -126,6 +141,8 @@ private:
     Realm::Config m_config;
     util::Optional<Schema> m_cached_schema;
     uint64_t m_schema_version = -1;
+    uint64_t m_schema_transaction_version_min = 0;
+    uint64_t m_schema_transaction_version_max = 0;
 
     std::mutex m_realm_mutex;
     std::vector<WeakRealmNotifier> m_weak_realm_notifiers;

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -69,7 +69,7 @@ public:
     // of any Realm instances managed by this coordinator, as individual Realms
     // may only be using a subset of it.
 
-    // Get the latest cached schema and the transaction version which is applies
+    // Get the latest cached schema and the transaction version which it applies
     // to. Returns false if there is no cached schema.
     bool get_cached_schema(Schema& schema, uint64_t& schema_version, uint64_t& transaction) const noexcept;
 

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -57,7 +57,7 @@ public:
 
     Realm::Config get_config() const { return m_config; }
 
-    const Schema* get_schema() const noexcept;
+    const Schema* get_schema() const noexcept { return m_cached_schema ? &*m_cached_schema : nullptr; }
     uint64_t get_schema_version() const noexcept { return m_schema_version; }
     const std::string& get_path() const noexcept { return m_config.path; }
     const std::vector<char>& get_encryption_key() const noexcept { return m_config.encryption_key; }
@@ -92,7 +92,8 @@ public:
     void on_change();
 
     // Update the cached schema
-    void update_schema(Schema const& new_schema, uint64_t new_schema_version);
+    void cache_schema(Schema const& new_schema, uint64_t new_schema_version);
+    void set_schema_version(uint64_t new_schema_version);
 
     static void register_notifier(std::shared_ptr<CollectionNotifier> notifier);
 
@@ -123,7 +124,7 @@ public:
 
 private:
     Realm::Config m_config;
-    Schema m_schema;
+    util::Optional<Schema> m_cached_schema;
     uint64_t m_schema_version = -1;
 
     std::mutex m_realm_mutex;

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -139,6 +139,8 @@ public:
 
 private:
     Realm::Config m_config;
+
+    mutable std::mutex m_schema_cache_mutex;
     util::Optional<Schema> m_cached_schema;
     uint64_t m_schema_version = -1;
     uint64_t m_schema_transaction_version_min = 0;

--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -435,6 +435,35 @@ bool ObjectStore::verify_valid_additive_changes(std::vector<SchemaChange> const&
     return verifier.other_changes || (verifier.index_changes && update_indexes);
 }
 
+void ObjectStore::verify_valid_external_changes(std::vector<SchemaChange> const& changes)
+{
+    using namespace schema_change;
+    struct Verifier : SchemaDifferenceExplainer {
+        using SchemaDifferenceExplainer::operator();
+
+        // Adding new things is fine
+        void operator()(AddTable) { }
+        void operator()(AddProperty) { }
+        void operator()(AddIndex) { }
+        void operator()(RemoveIndex) { }
+    } verifier;
+    verify_no_errors<InvalidSchemaChangeException>(verifier, changes);
+}
+
+void ObjectStore::verify_compatible_for_read_only(std::vector<SchemaChange> const& changes)
+{
+    using namespace schema_change;
+    struct Verifier : SchemaDifferenceExplainer {
+        using SchemaDifferenceExplainer::operator();
+
+        void operator()(AddTable) { }
+        void operator()(RemoveProperty) { }
+        void operator()(AddIndex) { }
+        void operator()(RemoveIndex) { }
+    } verifier;
+    verify_no_errors<InvalidSchemaChangeException>(verifier, changes);
+}
+
 static void apply_non_migration_changes(Group& group, std::vector<SchemaChange> const& changes)
 {
     using namespace schema_change;
@@ -579,8 +608,8 @@ static void apply_post_migration_changes(Group& group, std::vector<SchemaChange>
     }
 }
 
-void ObjectStore::apply_schema_changes(Group& group, Schema& schema, uint64_t& schema_version,
-                                       Schema const& target_schema, uint64_t target_schema_version,
+void ObjectStore::apply_schema_changes(Group& group, uint64_t schema_version,
+                                       Schema& target_schema, uint64_t target_schema_version,
                                        SchemaMode mode, std::vector<SchemaChange> const& changes,
                                        std::function<void()> migration_function)
 {
@@ -589,9 +618,7 @@ void ObjectStore::apply_schema_changes(Group& group, Schema& schema, uint64_t& s
     if (schema_version == ObjectStore::NotVersioned) {
         create_initial_tables(group, changes);
         set_schema_version(group, target_schema_version);
-        schema_version = target_schema_version;
-        schema = target_schema;
-        set_schema_columns(group, schema);
+        set_schema_columns(group, target_schema);
         return;
     }
 
@@ -603,75 +630,44 @@ void ObjectStore::apply_schema_changes(Group& group, Schema& schema, uint64_t& s
             set_schema_version(group, target_schema_version);
         }
 
-        schema = target_schema;
-        set_schema_columns(group, schema);
+        set_schema_columns(group, target_schema);
         return;
     }
 
     if (mode == SchemaMode::Manual) {
-        // Have to update the schema on the Realm before calling the migration
-        // function as the migration will need it
-        auto old_version = schema_version;
-        auto old_schema = schema;
-        schema_version = target_schema_version;
-        schema = target_schema;
-        set_schema_columns(group, schema);
+        set_schema_columns(group, target_schema);
+        migration_function();
 
-        try {
-            migration_function();
-            verify_no_changes_required(schema_from_group(group).compare(schema));
-            validate_primary_column_uniqueness(group);
-        }
-        catch (...) {
-            schema = move(old_schema);
-            schema_version = old_version;
-            throw;
-        }
-
-        set_schema_columns(group, schema);
+        verify_no_changes_required(schema_from_group(group).compare(target_schema));
+        validate_primary_column_uniqueness(group);
+        set_schema_columns(group, target_schema);
         set_schema_version(group, target_schema_version);
         return;
     }
 
     if (schema_version == target_schema_version) {
         apply_non_migration_changes(group, changes);
-        schema = target_schema;
-        set_schema_columns(group, schema);
+        set_schema_columns(group, target_schema);
         return;
     }
 
+    auto old_schema = schema_from_group(group);
     apply_pre_migration_changes(group, changes);
     if (migration_function) {
-        // Have to update the schema on the Realm before calling the migration
-        // function as the migration will need it
-        auto old_version = schema_version;
-        auto old_schema = schema;
-        schema_version = target_schema_version;
-        schema = target_schema;
-        set_schema_columns(group, schema);
+        set_schema_columns(group, target_schema);
+        migration_function();
 
-        try {
-            migration_function();
-
-            // Migration function may have changed the schema, so we need to re-read it
-            schema = schema_from_group(group);
-            apply_post_migration_changes(group, schema.compare(target_schema), old_schema);
-            validate_primary_column_uniqueness(group);
-        }
-        catch (...) {
-            schema = move(old_schema);
-            schema_version = old_version;
-            throw;
-        }
+        // Migration function may have changed the schema, so we need to re-read it
+        auto schema = schema_from_group(group);
+        apply_post_migration_changes(group, schema.compare(target_schema), old_schema);
+        validate_primary_column_uniqueness(group);
     }
     else {
         apply_post_migration_changes(group, changes, {});
     }
 
     set_schema_version(group, target_schema_version);
-    schema_version = target_schema_version;
-    schema = target_schema;
-    set_schema_columns(group, schema);
+    set_schema_columns(group, target_schema);
 }
 
 Schema ObjectStore::schema_from_group(Group const& group) {

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -66,6 +66,13 @@ public:
     static bool verify_valid_additive_changes(std::vector<SchemaChange> const& changes,
                                               bool update_indexes=false);
 
+    // check if the schema changes made by a different process made any changes
+    // which will prevent us from being able to continue (such as removing a
+    // property we were relying on)
+    static void verify_valid_external_changes(std::vector<SchemaChange> const& changes);
+
+    static void verify_compatible_for_read_only(std::vector<SchemaChange> const& changes);
+
     // check if changes is empty, and throw an exception if not
     static void verify_no_changes_required(std::vector<SchemaChange> const& changes);
 
@@ -73,8 +80,8 @@ public:
     // passed in target schema is updated with the correct column mapping
     // optionally runs migration function if schema is out of date
     // NOTE: must be performed within a write transaction
-    static void apply_schema_changes(Group& group, Schema& schema, uint64_t& schema_version,
-                                     Schema const& target_schema, uint64_t target_schema_version,
+    static void apply_schema_changes(Group& group, uint64_t schema_version,
+                                     Schema& target_schema, uint64_t target_schema_version,
                                      SchemaMode mode, std::vector<SchemaChange> const& changes,
                                      std::function<void()> migration_function={});
 

--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -152,46 +152,60 @@ static void compare(ObjectSchema const& existing_schema,
               [](auto a, auto b) { return GetRemovedColumn()(a) > GetRemovedColumn()(b); });
 }
 
-std::vector<SchemaChange> Schema::compare(Schema const& target_schema) const
+template<typename T, typename U, typename Func>
+void Schema::zip_matching(T&& a, U&& b, Func&& func)
 {
-    std::vector<SchemaChange> changes;
     size_t i = 0, j = 0;
-    while (i < target_schema.size() && j < size()) {
-        auto& object_schema = target_schema[i];
-        auto& matching_schema = operator[](j);
+    while (i < a.size() && j < b.size()) {
+        auto& object_schema = a[i];
+        auto& matching_schema = b[j];
         int cmp = object_schema.name.compare(matching_schema.name);
         if (cmp == 0) {
-            ::compare(matching_schema, object_schema, changes);
+            func(&object_schema, &matching_schema);
             ++i, ++j;
         }
-        else if (cmp < 0) { // table in target but not current
-            changes.emplace_back(schema_change::AddTable{&object_schema});
+        else if (cmp < 0) {
+            func(&object_schema, nullptr);
             ++i;
         }
-        else { // table in current but not target
+        else {
+            func(nullptr, &matching_schema);
             ++j;
         }
     }
-    for (; i < target_schema.size(); ++i)
-            changes.emplace_back(schema_change::AddTable{&target_schema[i]});
+    for (; i < a.size(); ++i)
+        func(&a[i], nullptr);
+    for (; j < b.size(); ++j)
+        func(nullptr, &b[j]);
+
+}
+
+std::vector<SchemaChange> Schema::compare(Schema const& target_schema) const
+{
+    std::vector<SchemaChange> changes;
+    zip_matching(target_schema, *this, [&](const ObjectSchema* target, const ObjectSchema* existing) {
+        if (target && existing)
+            ::compare(*existing, *target, changes);
+        else if (target)
+            changes.emplace_back(schema_change::AddTable{target});
+        // nothing for tables in existing but not target
+    });
     return changes;
 }
 
 void Schema::copy_table_columns_from(realm::Schema const& other)
 {
-    for (auto& source_schema : other) {
-        auto matching_schema = find(source_schema);
-        if (matching_schema == end()) {
-            continue;
-        }
+    zip_matching(*this, other, [&](ObjectSchema* existing, const ObjectSchema* other) {
+        if (!existing || !other)
+            return;
 
-        for (auto& current_prop : source_schema.persisted_properties) {
-            auto target_prop = matching_schema->property_for_name(current_prop.name);
+        for (auto& current_prop : other->persisted_properties) {
+            auto target_prop = existing->property_for_name(current_prop.name);
             if (target_prop) {
                 target_prop->table_column = current_prop.table_column;
             }
         }
-    }
+    });
 }
 
 namespace realm {

--- a/src/schema.hpp
+++ b/src/schema.hpp
@@ -71,6 +71,10 @@ public:
     using base::end;
     using base::empty;
     using base::size;
+
+private:
+    template<typename T, typename U, typename Func>
+    static void zip_matching(T&& a, U&& b, Func&& func);
 };
 
 namespace schema_change {

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -52,25 +52,15 @@ Realm::Realm(Config config, std::shared_ptr<_impl::RealmCoordinator> coordinator
 
     if (m_read_only_group) {
         m_group = m_read_only_group.get();
+        m_schema_version = ObjectStore::get_schema_version(*m_group);
+        m_schema = ObjectStore::schema_from_group(*m_group);
     }
-
-    // if there is an existing realm at the current path steal its schema/column mapping
-    if (auto existing = coordinator ? coordinator->get_schema() : nullptr) {
-        m_schema = *existing;
-        m_schema_version = coordinator->get_schema_version();
-    }
-    else {
-        // otherwise get the schema from the group
-        m_schema_version = ObjectStore::get_schema_version(read_group());
-        m_schema = ObjectStore::schema_from_group(read_group());
-        if (coordinator && m_schema_version != ObjectStore::NotVersioned)
-            coordinator->cache_schema(m_schema, m_schema_version);
-
-        if (m_shared_group) {
-            m_schema_transaction_version = m_shared_group->get_version_of_current_transaction().version;
-            m_shared_group->end_read();
-            m_group = nullptr;
-        }
+    else if (!coordinator || !coordinator->get_cached_schema(m_schema, m_schema_version, m_schema_transaction_version)) {
+        read_group();
+        if (coordinator)
+            coordinator->cache_schema(m_schema, m_schema_version, m_schema_transaction_version);
+        m_shared_group->end_read();
+        m_group = nullptr;
     }
 
     m_coordinator = std::move(coordinator);
@@ -195,20 +185,22 @@ Group& Realm::read_group()
 {
     verify_open();
 
-    if (!m_group) {
-        m_group = &const_cast<Group&>(m_shared_group->begin_read());
-        add_schema_change_handler();
-    }
+    if (!m_group)
+        begin_read(VersionID{});
     return *m_group;
 }
 
 void Realm::Internal::begin_read(Realm& realm, VersionID version_id)
 {
-    REALM_ASSERT(!realm.m_group);
-    realm.m_group = &const_cast<Group&>(realm.m_shared_group->begin_read(version_id));
-    realm.m_schema_version = ObjectStore::get_schema_version(*realm.m_group);
-    realm.m_schema = ObjectStore::schema_from_group(*realm.m_group);
-    realm.add_schema_change_handler();
+    realm.begin_read(version_id);
+}
+
+void Realm::begin_read(VersionID version_id)
+{
+    REALM_ASSERT(!m_group);
+    m_group = &const_cast<Group&>(m_shared_group->begin_read(version_id));
+    add_schema_change_handler();
+    read_schema_from_group_if_needed();
 }
 
 SharedRealm Realm::get_shared_realm(Config config)
@@ -217,43 +209,40 @@ SharedRealm Realm::get_shared_realm(Config config)
     return coordinator->get_realm(std::move(config));
 }
 
-void Realm::set_schema(Schema schema, uint64_t version)
+void Realm::set_schema(Schema const& reference, Schema schema)
 {
-    schema.copy_table_columns_from(m_schema);
-    m_schema = schema;
-    m_coordinator->set_schema_version(version);
+    m_dynamic_schema = false;
+    schema.copy_table_columns_from(reference);
+    m_schema = std::move(schema);
 }
 
-bool Realm::read_schema_from_group_if_needed()
+void Realm::read_schema_from_group_if_needed()
 {
-    // schema of read-only Realms can't change
-    if (m_read_only_group)
-        return false;
+    REALM_ASSERT(!m_read_only_group);
 
     Group& group = read_group();
     auto current_version = m_shared_group->get_version_of_current_transaction().version;
     if (m_schema_transaction_version == current_version)
-        return false;
+        return;
 
-    m_schema = ObjectStore::schema_from_group(group);
-    m_schema_version = ObjectStore::get_schema_version(group);
     m_schema_transaction_version = current_version;
-    return true;
+    m_schema_version = ObjectStore::get_schema_version(group);
+    auto schema = ObjectStore::schema_from_group(group);
+    if (m_coordinator)
+        m_coordinator->cache_schema(schema, m_schema_version,
+                                    m_schema_transaction_version);
+
+    if (m_dynamic_schema) {
+        m_schema = std::move(schema);
+    }
+    else {
+        ObjectStore::verify_valid_external_changes(m_schema.compare(schema));
+        m_schema.copy_table_columns_from(schema);
+    }
 }
 
-bool Realm::reset_file_if_needed(Schema& schema, uint64_t version, std::vector<SchemaChange>& required_changes)
+bool Realm::reset_file(Schema& schema, std::vector<SchemaChange>& required_changes)
 {
-    if (m_schema_version == ObjectStore::NotVersioned)
-        return false;
-    if (m_schema_version == version) {
-        if (required_changes.empty()) {
-            set_schema(std::move(schema), version);
-            return true;
-        }
-        if (!ObjectStore::needs_migration(required_changes))
-            return false;
-    }
-
     // FIXME: this does not work if multiple processes try to open the file at
     // the same time, or even multiple threads if there is not any external
     // synchronization. The latter is probably fixable, but making it
@@ -267,86 +256,116 @@ bool Realm::reset_file_if_needed(Schema& schema, uint64_t version, std::vector<S
     m_schema = ObjectStore::schema_from_group(read_group());
     m_schema_version = ObjectStore::get_schema_version(read_group());
     required_changes = m_schema.compare(schema);
+    m_coordinator->clear_schema_cache_and_set_schema_version(m_schema_version);
     return false;
 }
 
-void Realm::update_schema(Schema schema, uint64_t version, MigrationFunction migration_function, bool in_transaction)
+bool Realm::schema_change_needs_write_transaction(Schema& schema,
+                                                  std::vector<SchemaChange>& changes,
+                                                  uint64_t version)
+{
+    if (version == m_schema_version && changes.empty())
+        return false;
+
+    switch (m_config.schema_mode) {
+        case SchemaMode::Automatic:
+            if (version < m_schema_version && m_schema_version != ObjectStore::NotVersioned)
+                throw InvalidSchemaVersionException(m_schema_version, version);
+            return true;
+
+        case SchemaMode::ReadOnly:
+            if (version != m_schema_version)
+                throw InvalidSchemaVersionException(m_schema_version, version);
+            ObjectStore::verify_compatible_for_read_only(changes);
+            return false;
+
+        case SchemaMode::ResetFile:
+            if (m_schema_version == ObjectStore::NotVersioned)
+                return true;
+            if (m_schema_version == version && !ObjectStore::needs_migration(changes))
+                return true;
+            reset_file(schema, changes);
+            return true;
+
+        case SchemaMode::Additive: {
+            bool will_apply_index_changes = version > m_schema_version;
+            if (ObjectStore::verify_valid_additive_changes(changes, will_apply_index_changes))
+                return true;
+            return version != m_schema_version;
+        }
+
+        case SchemaMode::Manual:
+            if (version < m_schema_version && m_schema_version != ObjectStore::NotVersioned)
+                throw InvalidSchemaVersionException(m_schema_version, version);
+            if (version == m_schema_version) {
+                ObjectStore::verify_no_changes_required(changes);
+                REALM_UNREACHABLE(); // changes is non-empty so above line always throws
+            }
+            return true;
+    }
+    REALM_COMPILER_HINT_UNREACHABLE();
+}
+
+Schema Realm::get_full_schema()
+{
+    if (!m_read_only_group)
+        refresh();
+
+    // If the user hasn't specified a schema previously then m_schema is always
+    // the full schema
+    if (m_dynamic_schema)
+        return m_schema;
+
+    // Otherwise we may have a subset of the file's schema, so we need to get
+    // the complete thing to calculate what changes to make
+    if (m_read_only_group)
+        return ObjectStore::schema_from_group(read_group());
+
+    Schema actual_schema;
+    uint64_t actual_version;
+    uint64_t transaction = -1;
+    bool got_cached = m_coordinator->get_cached_schema(actual_schema, actual_version, transaction);
+    if (!got_cached || transaction != m_shared_group->get_version_of_current_transaction().version)
+        return ObjectStore::schema_from_group(read_group());
+    return actual_schema;
+}
+
+void Realm::update_schema(Schema schema, uint64_t version,
+                          MigrationFunction migration_function, bool in_transaction)
 {
     schema.validate();
-    read_schema_from_group_if_needed();
-    std::vector<SchemaChange> required_changes = m_schema.compare(schema);
 
-    auto no_changes_required = [&] {
-        switch (m_config.schema_mode) {
-            case SchemaMode::Automatic:
-                if (version < m_schema_version && m_schema_version != ObjectStore::NotVersioned) {
-                    throw InvalidSchemaVersionException(m_schema_version, version);
-                }
-                if (version == m_schema_version) {
-                    if (required_changes.empty()) {
-                        set_schema(std::move(schema), version);
-                        return true;
-                    }
-                    ObjectStore::verify_no_migration_required(required_changes);
-                }
-                return false;
+    Schema actual_schema = get_full_schema();
+    std::vector<SchemaChange> required_changes = actual_schema.compare(schema);
 
-            case SchemaMode::ReadOnly:
-                if (version != m_schema_version)
-                    throw InvalidSchemaVersionException(m_schema_version, version);
-                ObjectStore::verify_no_migration_required(m_schema.compare(schema));
-                set_schema(std::move(schema), version);
-                return true;
-
-            case SchemaMode::ResetFile:
-                return reset_file_if_needed(schema, version, required_changes);
-
-            case SchemaMode::Additive: {
-                bool will_apply_index_changes = version > m_schema_version;
-                if (ObjectStore::verify_valid_additive_changes(required_changes, will_apply_index_changes))
-                    return false;
-
-                if (version == m_schema_version) {
-                    set_schema(std::move(schema), version);
-                    return true;
-                }
-                return false;
-            }
-
-            case SchemaMode::Manual:
-                if (version < m_schema_version && m_schema_version != ObjectStore::NotVersioned) {
-                    throw InvalidSchemaVersionException(m_schema_version, version);
-                }
-                if (version == m_schema_version) {
-                    ObjectStore::verify_no_changes_required(required_changes);
-                    return true;
-                }
-                return false;
-        }
-        REALM_COMPILER_HINT_UNREACHABLE();
-    };
-
-    if (no_changes_required())
+    if (!schema_change_needs_write_transaction(schema, required_changes, version)) {
+        set_schema(actual_schema, std::move(schema));
         return;
+    }
     // Either the schema version has changed or we need to do non-migration changes
 
     if (!in_transaction) {
-        bool schema_changed = false;
-        m_group->set_schema_change_notification_handler([&]{
-            schema_changed = true;
-            m_schema = ObjectStore::schema_from_group(read_group());
-            m_schema_version = ObjectStore::get_schema_version(read_group());
-            m_coordinator->cache_schema(m_schema, m_schema_version);
-            required_changes = m_schema.compare(schema);
-        });
+        auto old_version = m_shared_group->get_version_of_current_transaction();
         transaction::begin_without_validation(*m_shared_group);
-        add_schema_change_handler();
 
         // Beginning the write transaction may have advanced the version and left
         // us with nothing to do if someone else initialized the schema on disk
-        if (schema_changed && no_changes_required()) {
-            cancel_transaction();
-            return;
+        if (m_new_schema) {
+            actual_schema = std::move(*m_new_schema);
+            m_new_schema = util::none;
+            m_coordinator->cache_schema(actual_schema, m_schema_version,
+                                        m_shared_group->get_version_of_current_transaction().version);
+            required_changes = actual_schema.compare(schema);
+
+            if (!schema_change_needs_write_transaction(schema, required_changes, version)) {
+                cancel_transaction();
+                set_schema(actual_schema, std::move(schema));
+                return;
+            }
+        }
+        else if (old_version != m_shared_group->get_version_of_current_transaction()) {
+            m_coordinator->advance_schema_cache(old_version.version,
+                                                m_shared_group->get_version_of_current_transaction().version);
         }
     }
 
@@ -364,15 +383,23 @@ void Realm::update_schema(Schema schema, uint64_t version, MigrationFunction mig
             // Need to open in read-write mode so that it uses a SharedGroup, but
             // users shouldn't actually be able to write via the old realm
             old_realm->m_config.schema_mode = SchemaMode::ReadOnly;
-
             migration_function(old_realm, shared_from_this(), m_schema);
         };
-        ObjectStore::apply_schema_changes(read_group(), m_schema, m_schema_version,
-                                          schema, version, m_config.schema_mode, required_changes, wrapper);
+
+        // migration function needs to see the target schema on the "new" Realm
+        std::swap(m_schema, schema);
+        std::swap(m_schema_version, version);
+        auto restore = util::make_scope_exit([&]() noexcept {
+            std::swap(m_schema, schema);
+            std::swap(m_schema_version, version);
+        });
+
+        ObjectStore::apply_schema_changes(read_group(), version, m_schema, m_schema_version,
+                                          m_config.schema_mode, required_changes, wrapper);
     }
     else {
-        ObjectStore::apply_schema_changes(read_group(), m_schema, m_schema_version,
-                                          schema, version, m_config.schema_mode, required_changes);
+        ObjectStore::apply_schema_changes(read_group(), m_schema_version, schema, version,
+                                          m_config.schema_mode, required_changes);
         REALM_ASSERT_DEBUG(additive || (required_changes = ObjectStore::schema_from_group(read_group()).compare(schema)).empty());
     }
 
@@ -380,21 +407,40 @@ void Realm::update_schema(Schema schema, uint64_t version, MigrationFunction mig
         commit_transaction();
     }
 
-    m_coordinator->set_schema_version(version);
+    m_schema = std::move(schema);
+    m_schema_version = ObjectStore::get_schema_version(read_group());
+    m_dynamic_schema = false;
+    m_coordinator->clear_schema_cache_and_set_schema_version(version);
 }
 
 void Realm::add_schema_change_handler()
 {
-    if (m_coordinator && m_config.schema_mode == SchemaMode::Additive) {
-        m_group->set_schema_change_notification_handler([&] {
-            auto new_schema = ObjectStore::schema_from_group(read_group());
-            auto required_changes = m_schema.compare(new_schema);
-            ObjectStore::verify_valid_additive_changes(required_changes);
-            m_schema_version = ObjectStore::get_schema_version(read_group());
-            m_coordinator->cache_schema(new_schema, m_schema_version);
-            m_schema.copy_table_columns_from(new_schema);
-        });
+    if (m_config.read_only())
+        return;
+    m_group->set_schema_change_notification_handler([&] {
+        m_new_schema = ObjectStore::schema_from_group(read_group());
+        m_schema_version = ObjectStore::get_schema_version(read_group());
+        if (m_dynamic_schema)
+            m_schema = *m_new_schema;
+        else
+            m_schema.copy_table_columns_from(*m_new_schema);
+    });
+}
+
+void Realm::cache_new_schema()
+{
+    if (!m_shared_group)
+        return;
+
+    auto new_version = m_shared_group->get_version_of_current_transaction().version;
+    if (m_coordinator) {
+        if (m_new_schema)
+            m_coordinator->cache_schema(std::move(*m_new_schema), m_schema_version, new_version);
+        else
+            m_coordinator->advance_schema_cache(m_schema_transaction_version, new_version);
     }
+    m_schema_transaction_version = new_version;
+    m_new_schema = util::none;
 }
 
 static void check_read_write(Realm *realm)
@@ -466,6 +512,7 @@ void Realm::begin_transaction()
     auto cleanup = util::make_scope_exit([this]() noexcept { m_is_sending_notifications = false; });
 
     m_coordinator->promote_to_write(*this);
+    cache_new_schema();
 }
 
 void Realm::commit_transaction()
@@ -478,6 +525,7 @@ void Realm::commit_transaction()
     }
 
     m_coordinator->commit_write(*this);
+    cache_new_schema();
 }
 
 void Realm::cancel_transaction()
@@ -594,6 +642,7 @@ void Realm::notify()
     if (m_auto_refresh) {
         if (m_group) {
             m_coordinator->advance_to_ready(*this);
+            cache_new_schema();
         }
         else  {
             if (m_binding_context) {
@@ -632,7 +681,9 @@ bool Realm::refresh()
         m_binding_context->before_notify();
     }
     if (m_group) {
-        return m_coordinator->advance_to_latest(*this);
+        bool version_changed = m_coordinator->advance_to_latest(*this);
+        cache_new_schema();
+        return version_changed;
     }
 
     // No current read transaction, so just create a new one
@@ -666,8 +717,12 @@ uint64_t Realm::get_schema_version(const Realm::Config &config)
 
 void Realm::close()
 {
+    // Order matters here: if we're the last Realm instance for this path, we
+    // need to tear down the coordinator before destroying our shared group
+    // to maintain the coordinator's invariant that there be a continuous session
     if (m_coordinator) {
         m_coordinator->unregister_realm(this);
+        m_coordinator = nullptr;
     }
 
     m_group = nullptr;
@@ -675,7 +730,6 @@ void Realm::close()
     m_history = nullptr;
     m_read_only_group = nullptr;
     m_binding_context = nullptr;
-    m_coordinator = nullptr;
 }
 
 util::Optional<int> Realm::file_format_upgraded_from_version() const
@@ -722,13 +776,12 @@ T Realm::resolve_thread_safe_reference(ThreadSafeReference<T> reference)
     // Ensure we're on the same version as the reference
     if (!m_group) {
         // A read transaction doesn't yet exist, so create at the reference's version
-        m_group = &const_cast<Group&>(m_shared_group->begin_read(reference.m_version_id));
-        add_schema_change_handler();
+        begin_read(reference.m_version_id);
     }
     else {
         // A read transaction does exist, but let's make sure that its version matches the reference's
         auto current_version = m_shared_group->get_version_of_current_transaction();
-        SharedGroup::VersionID reference_version = SharedGroup::VersionID(reference.m_version_id);
+        VersionID reference_version(reference.m_version_id);
 
         if (reference_version == current_version) {
             return std::move(reference).import_into_realm(shared_from_this());
@@ -744,16 +797,11 @@ T Realm::resolve_thread_safe_reference(ThreadSafeReference<T> reference)
             Realm::Config config = m_coordinator->get_config();
             config.cache = false;
             SharedRealm temporary_realm = m_coordinator->get_realm(config);
-            REALM_ASSERT(!temporary_realm->is_in_read_transaction());
-
-            // Begin read in temporary Realm at reference's version
-            temporary_realm->m_group =
-                &const_cast<Group&>(temporary_realm->m_shared_group->begin_read(reference_version));
+            temporary_realm->begin_read(reference_version);
 
             // With reference imported, advance temporary Realm to our version
             T imported_value = std::move(reference).import_into_realm(temporary_realm);
-            transaction::advance(*temporary_realm->m_shared_group, temporary_realm->m_binding_context.get(),
-                                 current_version);
+            transaction::advance(*temporary_realm->m_shared_group, nullptr, current_version);
             reference = ThreadSafeReference<T>(imported_value);
         }
     }
@@ -777,15 +825,13 @@ SharedGroup& RealmFriend::get_shared_group(Realm& realm)
     return *realm.m_shared_group;
 }
 
-Group& RealmFriend::read_group_to(Realm& realm, VersionID& version)
+Group& RealmFriend::read_group_to(Realm& realm, VersionID version)
 {
-    if (!realm.m_group) {
-        realm.m_group = &const_cast<Group&>(realm.m_shared_group->begin_read(version));
-        realm.add_schema_change_handler();
-    }
-    else if (version != realm.m_shared_group->get_version_of_current_transaction()) {
+    if (realm.m_group && realm.m_shared_group->get_version_of_current_transaction() == version)
+        return *realm.m_group;
+
+    if (realm.m_group)
         realm.m_shared_group->end_read();
-        realm.m_group = &const_cast<Group&>(realm.m_shared_group->begin_read(version));
-    }
+    realm.begin_read(version);
     return *realm.m_group;
 }

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -745,12 +745,8 @@ uint64_t Realm::get_schema_version(const Realm::Config &config)
 
 void Realm::close()
 {
-    // Order matters here: if we're the last Realm instance for this path, we
-    // need to tear down the coordinator before destroying our shared group
-    // to maintain the coordinator's invariant that there be a continuous session
     if (m_coordinator) {
         m_coordinator->unregister_realm(this);
-        m_coordinator = nullptr;
     }
 
     m_group = nullptr;
@@ -758,6 +754,7 @@ void Realm::close()
     m_history = nullptr;
     m_read_only_group = nullptr;
     m_binding_context = nullptr;
+    m_coordinator = nullptr;
 }
 
 util::Optional<int> Realm::file_format_upgraded_from_version() const

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -188,6 +188,12 @@ public:
                        MigrationFunction migration_function=nullptr,
                        bool in_transaction=false);
 
+    // Set the schema used for this Realm, but do not update the file's schema
+    // if it is not compatible (and instead throw an error).
+    // Cannot be called multiple times on a single Realm instance or an instance
+    // which has already had update_schema() called on it.
+    void set_schema_subset(Schema schema);
+
     // Read the schema version from the file specified by the given config, or
     // ObjectStore::NotVersioned if it does not exist
     static uint64_t get_schema_version(Config const& config);

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -41,17 +41,6 @@
 
 using namespace realm;
 
-class joining_thread {
-public:
-    template<typename... Args>
-    joining_thread(Args&&... args) : m_thread(std::forward<Args>(args)...) { }
-    ~joining_thread() { if (m_thread.joinable()) m_thread.join(); }
-    void join() { m_thread.join(); }
-
-private:
-    std::thread m_thread;
-};
-
 TEST_CASE("notifications: async delivery") {
     _impl::RealmCoordinator::assert_no_open_realms();
 
@@ -127,7 +116,7 @@ TEST_CASE("notifications: async delivery") {
 
         SECTION("refresh() blocks due to initial results not being ready") {
             REQUIRE(notification_calls == 0);
-            joining_thread thread([&] {
+            JoiningThread thread([&] {
                 std::this_thread::sleep_for(std::chrono::microseconds(5000));
                 coordinator->on_change();
             });
@@ -137,7 +126,7 @@ TEST_CASE("notifications: async delivery") {
 
         SECTION("begin_transaction() blocks due to initial results not being ready") {
             REQUIRE(notification_calls == 0);
-            joining_thread thread([&] {
+            JoiningThread thread([&] {
                 std::this_thread::sleep_for(std::chrono::microseconds(5000));
                 coordinator->on_change();
             });
@@ -328,7 +317,7 @@ TEST_CASE("notifications: async delivery") {
 
         SECTION("refresh() blocks") {
             REQUIRE(notification_calls == 1);
-            joining_thread thread([&] {
+            JoiningThread thread([&] {
                 std::this_thread::sleep_for(std::chrono::microseconds(5000));
                 coordinator->on_change();
             });
@@ -337,7 +326,7 @@ TEST_CASE("notifications: async delivery") {
         }
 
         SECTION("refresh() advances to the first version with notifiers ready that is at least a recent as the newest at the time it is called") {
-            joining_thread thread([&] {
+            JoiningThread thread([&] {
                 std::this_thread::sleep_for(std::chrono::microseconds(5000));
                 make_remote_change();
                 coordinator->on_change();
@@ -359,7 +348,7 @@ TEST_CASE("notifications: async delivery") {
 
         SECTION("begin_transaction() blocks") {
             REQUIRE(notification_calls == 1);
-            joining_thread thread([&] {
+            JoiningThread thread([&] {
                 std::this_thread::sleep_for(std::chrono::microseconds(5000));
                 coordinator->on_change();
             });
@@ -409,7 +398,7 @@ TEST_CASE("notifications: async delivery") {
 
         SECTION("refresh() blocks") {
             REQUIRE(notification_calls == 1);
-            joining_thread thread([&] {
+            JoiningThread thread([&] {
                 std::this_thread::sleep_for(std::chrono::microseconds(5000));
                 coordinator->on_change();
             });
@@ -419,7 +408,7 @@ TEST_CASE("notifications: async delivery") {
 
         SECTION("begin_transaction() blocks") {
             REQUIRE(notification_calls == 1);
-            joining_thread thread([&] {
+            JoiningThread thread([&] {
                 std::this_thread::sleep_for(std::chrono::microseconds(5000));
                 coordinator->on_change();
             });

--- a/tests/transaction_log_parsing.cpp
+++ b/tests/transaction_log_parsing.cpp
@@ -564,7 +564,6 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
         }
 
         SECTION("merge_rows() to a new row followed by move_last_over() produces no net change") {
-            size_t new_row;
             auto info = track_changes({false, false, true}, [&] {
                 size_t new_row = table.add_empty_row();
                 table.merge_rows(5, new_row);

--- a/tests/util/test_file.hpp
+++ b/tests/util/test_file.hpp
@@ -37,6 +37,18 @@ static const std::string s_test_token = "eyJpZGVudGl0eSI6InRlc3QiLCAiYWNjZXNzIjo
 
 #endif
 
+class JoiningThread {
+public:
+    template<typename... Args>
+    JoiningThread(Args&&... args) : m_thread(std::forward<Args>(args)...) { }
+    ~JoiningThread() { if (m_thread.joinable()) m_thread.join(); }
+    void join() { m_thread.join(); }
+
+private:
+    std::thread m_thread;
+};
+
+
 struct TestFile : realm::Realm::Config {
     TestFile();
     ~TestFile();


### PR DESCRIPTION
This attempts to generalize all of the schema handling logic to fully work with the idea that a file's schema may be different at different transaction versions, and different Realm instances may be working with different subsets of the schema at the same time.

RealmCoordinator no longer tries to track "the" schema for a file, and instead has a cache of the most recent schema seen, along with the range of transaction versions that it's known to be valid for. This is used to minimize how often we have to introspect the file, as that's an expensive process.

Opening a Realm with different subsets of tables or columns (in additive or read-only mode) on different threads now fully works. This is mostly for the sake of giving operations sensible semantics: it's unlikely that any of the bindings need this, but it's easier to test than trying to figure out what the exact combination of things actually can be done via the bindings and only testing those (and probably missing a few).

SharedRealm now re-reads (usually from the cache) and validates the schema when beginning a new read transaction rather than simply assuming it's still valid, which fixes a crash when it's changed by another process or sync while a Realm instance existed with no read transaction.

The value of the schema returned by `Realm::schema()` has now been made consistent: it used to be either the current schema on disk, an out-of-date version of the schema on disk (but with up-to-date table_columns) or the user-supplied schema (with up-to-date table_columns) depending on what happened to last update it. It is now either exactly the user-supplied schema (with table columns populated), or exactly the schema on disk at the realm's transaction version if no schema has been applied. This fixes some crashes due to property indexes changing when they weren't supposed to, and is a halfway step towards a proper dynamic schema mode.

Since this results in the schema being validated more often, it includes some optimizations to avoid regressions in the obj-c performance tests.