### PR TITLE
Fix compilation with Clang 4.0

### DIFF
--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -265,7 +265,14 @@ public:
     Handle& operator=(Handle&& other)
     {
         reset();
-        std::shared_ptr<T>::shared_ptr::operator=(std::move(other));
+        std::shared_ptr<T>::operator=(std::move(other));
+        return *this;
+    }
+
+    Handle& operator=(std::shared_ptr<T>&& other)
+    {
+        reset();
+        std::shared_ptr<T>::operator=(std::move(other));
         return *this;
     }
 

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -38,6 +38,10 @@ class Results;
 class SortDescriptor;
 template <typename T> class ThreadSafeReference;
 
+namespace _impl {
+class ListNotifier;
+}
+
 class List {
 public:
     List() noexcept;
@@ -113,7 +117,7 @@ private:
     std::shared_ptr<Realm> m_realm;
     mutable const ObjectSchema* m_object_schema = nullptr;
     LinkViewRef m_link_view;
-    _impl::CollectionNotifier::Handle<_impl::CollectionNotifier> m_notifier;
+    _impl::CollectionNotifier::Handle<_impl::ListNotifier> m_notifier;
 
     void verify_valid_row(size_t row_ndx, bool insertion = false) const;
 


### PR DESCRIPTION
Add a move assignment operator to `CollectionNotifier::Handle` that takes a `std::shared_ptr<T>` as Clang 4.0 no longer uses the move assignment operator taking a `Handle` in those cases.

Change `List`'s `m_notifier` member to be a handle to the concerete type rather than the base type, matching what `Results` does.