### PR TITLE
Fix delivery of notifications for current version when there are later versions

### DIFF
--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -175,6 +175,14 @@ TEST_CASE("notifications: async delivery") {
                 r->cancel_transaction();
             }
         }
+
+        SECTION("is delivered by notify() even if there are later versions") {
+            REQUIRE(notification_calls == 0);
+            coordinator->on_change();
+            make_remote_change();
+            r->notify();
+            REQUIRE(notification_calls == 1);
+        }
     }
 
     advance_and_notify(*r);


### PR DESCRIPTION
advance_to_ready() may be called even if the notifications are for the current version, so it needs to handle that case.

@alazier should fix the GN issue.