### PR TITLE
Silence warnings about WIN32 not being defined when building JS binding on Mac

### DIFF
--- a/src/impl/external_commit_helper.hpp
+++ b/src/impl/external_commit_helper.hpp
@@ -21,7 +21,7 @@
 
 #include <realm/util/features.h>
 
-#if (defined(REALM_HAVE_EPOLL) && REALM_HAVE_EPOLL) || REALM_ANDROID || (defined(REALM_PLATFORM_NODE) && REALM_PLATFORM_NODE && !REALM_PLATFORM_APPLE && !WIN32)
+#if (defined(REALM_HAVE_EPOLL) && REALM_HAVE_EPOLL) || REALM_ANDROID || (defined(REALM_PLATFORM_NODE) && REALM_PLATFORM_NODE && !REALM_PLATFORM_APPLE && !defined(_WIN32))
 #define REALM_USE_EPOLL 1
 #else
 #define REALM_USE_EPOLL 0
@@ -31,7 +31,7 @@
 #include "impl/apple/external_commit_helper.hpp"
 #elif REALM_USE_EPOLL
 #include "impl/epoll/external_commit_helper.hpp"
-#elif WIN32
+#elif defined(_WIN32)
 #include "impl/windows/external_commit_helper.hpp"
 #else
 #include "impl/generic/external_commit_helper.hpp"

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -161,7 +161,7 @@ void Realm::open_with_config(const Config& config,
             };
             shared_group = std::make_unique<SharedGroup>(*history, options);
 
-#if !WIN32
+#ifndef _WIN32
             if (config.should_compact_on_launch_function) {
                 size_t free_space = -1;
                 size_t used_space = -1;

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -127,7 +127,7 @@ public:
     // functions which take a Schema from within the migration function.
     using MigrationFunction = std::function<void (SharedRealm old_realm, SharedRealm realm, Schema&)>;
 
-#if !WIN32
+#ifndef _WIN32
     // A callback function called when opening a SharedRealm when no cached
     // version of this Realm exists. It is passed the total bytes allocated for
     // the file (file size) and the total bytes used by data in the file.
@@ -156,7 +156,7 @@ public:
         uint64_t schema_version = -1;
         MigrationFunction migration_function;
 
-#if !WIN32
+#ifndef _WIN32
         // A callback function called when opening a SharedRealm when no cached
         // version of this Realm exists. It is passed the total bytes allocated for
         // the file (file size) and the total bytes used by data in the file.

--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -27,7 +27,7 @@
 #include <sstream>
 #include <system_error>
 
-#if WIN32
+#ifdef _WIN32
 #include <io.h>
 #include <fcntl.h>
 

--- a/src/util/time.hpp
+++ b/src/util/time.hpp
@@ -31,7 +31,7 @@ namespace util {
 inline std::tm localtime(std::time_t time)
 {
     std::tm calendar_time;
-#if defined(WIN32)
+#ifdef _WIN32
     auto* result = localtime_s(&time, &calendar_time);
 #else
     auto* result = localtime_r(&time, &calendar_time);

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -315,7 +315,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
     }
 
 // The ExternalCommitHelper implementation on Windows doesn't rely on files
-#if !WIN32
+#ifndef _WIN32
     SECTION("should throw when creating the notification pipe fails") {
         util::try_make_dir(config.path + ".note");
         REQUIRE_THROWS(Realm::get_shared_realm(config));
@@ -1062,7 +1062,7 @@ TEST_CASE("SharedRealm: coordinator schema cache") {
     }
 }
 
-#if !WIN32
+#ifndef _WIN32
 TEST_CASE("SharedRealm: compact on launch") {
     // Make compactable Realm
     TestFile config;

--- a/tests/util/test_file.cpp
+++ b/tests/util/test_file.cpp
@@ -33,7 +33,7 @@
 
 #include <cstdlib>
 
-#if WIN32
+#ifdef _WIN32
 #include <io.h>
 #include <fcntl.h>
 


### PR DESCRIPTION
1. Use the `_WIN32` macro to detect building on Windows. This matches what core does, and is consistent with Microsoft's documentation.
2. Test whether `_WIN32` is defined rather than testing its value. Testing its value when its not defined results in a warning with the configuration of some downstream projects.