### PR TITLE
Expose Apple reachability observer

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -98,6 +98,7 @@ endif()
 if(REALM_ENABLE_SYNC)
     # Add the sync files separately to reduce merge conflicts.
     list(APPEND HEADERS
+        sync/network_reachability_observer.hpp
         sync/sync_config.hpp
         sync/sync_manager.hpp
         sync/sync_permission.hpp

--- a/src/sync/impl/apple/network_reachability_observer.cpp
+++ b/src/sync/impl/apple/network_reachability_observer.cpp
@@ -52,7 +52,6 @@ NetworkReachabilityStatus reachability_status_for_flags(SCNetworkReachabilityFla
 
 NetworkReachabilityObserver& NetworkReachabilityObserver::shared(util::Optional<util::Logger&> logger_ref)
 {
-    // FIXME: is this static property going to screw up our tests?
     static NetworkReachabilityObserver shared;
     if (!shared.start_observing() && logger_ref)
         logger_ref->error("Failed to set up network reachability observer.");

--- a/src/sync/impl/apple/network_reachability_observer.cpp
+++ b/src/sync/impl/apple/network_reachability_observer.cpp
@@ -18,6 +18,8 @@
 
 #include "sync/impl/apple/network_reachability_observer.hpp"
 
+#include <realm/util/logger.hpp>
+
 #if NETWORK_REACHABILITY_AVAILABLE
 
 using namespace realm;
@@ -28,15 +30,15 @@ namespace {
 NetworkReachabilityStatus reachability_status_for_flags(SCNetworkReachabilityFlags flags)
 {
     if (!(flags & kSCNetworkReachabilityFlagsReachable))
-        return NotReachable;
+        return NetworkReachabilityStatus::NotReachable;
 
     if (flags & kSCNetworkReachabilityFlagsConnectionRequired) {
         if (!(flags & kSCNetworkReachabilityFlagsConnectionOnTraffic) ||
             (flags & kSCNetworkReachabilityFlagsInterventionRequired))
-            return NotReachable;
+            return NetworkReachabilityStatus::NotReachable;
     }
 
-    NetworkReachabilityStatus status = ReachableViaWiFi;
+    NetworkReachabilityStatus status = NetworkReachabilityStatus::ReachableViaWiFi;
 
 #if TARGET_OS_IPHONE
     if (flags & kSCNetworkReachabilityFlagsIsWWAN)
@@ -48,10 +50,18 @@ NetworkReachabilityStatus reachability_status_for_flags(SCNetworkReachabilityFla
 
 } // (anonymous namespace)
 
-NetworkReachabilityObserver::NetworkReachabilityObserver(util::Optional<std::string> hostname,
-                                                         std::function<void (const NetworkReachabilityStatus)> handler)
+NetworkReachabilityObserver& NetworkReachabilityObserver::shared(util::Optional<util::Logger&> logger_ref)
+{
+    // FIXME: is this static property going to screw up our tests?
+    static NetworkReachabilityObserver shared;
+    if (!shared.start_observing() && logger_ref)
+        logger_ref->error("Failed to set up network reachability observer.");
+
+    return shared;
+}
+
+NetworkReachabilityObserver::NetworkReachabilityObserver(util::Optional<std::string> hostname)
 : m_callback_queue(dispatch_queue_create("io.realm.sync.reachability", DISPATCH_QUEUE_SERIAL))
-, m_change_handler(std::move(handler))
 {
     if (hostname) {
         m_reachability_ref = util::adoptCF(SystemConfiguration::shared().network_reachability_create_with_name(nullptr,
@@ -79,11 +89,29 @@ NetworkReachabilityStatus NetworkReachabilityObserver::reachability_status() con
     if (SystemConfiguration::shared().network_reachability_get_flags(m_reachability_ref.get(), &flags))
         return reachability_status_for_flags(flags);
 
-    return NotReachable;
+    return NetworkReachabilityStatus::NotReachable;
+}
+
+uint64_t NetworkReachabilityObserver::register_observer(ReachabilityCallback&& callback)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    uint64_t this_token = ++m_latest_token;
+    m_change_handlers[this_token] = callback;
+    return this_token;
+}
+
+void NetworkReachabilityObserver::unregister_observer(uint64_t token)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_change_handlers.erase(token);
 }
 
 bool NetworkReachabilityObserver::start_observing()
 {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_currently_observing)
+        return true;
+
     m_previous_status = reachability_status();
 
     auto callback = [](SCNetworkReachabilityRef, SCNetworkReachabilityFlags, void* self) {
@@ -98,28 +126,38 @@ bool NetworkReachabilityObserver::start_observing()
     if (!SystemConfiguration::shared().network_reachability_set_dispatch_queue(m_reachability_ref.get(), m_callback_queue))
         return false;
 
+    m_currently_observing = true;
     return true;
 }
 
 void NetworkReachabilityObserver::stop_observing()
 {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (!m_currently_observing)
+        return;
+
     SystemConfiguration::shared().network_reachability_set_dispatch_queue(m_reachability_ref.get(), nullptr);
     SystemConfiguration::shared().network_reachability_set_callback(m_reachability_ref.get(), nullptr, nullptr);
 
     // Wait for all previously-enqueued blocks to execute to guarantee that
     // no callback will be called after returning from this method
     dispatch_sync(m_callback_queue, ^{});
+
+    m_currently_observing = false;
 }
 
 void NetworkReachabilityObserver::reachability_changed()
 {
+    std::lock_guard<std::mutex> lock(m_mutex);
     auto current_status = reachability_status();
 
     // When observing reachability of the specific host the callback might be called
     // several times (because of DNS queries) with the same reachability flags while
     // the caller should be notified only when the reachability status is really changed.
     if (current_status != m_previous_status) {
-        m_change_handler(current_status);
+        for (auto& pair : m_change_handlers) {
+            pair.second(current_status);
+        }
         m_previous_status = current_status;
     }
 }

--- a/src/sync/impl/apple/network_reachability_observer.hpp
+++ b/src/sync/impl/apple/network_reachability_observer.hpp
@@ -74,7 +74,7 @@ private:
 
     bool m_currently_observing;
     uint64_t m_latest_token = 0;
-    std::unordered_map<int64_t, ReachabilityCallback> m_change_handlers;
+    std::unordered_map<uint64_t, ReachabilityCallback> m_change_handlers;
 
     util::CFPtr<SCNetworkReachabilityRef> m_reachability_ref;
     NetworkReachabilityStatus m_previous_status;

--- a/src/sync/network_reachability_observer.hpp
+++ b/src/sync/network_reachability_observer.hpp
@@ -1,0 +1,29 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2017 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_OS_NETWORK_REACHABILITY_OBSERVER_HPP
+#define REALM_OS_NETWORK_REACHABILITY_OBSERVER_HPP
+
+#include "sync/network_reachability.hpp"
+
+#if REALM_PLATFORM_APPLE && NETWORK_REACHABILITY_AVAILABLE
+#include "sync/impl/apple/network_reachability_observer.hpp"
+#else
+#endif
+
+#endif // REALM_OS_NETWORK_REACHABILITY_OBSERVER_HPP


### PR DESCRIPTION
Changes:
- Reachability observer is now exposed for binding use
- Reachability observer changed to be singleton
- Reachability observer can now register multiple callbacks, and unregister them
- Updated sync client code