### PR TITLE
Add support for `updatedAt` property

### DIFF
--- a/src/sync/sync_permission.cpp
+++ b/src/sync/sync_permission.cpp
@@ -63,11 +63,11 @@ Permission::AccessLevel extract_access_level(Object& permission, CppContext& con
 /// Turn a system time point value into the 64-bit integer representing ns since the Unix epoch.
 int64_t ns_since_unix_epoch(const system_clock::time_point& point)
 {
-    tm unix_epoch = {0};
+    tm unix_epoch{};
     unix_epoch.tm_year = 70;
     time_t epoch_time = mktime(&unix_epoch);
-    auto epoch_duration = system_clock::from_time_t(epoch_time).time_since_epoch();
-    return duration_cast<nanoseconds>(point.time_since_epoch() + epoch_duration).count();
+    auto epoch_point = system_clock::from_time_t(epoch_time);
+    return duration_cast<nanoseconds>(point - epoch_point).count();
 }
 
 }

--- a/src/sync/sync_permission.cpp
+++ b/src/sync/sync_permission.cpp
@@ -101,10 +101,11 @@ Permission PermissionResults::get(size_t index)
 {
     Object permission(m_results.get_realm(), m_results.get_object_schema(), m_results.get(index));
     CppContext context;
-    return {
+    return Permission{
         any_cast<std::string>(permission.get_property_value<util::Any>(&context, "path")),
         extract_access_level(permission, context),
-        { any_cast<std::string>(permission.get_property_value<util::Any>(&context, "userId")) }
+        { any_cast<std::string>(permission.get_property_value<util::Any>(&context, "userId")) },
+        any_cast<Timestamp>(permission.get_property_value<util::Any>(&context, "updatedAt"))
     };
 }
 
@@ -170,16 +171,22 @@ void Permissions::set_permission(std::shared_ptr<SyncUser> user,
                                  PermissionChangeCallback callback,
                                  const ConfigMaker& make_config)
 {
+    using namespace std::chrono;
     const auto realm_url = user->server_url() + permission.path;
     auto realm = Permissions::management_realm(std::move(user), make_config);
     CppContext context;
+
+    // Get the current time.
+    int64_t ns_since_epoch = duration_cast<nanoseconds>(system_clock::now().time_since_epoch()).count();
+    int64_t s_arg = ns_since_epoch / (int64_t)Timestamp::nanoseconds_per_second;
+    int32_t ns_arg = ns_since_epoch % Timestamp::nanoseconds_per_second;
 
     // Write the permission object.
     realm->begin_transaction();
     auto raw = Object::create<util::Any>(&context, realm, *realm->schema().find("PermissionChange"), AnyDict{
         { "id", util::uuid_string() },
-        { "createdAt", Timestamp(0, 0) },
-        { "updatedAt", Timestamp(0, 0) },
+        { "createdAt", Timestamp(s_arg, ns_arg) },
+        { "updatedAt", Timestamp(s_arg, ns_arg) },
         { "userId", permission.condition.user_id },
         { "realmUrl", realm_url },
         { "mayRead", permission.access != Permission::AccessLevel::None },

--- a/src/sync/sync_permission.hpp
+++ b/src/sync/sync_permission.hpp
@@ -83,6 +83,8 @@ struct Permission {
         { }
     };
     Condition condition;
+
+    Timestamp updated_at;
 };
 
 class PermissionResults {


### PR DESCRIPTION
Changes:
- Permission change timestamps are now set properly
- `realm::Permission` values now expose an `updated_at` property

Note that this PR is based on top of #440 so that I can continue working on the binding, but will be changed to be on top of master if that previous PR is accepted.