### PR TITLE
Ignore the schema when resolving an older thread safe reference

### DIFF
--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -814,6 +814,7 @@ T Realm::resolve_thread_safe_reference(ThreadSafeReference<T> reference)
             // Duplicate config for uncached Realm so we don't advance the user's Realm
             Realm::Config config = m_coordinator->get_config();
             config.cache = false;
+            config.schema = util::none;
             SharedRealm temporary_realm = m_coordinator->get_realm(config);
             temporary_realm->begin_read(reference_version);
 


### PR DESCRIPTION
When resolving a thread safe reference, whose `reference_version` is older than `current_version`, remove config's schema as if that is present, it will advance the read transaction.

Not sure if we need tests for that.