### PR TITLE
Parallelize compilation on Windows

### DIFF
--- a/CMake/CompilerFlags.cmake
+++ b/CMake/CompilerFlags.cmake
@@ -47,6 +47,9 @@ if(MSVC)
         /D_CRT_SECURE_NO_WARNINGS
         /D_SCL_SECURE_NO_WARNINGS
     )
+    add_compile_options(
+        /MP # Enable multi-processor compilation
+    )
 endif()
 
 if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")


### PR DESCRIPTION
Yields 2x speedup on CI when building for plain Windows (UWP already has `/MP` by default).