### PR TITLE
Let binding be able to handle sync client error

### DIFF
--- a/src/binding_callback_thread_observer.hpp
+++ b/src/binding_callback_thread_observer.hpp
@@ -19,6 +19,8 @@
 #ifndef REALM_OS_BINDING_CALLBACK_THREAD_OBSERVER_HPP
 #define REALM_OS_BINDING_CALLBACK_THREAD_OBSERVER_HPP
 
+#include <exception>
+
 namespace realm {
 // Interface for bindings interested in registering callbacks before/after the ObjectStore thread runs.
 // This is for example helpful to attach/detach the pthread to the JavaVM in order to be able to perform JNI calls.
@@ -29,6 +31,9 @@ public:
 
     // This method is called just before the thread is being destroyed
     virtual void will_destroy_thread() = 0;
+
+    // This method is called with any exception throws by client.run().
+    virtual void handle_error(std::exception const& e) = 0;
 };
 
 extern BindingCallbackThreadObserver* g_binding_callback_thread_observer;

--- a/src/sync/impl/sync_client.hpp
+++ b/src/sync/impl/sync_client.hpp
@@ -41,21 +41,27 @@ using ReconnectMode = sync::Client::ReconnectMode;
 struct SyncClient {
     sync::Client client;
 
-    SyncClient(std::unique_ptr<util::Logger> logger,
-               ReconnectMode reconnect_mode = ReconnectMode::normal)
-    : client(make_client(*logger, reconnect_mode)) // Throws
-    , m_logger(std::move(logger))
-    , m_thread([this] {
-        if (g_binding_callback_thread_observer)
-            g_binding_callback_thread_observer->did_create_thread();
-
-        auto will_destroy_thread = util::make_scope_exit([&]() noexcept {
-            if (g_binding_callback_thread_observer)
-                g_binding_callback_thread_observer->will_destroy_thread();
-        });
-
-        client.run(); // Throws
-    }) // Throws
+    SyncClient(std::unique_ptr<util::Logger> logger, ReconnectMode reconnect_mode = ReconnectMode::normal)
+        : client(make_client(*logger, reconnect_mode)) // Throws
+        , m_logger(std::move(logger))
+        , m_thread([this] {
+            if (g_binding_callback_thread_observer) {
+                g_binding_callback_thread_observer->did_create_thread();
+                auto will_destroy_thread = util::make_scope_exit([&]() noexcept {
+                    g_binding_callback_thread_observer->will_destroy_thread();
+                });
+                try {
+                    throw std::bad_alloc();
+                    client.run(); // Throws
+                }
+                catch (std::exception const& e) {
+                    g_binding_callback_thread_observer->handle_error(e);
+                }
+            }
+            else {
+                client.run(); // Throws
+            }
+        }) // Throws
 #if NETWORK_REACHABILITY_AVAILABLE
     , m_reachability_observer(none, [=](const NetworkReachabilityStatus status) {
         if (status != NotReachable)

--- a/src/sync/impl/sync_client.hpp
+++ b/src/sync/impl/sync_client.hpp
@@ -51,7 +51,6 @@ struct SyncClient {
                     g_binding_callback_thread_observer->will_destroy_thread();
                 });
                 try {
-                    throw std::bad_alloc();
                     client.run(); // Throws
                 }
                 catch (std::exception const& e) {


### PR DESCRIPTION
This is mostly due to the fact that we don't have too much information
when native exception thrown on Android.
With this at least Android has a chance to print the exception message
when error happens on the sync client thread.