### PR TITLE
Sleep longer when running Android tests

### DIFF
--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -1024,14 +1024,21 @@ TEST_CASE("SharedRealm: coordinator schema cache") {
 
         // We want to commit the write while we're waiting on the write lock on
         // this thread, which can't really be done in a properly synchronized manner
+        std::chrono::microseconds wait_time{5000};
+#if REALM_ANDROID
+        // When running on device or in an emulator we need to wait longer due
+        // to them being slow
+        wait_time *= 10;
+#endif
+
         JoiningThread thread([&] {
             ExternalWriter writer(config);
             auto table = writer.wt.add_table("class_object 2");
             table->add_column(type_Int, "value");
-            std::this_thread::sleep_for(std::chrono::microseconds(10000));
+            std::this_thread::sleep_for(wait_time * 2);
             writer.wt.commit();
         });
-        std::this_thread::sleep_for(std::chrono::microseconds(5000));
+        std::this_thread::sleep_for(wait_time);
 
         auto tv = cache_tv;
         r->update_schema(Schema{


### PR DESCRIPTION
Unsurprisingly the test which uses sleep for synchronization is a bit unreliable. Increase how long it sleeps for when running on Android to increase the chance of it working, and ignore failures due to the timing not working out correctly.

Fixed #417.