### PR TITLE
Avoid invalidating object schema pointers when the schema has not changed

### DIFF
--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -246,7 +246,16 @@ void Realm::read_schema_from_group_if_needed()
                                     m_schema_transaction_version);
 
     if (m_dynamic_schema) {
-        m_schema = std::move(schema);
+        if (m_schema == schema) {
+            // The structure of the schema hasn't changed. Bring the table column indices up to date.
+            m_schema.copy_table_columns_from(schema);
+        }
+        else {
+            // The structure of the schema has changed, so replace our copy of the schema.
+            // FIXME: This invalidates any pointers to the object schemas within the schema vector,
+            // which will cause problems for anyone that caches such a pointer.
+            m_schema = std::move(schema);
+        }
     }
     else {
         ObjectStore::verify_valid_external_changes(m_schema.compare(schema));
@@ -454,8 +463,11 @@ void Realm::add_schema_change_handler()
     m_group->set_schema_change_notification_handler([&] {
         m_new_schema = ObjectStore::schema_from_group(read_group());
         m_schema_version = ObjectStore::get_schema_version(read_group());
-        if (m_dynamic_schema)
+        if (m_dynamic_schema) {
+            // FIXME: This invalidates any pointers to the object schemas within the schema vector,
+            // which will cause problems for anyone that caches such a pointer.
             m_schema = *m_new_schema;
+        }
         else
             m_schema.copy_table_columns_from(*m_new_schema);
     });


### PR DESCRIPTION
The Cocoa binding stores pointers to `ObjectSchema` instances owned by the `Schema` that the `Realm` instance holds. Replacing the `Schema` invalidates those pointers. To work around the specific issue seen in the Realm Browser we can avoid replacing the schema when it has not changed, which happens whenever new data is written by an external process, whether sync or a different app, while the Browser has a given Realm open. Solving this problem in the face of schema changes will require broader changes (tracked at realm/realm-cocoa#4954).

Related to realm/realm-browser-osx#297 / realm/realm-browser-osx#311.
