### PR TITLE
Fix bad_version when m_notifiers is empty

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -692,7 +692,9 @@ void RealmCoordinator::run_async_notifiers()
     m_notifiers.insert(m_notifiers.end(), new_notifiers.begin(), new_notifiers.end());
     lock.unlock();
 
-    if (skip_version.version) {
+    // When the notifiers is empty, the m_notifier_sg will be advanced to the latest in open_helper_shared_group(),
+    // but the skip_version might be behind which will cause bad version.
+    if (skip_version.version && !notifiers.empty()) {
         REALM_ASSERT(version >= skip_version);
         IncrementalChangeInfo change_info(*m_notifier_sg, notifiers);
         for (auto& notifier : notifiers)

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -834,6 +834,27 @@ TEST_CASE("notifications: skip") {
         advance_and_notify(*r);
         REQUIRE(calls1 == 2);
     }
+
+    SECTION("removing skipped notifier before it gets the chance to run") {
+        advance_and_notify(*r);
+        REQUIRE(calls1 == 1);
+
+        // Set the skip version
+        make_local_change(token1);
+        // Advance the file to a version after the skip version
+        make_remote_change();
+        REQUIRE(calls1 == 1);
+
+        // Remove the skipped notifier and add an entirely new notifier, so that
+        // notifications need to run but the skip logic shouldn't be used
+        token1 = {};
+        results = {};
+        Results results2(r, table->where());
+        auto token2 = add_callback(results2, calls1, changes1);
+
+        advance_and_notify(*r);
+        REQUIRE(calls1 == 2);
+    }
 }
 
 #if REALM_PLATFORM_APPLE


### PR DESCRIPTION
https://github.com/realm/realm-cocoa/issues/4768
https://github.com/realm/realm-java/issues/4369

When m_notifiers is empty, m_notifier_sg will be advanced to the latest.
But the skip_version might be behind. In this case, bad_version will be
throw when calling advance_to_final().