### PR TITLE
Change reconnect logic so sessions are revived upon reconnect

### DIFF
--- a/src/sync/impl/sync_client.hpp
+++ b/src/sync/impl/sync_client.hpp
@@ -26,6 +26,7 @@
 
 #include <thread>
 
+#include "sync/sync_manager.hpp"
 #include "sync/impl/network_reachability.hpp"
 
 #if NETWORK_REACHABILITY_AVAILABLE
@@ -58,7 +59,7 @@ struct SyncClient {
 #if NETWORK_REACHABILITY_AVAILABLE
     , m_reachability_observer(none, [=](const NetworkReachabilityStatus status) {
         if (status != NotReachable)
-            cancel_reconnect_delay();
+            SyncManager::shared().reconnect();
     })
     {
         if (!m_reachability_observer.start_observing())

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -278,6 +278,13 @@ void SyncManager::reconnect()
     }
 }
 
+void SyncManager::cancel_reconnect_delay()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_sync_client)
+        m_sync_client->cancel_reconnect_delay();
+}
+
 util::Logger::Level SyncManager::log_level() const noexcept
 {
     std::lock_guard<std::mutex> lock(m_mutex);

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -263,9 +263,18 @@ bool SyncManager::client_should_reconnect_immediately() const noexcept
 
 void SyncManager::reconnect()
 {
-    std::lock_guard<std::mutex> lock(m_mutex);
-    if (m_sync_client) {
-        m_sync_client->cancel_reconnect_delay();
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        if (m_sync_client) {
+            m_sync_client->cancel_reconnect_delay();
+        } else {
+            return;
+        }
+    }
+    // Ask all sessions to revive.
+    std::lock_guard<std::mutex> lock(m_session_mutex);
+    for (auto& it : m_sessions) {
+        it.second->revive_if_needed();
     }
 }
 

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -271,10 +271,10 @@ void SyncManager::reconnect()
             return;
         }
     }
-    // Ask all sessions to revive.
+    // Ask all sessions to process reconnection.
     std::lock_guard<std::mutex> lock(m_session_mutex);
     for (auto& it : m_sessions) {
-        it.second->revive_if_needed();
+        it.second->handle_reconnect();
     }
 }
 

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -88,6 +88,10 @@ public:
     /// Force sync client to reconnect immediately if the connection was lost.
     void reconnect();
 
+    /// Ask sync client to cancel its reconnection delay. This does not ask the sessions to
+    /// perform reconnect-related work (such as refreshing access tokens).
+    void cancel_reconnect_delay();
+
     util::Logger::Level log_level() const noexcept;
 
     std::shared_ptr<SyncSession> get_session(const std::string& path, const SyncConfig& config);

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -184,7 +184,7 @@ struct sync_session_states::WaitingForAccessToken : public SyncSession::State {
     bool revive_if_needed(std::unique_lock<std::mutex>&, SyncSession& session) const override
     {
         session.m_deferred_close = false;
-        return false;
+        return true;
     }
 
     void nonsync_transact_notify(std::unique_lock<std::mutex>&,

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -187,7 +187,7 @@ struct sync_session_states::WaitingForAccessToken : public SyncSession::State {
     bool revive_if_needed(std::unique_lock<std::mutex>&, SyncSession& session) const override
     {
         session.m_deferred_close = false;
-        return true;
+        return false;
     }
 
     void handle_reconnect(std::unique_lock<std::mutex>& lock, SyncSession& session) const override

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -109,6 +109,9 @@ struct SyncSession::State {
     // Returns true iff the session should ask the binding to get a token for `bind()`.
     virtual bool revive_if_needed(std::unique_lock<std::mutex>&, SyncSession&) const { return false; }
 
+    // Perform any work needed to respond to the application regaining network connectivity.
+    virtual void handle_reconnect(std::unique_lock<std::mutex>&, SyncSession&) const { };
+
     // The user that owns this session has been logged out, and the session should take appropriate action.
     virtual void log_out(std::unique_lock<std::mutex>&, SyncSession&) const { }
 
@@ -187,6 +190,14 @@ struct sync_session_states::WaitingForAccessToken : public SyncSession::State {
         return true;
     }
 
+    void handle_reconnect(std::unique_lock<std::mutex>& lock, SyncSession& session) const override
+    {
+        // Ask the binding to retry getting the token for this session.
+        std::shared_ptr<SyncSession> session_ptr = session.shared_from_this();
+        lock.unlock();
+        session.m_config.bind_session_handler(session_ptr->m_realm_path, session_ptr->m_config, session_ptr);
+    }
+
     void nonsync_transact_notify(std::unique_lock<std::mutex>&,
                                  SyncSession& session,
                                  sync::Session::version_type version) const override
@@ -239,6 +250,14 @@ struct sync_session_states::Active : public SyncSession::State {
     void log_out(std::unique_lock<std::mutex>& lock, SyncSession& session) const override
     {
         session.advance_state(lock, inactive);
+    }
+
+    void handle_reconnect(std::unique_lock<std::mutex>& lock, SyncSession& session) const override
+    {
+        // Ask the binding to immediately renew the token for this session.
+        std::shared_ptr<SyncSession> session_ptr = session.shared_from_this();
+        lock.unlock();
+        session.m_config.bind_session_handler(session_ptr->m_realm_path, session_ptr->m_config, session_ptr);
     }
 
     void nonsync_transact_notify(std::unique_lock<std::mutex>&, SyncSession& session,
@@ -663,6 +682,12 @@ void SyncSession::revive_if_needed()
     }
     if (handler)
         handler.value()(m_realm_path, m_config, shared_from_this());
+}
+
+void SyncSession::handle_reconnect()
+{
+    std::unique_lock<std::mutex> lock(m_state_mutex);
+    m_state->handle_reconnect(lock, *this);
 }
 
 void SyncSession::log_out()

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -113,6 +113,9 @@ public:
     // If the sync session is currently `Inactive`, recreate it. Otherwise, a no-op.
     void revive_if_needed();
 
+    // Perform any actions needed in response to regaining network connectivity.
+    void handle_reconnect();
+
     // Give the `SyncSession` a new, valid token, and ask it to refresh the underlying session.
     // If the session can't accept a new token, this method does nothing.
     // Note that, if this is the first time the session will be given a token, `server_url` must


### PR DESCRIPTION
~WIP pending integration with Cocoa changes and manual verification.~ It works

Changes:
- When the reachability system detects network connectivity, the sync manager's `reconnect()` method is now called, rather than directly calling the client cancel delay method.
- The sync manager's `reconnect()` method now asks each session to revive itself if needed.
- If a session is revived in the 'waiting for token' state, the session will now run the login callback. For the Cocoa binding, this simply means that any existing refresh handle will be cancelled and a new one will be created, causing a login request to be sent immediately.