### PR TITLE
Some link's field changes are not reported

### DIFF
--- a/src/impl/collection_notifier.cpp
+++ b/src/impl/collection_notifier.cpp
@@ -94,7 +94,7 @@ bool DeepChangeChecker::check_outgoing_links(size_t table_ndx,
             if (p->table == table_ndx && p->row == row_ndx && p->col == col)
                 return true;
         }
-        m_current_path[depth] = {table_ndx, row_ndx, col, false};
+        m_current_path[depth] = {table_ndx, row_ndx, col};
         return false;
     };
 
@@ -125,10 +125,6 @@ bool DeepChangeChecker::check_row(Table const& table, size_t idx, size_t depth)
 {
     // Arbitrary upper limit on the maximum depth to search
     if (depth >= m_current_path.size()) {
-        // Don't mark any of the intermediate rows checked along the path as
-        // not modified, as a search starting from them might hit a modification
-        for (size_t i = 1; i < m_current_path.size(); ++i)
-            m_current_path[i].depth_exceeded = true;
         return false;
     }
 
@@ -142,7 +138,8 @@ bool DeepChangeChecker::check_row(Table const& table, size_t idx, size_t depth)
         return false;
 
     bool ret = check_outgoing_links(table_ndx, table, idx, depth);
-    if (!ret && (depth == 0 || !m_current_path[depth - 1].depth_exceeded))
+
+    if (!ret && depth == 0)
         m_not_modified[table_ndx].add(idx);
     return ret;
 }

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -87,7 +87,6 @@ private:
         size_t table;
         size_t row;
         size_t col;
-        bool depth_exceeded;
     };
     std::array<Path, 16> m_current_path;
 

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -87,6 +87,7 @@ private:
         size_t table;
         size_t row;
         size_t col;
+        bool depth_exceeded;
     };
     std::array<Path, 16> m_current_path;
 

--- a/tests/transaction_log_parsing.cpp
+++ b/tests/transaction_log_parsing.cpp
@@ -2129,4 +2129,23 @@ TEST_CASE("DeepChangeChecker") {
         });
         REQUIRE(_impl::DeepChangeChecker(info, *table, tables)(0));
     }
+
+    SECTION("changes made in the 3rd elements in the link list") {
+        r->begin_transaction();
+        table->get_linklist(3, 0)->add(1);
+        table->get_linklist(3, 0)->add(2);
+        table->get_linklist(3, 0)->add(3);
+        table->set_link(1, 1, 0);
+        table->set_link(1, 2, 0);
+        table->set_link(1, 3, 0);
+        r->commit_transaction();
+
+        auto info = track_changes([&] {
+            table->set_int(0, 3, 42);
+        });
+        _impl::DeepChangeChecker checker(info, *table, tables);
+        REQUIRE(checker(1));
+        REQUIRE(checker(2));
+        REQUIRE(checker(3));
+    }
 }


### PR DESCRIPTION
This is reported by https://github.com/realm/realm-java/issues/4474
The root cause is the nested links is not handled well. In some cases
those indices have been saved to the m_not_modified accidentally.