### PR TITLE
Set default value for SSL validation option

### DIFF
--- a/src/sync/sync_config.hpp
+++ b/src/sync/sync_config.hpp
@@ -106,7 +106,7 @@ struct SyncConfig {
     std::function<SyncSessionErrorHandler> error_handler;
     std::shared_ptr<ChangesetTransformer> transformer;
     util::Optional<std::array<char, 64>> realm_encryption_key;
-    bool client_validate_ssl;
+    bool client_validate_ssl = true;
     util::Optional<std::string> ssl_trust_certificate_path;
 #if __GNUC__ < 5
     // GCC 4.9 does not support C++14 braced-init

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -153,7 +153,8 @@ struct sync_session_states::WaitingForAccessToken : public SyncSession::State {
         if (session.m_session_has_been_bound) {
             session.m_session->refresh(std::move(access_token));
         } else {
-            session.m_session->bind(*session.m_server_url, std::move(access_token), session.m_config.client_validate_ssl, session.m_config.ssl_trust_certificate_path);
+            session.m_session->bind(*session.m_server_url, std::move(access_token),
+                                    session.m_config.client_validate_ssl, session.m_config.ssl_trust_certificate_path);
             session.m_session_has_been_bound = true;
         }
 


### PR DESCRIPTION
Changes:
- Set default option so SSL validation is enabled by default
- Code formatting

AFAIK without this change the SSL validation option only defaults to `true` if we use an old version of GCC, which enables the explicitly defined initializer.