### PR TITLE
Object store support for setting permissions by email

### DIFF
--- a/src/sync/sync_permission.cpp
+++ b/src/sync/sync_permission.cpp
@@ -197,10 +197,10 @@ void Permissions::set_permission(std::shared_ptr<SyncUser> user,
         { "id", util::uuid_string() },
         { "createdAt", Timestamp(s_arg, ns_arg) },
         { "updatedAt", Timestamp(s_arg, ns_arg) },
-        { "realmUrl", realm_url },
         // Always set userId as it is required but will be empty for
         // metadata conditions
         { "userId", permission.condition.user_id },
+        { "realmUrl", realm_url },
         { "mayRead", permission.access != Permission::AccessLevel::None },
         { "mayWrite", permission.access == Permission::AccessLevel::Write || permission.access == Permission::AccessLevel::Admin },
         { "mayManage", permission.access == Permission::AccessLevel::Admin },

--- a/src/sync/sync_permission.cpp
+++ b/src/sync/sync_permission.cpp
@@ -198,6 +198,9 @@ void Permissions::set_permission(std::shared_ptr<SyncUser> user,
         { "createdAt", Timestamp(s_arg, ns_arg) },
         { "updatedAt", Timestamp(s_arg, ns_arg) },
         { "realmUrl", realm_url },
+        // Always set userId as it is required but will be empty for
+        // metadata conditions
+        { "userId", permission.condition.user_id },
         { "mayRead", permission.access != Permission::AccessLevel::None },
         { "mayWrite", permission.access == Permission::AccessLevel::Write || permission.access == Permission::AccessLevel::Admin },
         { "mayManage", permission.access == Permission::AccessLevel::Admin },
@@ -205,9 +208,6 @@ void Permissions::set_permission(std::shared_ptr<SyncUser> user,
 
     // Set condition properties based on type
     switch (permission.condition.type) {
-        case Permission::Condition::Type::UserId:
-            raw.set_property_value<util::Any>(&context, "userId", permission.condition.user_id, false);
-            break;
         case Permission::Condition::Type::KeyValue:
             raw.set_property_value<util::Any>(&context, "metadataKey", permission.condition.key_value.first, false);
             raw.set_property_value<util::Any>(&context, "metadataValue", permission.condition.key_value.second, false);
@@ -273,7 +273,7 @@ SharedRealm Permissions::management_realm(std::shared_ptr<SyncUser> user, const 
             Property::make("updatedAt", PropertyType::Date, PrimaryKey::no, Indexed::no, Nullable::no),
             Property::make("statusCode", PropertyType::Int, PrimaryKey::no, Indexed::no, Nullable::yes),
             Property::make("statusMessage", PropertyType::String, PrimaryKey::no, Indexed::no, Nullable::yes),
-            Property::make("userId", PropertyType::String, PrimaryKey::no, Indexed::no, Nullable::yes),
+            Property::make("userId", PropertyType::String, PrimaryKey::no, Indexed::no, Nullable::no),
             Property::make("metadataKey", PropertyType::String, PrimaryKey::no, Indexed::no, Nullable::yes),
             Property::make("metadataValue", PropertyType::String, PrimaryKey::no, Indexed::no, Nullable::yes),
             Property::make("metadataNamespace", PropertyType::String, PrimaryKey::no, Indexed::no, Nullable::yes),

--- a/src/sync/sync_permission.cpp
+++ b/src/sync/sync_permission.cpp
@@ -206,11 +206,11 @@ void Permissions::set_permission(std::shared_ptr<SyncUser> user,
     // Set condition properties based on type
     switch (permission.condition.type) {
         case Permission::Condition::Type::UserId:
-            raw.set_property_value(&context, "userId", permission.condition.user_id, false);
+            raw.set_property_value<util::Any>(&context, "userId", permission.condition.user_id, false);
             break;
         case Permission::Condition::Type::KeyValue:
-            raw.set_property_value(&context, "metadataKey", permission.condition.key_value.first, false);
-            raw.set_property_value(&context, "metadataValue", permission.condition.key_value.second, false);
+            raw.set_property_value<util::Any>(&context, "metadataKey", permission.condition.key_value.first, false);
+            raw.set_property_value<util::Any>(&context, "metadataValue", permission.condition.key_value.second, false);
             break;
         default:
             break;

--- a/src/sync/sync_permission.hpp
+++ b/src/sync/sync_permission.hpp
@@ -72,6 +72,8 @@ struct Permission {
         std::string user_id;
         std::pair<std::string, std::string> key_value;
 
+        Condition() {}
+
         Condition(std::string id)
         : type(Type::UserId)
         , user_id(std::move(id))


### PR DESCRIPTION
Needs https://github.com/realm/realm-object-server/pull/1137 to work, but shouldn't break anything as is.

Still needs tests in object store (have tests in JS).