### PR TITLE
Expose the compact api on Win32

### DIFF
--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -161,7 +161,6 @@ void Realm::open_with_config(const Config& config,
             };
             shared_group = std::make_unique<SharedGroup>(*history, options);
 
-#ifndef _WIN32
             if (config.should_compact_on_launch_function) {
                 size_t free_space = -1;
                 size_t used_space = -1;
@@ -174,7 +173,6 @@ void Realm::open_with_config(const Config& config,
                         realm->compact();
                 }
             }
-#endif
         }
     }
     catch (realm::FileFormatUpgradeRequired const&) {

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -133,6 +133,9 @@ public:
     // Return `true` to indicate that an attempt to compact the file should be made
     // if it is possible to do so.
     // Won't compact the file if another process is accessing it.
+    //
+    // WARNING / FIXME: compact() should NOT be exposed publicly on Windows
+    // because it's not crash safe! It may corrupt your database if something fails
     using ShouldCompactOnLaunchFunction = std::function<bool (uint64_t total_bytes, uint64_t used_bytes)>;
 
     struct Config {
@@ -160,6 +163,9 @@ public:
         // Return `true` to indicate that an attempt to compact the file should be made
         // if it is possible to do so.
         // Won't compact the file if another process is accessing it.
+        //
+        // WARNING / FIXME: compact() should NOT be exposed publicly on Windows
+        // because it's not crash safe! It may corrupt your database if something fails
         ShouldCompactOnLaunchFunction should_compact_on_launch_function;
 
         bool read_only() const { return schema_mode == SchemaMode::ReadOnly; }
@@ -230,6 +236,9 @@ public:
     void notify();
 
     void invalidate();
+
+    // WARNING / FIXME: compact() should NOT be exposed publicly on Windows
+    // because it's not crash safe! It may corrupt your database if something fails
     bool compact();
     void write_copy(StringData path, BinaryData encryption_key);
     OwnedBinaryData write_copy();

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -127,7 +127,6 @@ public:
     // functions which take a Schema from within the migration function.
     using MigrationFunction = std::function<void (SharedRealm old_realm, SharedRealm realm, Schema&)>;
 
-#ifndef _WIN32
     // A callback function called when opening a SharedRealm when no cached
     // version of this Realm exists. It is passed the total bytes allocated for
     // the file (file size) and the total bytes used by data in the file.
@@ -135,7 +134,6 @@ public:
     // if it is possible to do so.
     // Won't compact the file if another process is accessing it.
     using ShouldCompactOnLaunchFunction = std::function<bool (uint64_t total_bytes, uint64_t used_bytes)>;
-#endif
 
     struct Config {
         // Path and binary data are mutually exclusive
@@ -156,7 +154,6 @@ public:
         uint64_t schema_version = -1;
         MigrationFunction migration_function;
 
-#ifndef _WIN32
         // A callback function called when opening a SharedRealm when no cached
         // version of this Realm exists. It is passed the total bytes allocated for
         // the file (file size) and the total bytes used by data in the file.
@@ -164,7 +161,6 @@ public:
         // if it is possible to do so.
         // Won't compact the file if another process is accessing it.
         ShouldCompactOnLaunchFunction should_compact_on_launch_function;
-#endif
 
         bool read_only() const { return schema_mode == SchemaMode::ReadOnly; }
 


### PR DESCRIPTION
The .NET assembly isn't aware if we're running on Windows or other platform, so there's no elegant way to prevent it from calling into those missing methods. Furthermore, the other compact methods are not behind and `#ifndef`, so for consistency's sake, we shouldn't hide these either.