### PR TITLE
Add reconnect() method to SyncManager

### DIFF
--- a/src/sync/impl/sync_client.hpp
+++ b/src/sync/impl/sync_client.hpp
@@ -52,6 +52,10 @@ struct SyncClient {
     }) // Throws
     {
     }
+    
+    void cancel_reconnect_delay() {
+        client.cancel_reconnect_delay();
+    }
 
     void stop()
     {

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -267,6 +267,14 @@ bool SyncManager::client_should_validate_ssl() const noexcept
     return m_client_validate_ssl;
 }
 
+void SyncManager::reconnect()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_sync_client) {
+        m_sync_client->cancel_reconnect_delay();
+    }
+}
+
 util::Logger::Level SyncManager::log_level() const noexcept
 {
     std::lock_guard<std::mutex> lock(m_mutex);

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -86,6 +86,9 @@ public:
     /// Control whether the sync client validates SSL certificates. Should *always* be `true` in production use.
     void set_client_should_validate_ssl(bool validate_ssl);
     bool client_should_validate_ssl() const noexcept;
+    
+    /// Force sync client to reconnect immediately if the connection was lost.
+    void reconnect();
 
     util::Logger::Level log_level() const noexcept;
 

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -45,7 +45,7 @@ bool validate_user_in_vector(std::vector<std::shared_ptr<SyncUser>> vector,
 
 }
 
-TEST_CASE("sync_manager: basic property APIs", "[sync]") {
+TEST_CASE("sync_manager: basic properties and APIs", "[sync]") {
     auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     reset_test_directory(base_path);
     SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoMetadata);
@@ -69,6 +69,10 @@ TEST_CASE("sync_manager: basic property APIs", "[sync]") {
         REQUIRE(SyncManager::shared().client_should_validate_ssl());
         SyncManager::shared().set_client_should_validate_ssl(false);
         REQUIRE(!SyncManager::shared().client_should_validate_ssl());
+    }
+    
+    SECTION("should not crash on 'reconnect()'") {
+        SyncManager::shared().reconnect();
     }
 }
 


### PR DESCRIPTION
This PR adds `reconnect()` method to `SyncManager` that forces sync client to reconnect without a delay after connection is back again.

refs https://github.com/realm/realm-object-store/pull/289
/cc @cmelchior, @bdash, @austinzheng, @fealebenpae 