### PR TITLE
Adjust how property types are defined to support arrays of all types

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -72,6 +72,7 @@ set(HEADERS
     util/compiler.hpp
     util/event_loop_signal.hpp
     util/format.hpp
+    util/tagged_bool.hpp
     util/time.hpp
     util/uuid.hpp)
 

--- a/src/impl/apple/keychain_helper.cpp
+++ b/src/impl/apple/keychain_helper.cpp
@@ -110,6 +110,6 @@ std::vector<char> metadata_realm_encryption_key()
     auto key_bytes = reinterpret_cast<const char *>(CFDataGetBytePtr(key_data.get()));
     return std::vector<char>(key_bytes, key_bytes + key_size);
 }
-    
+
 }
 }

--- a/src/impl/windows/external_commit_helper.cpp
+++ b/src/impl/windows/external_commit_helper.cpp
@@ -72,7 +72,7 @@ void ExternalCommitHelper::listen()
     while (true) {
         DWORD wait_result = WaitForMultipleObjectsEx(handles.size(), handles.data(), false, INFINITE, false);
         switch (wait_result) {
-        case WAIT_OBJECT_0: // event signaled 
+        case WAIT_OBJECT_0: // event signaled
             m_parent.on_change();
             continue;
         case WAIT_OBJECT_0 + 1: // mutex released

--- a/src/object_accessor.hpp
+++ b/src/object_accessor.hpp
@@ -86,6 +86,8 @@ void Object::set_property_value_impl(ContextType& ctx, const Property &property,
     }
 
     if (is_array(property.type)) {
+        if (property.type == PropertyType::LinkingObjects)
+            throw ReadOnlyPropertyException(m_object_schema->name, property.name);
         REALM_ASSERT(property.type == PropertyType::Object);
 
         List list(m_realm, m_row.get_linklist(col));
@@ -130,8 +132,6 @@ void Object::set_property_value_impl(ContextType& ctx, const Property &property,
             table.set_link(col, row, link.get_index(), is_default);
             break;
         }
-        case PropertyType::LinkingObjects:
-            throw ReadOnlyPropertyException(m_object_schema->name, property.name);
         default:
             REALM_COMPILER_HINT_UNREACHABLE();
     }

--- a/src/object_accessor.hpp
+++ b/src/object_accessor.hpp
@@ -148,7 +148,7 @@ ValueType Object::get_property_value_impl(ContextType& ctx, const Property &prop
         return ctx.null_value();
     }
 
-    if (is_array(property.type)) {
+    if (is_array(property.type) && property.type != PropertyType::LinkingObjects) {
         REALM_ASSERT(property.type == PropertyType::Object);
         return ctx.box(List(m_realm, m_row.get_linklist(column)));
     }

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -161,7 +161,7 @@ static void validate_property(Schema const& schema,
     if (is_array(prop.type)) {
         if (prop.type != PropertyType::Object && prop.type != PropertyType::LinkingObjects) {
             exceptions.emplace_back("Property '%1.%2' has unsupported type '%3'.",
-                                    object_name, prop.name, string_for_property_type(prop.type));
+                                    object_name, prop.name, prop.type_string());
         }
     }
     else if (prop.type == PropertyType::LinkingObjects) {
@@ -175,7 +175,7 @@ static void validate_property(Schema const& schema,
                                 object_name, prop.name, string_for_property_type(prop.type));
     }
     else if (prop.type == PropertyType::Object && !is_nullable(prop.type) && !is_array(prop.type)) {
-        exceptions.emplace_back("Property '%1.%2' of type 'Object' must be nullable.", object_name, prop.name);
+        exceptions.emplace_back("Property '%1.%2' of type 'object' must be nullable.", object_name, prop.name);
     }
 
     // check primary keys
@@ -185,7 +185,7 @@ static void validate_property(Schema const& schema,
                                     object_name, prop.name, string_for_property_type(prop.type));
         }
         if (*primary) {
-            exceptions.emplace_back("Properties'%1' and '%2' are both marked as the primary key of '%3'.",
+            exceptions.emplace_back("Properties '%1' and '%2' are both marked as the primary key of '%3'.",
                                     prop.name, (*primary)->name, object_name);
         }
         *primary = &prop;

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -158,9 +158,15 @@ static void validate_property(Schema const& schema,
                               std::vector<ObjectSchemaValidationException>& exceptions)
 {
     // currently only arrays of objects are allowed
-    if (is_array(prop.type) && prop.type != PropertyType::Object) {
-        exceptions.emplace_back("Property '%1.%2' has unsupported type '%3'.",
-                                object_name, prop.name, string_for_property_type(prop.type));
+    if (is_array(prop.type)) {
+        if (prop.type != PropertyType::Object && prop.type != PropertyType::LinkingObjects) {
+            exceptions.emplace_back("Property '%1.%2' has unsupported type '%3'.",
+                                    object_name, prop.name, string_for_property_type(prop.type));
+        }
+    }
+    else if (prop.type == PropertyType::LinkingObjects) {
+        exceptions.emplace_back("Linking Objects property '%1.%2' must be an array.",
+                                object_name, prop.name);
     }
 
     // check nullablity

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -180,7 +180,7 @@ static void validate_property(Schema const& schema,
 
     // check primary keys
     if (prop.is_primary) {
-        if (!prop.type_is_indexable()) {
+        if (prop.type != PropertyType::Int && prop.type != PropertyType::String) {
             exceptions.emplace_back("Property '%1.%2' of type '%3' cannot be made the primary key.",
                                     object_name, prop.name, string_for_property_type(prop.type));
         }

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -73,7 +73,7 @@ PropertyType ObjectSchema::from_core_type(Descriptor const& table, size_t col)
         case type_Link:      return PropertyType::Object | PropertyType::Nullable;
         case type_LinkList:  return PropertyType::Object | PropertyType::Array;
         case type_Table:     return from_core_type(*table.get_subdescriptor(col), 0) | PropertyType::Array;
-        default: REALM_UNREACHABLE(); // FIXME
+        default: REALM_UNREACHABLE();
     }
 }
 

--- a/src/object_schema.hpp
+++ b/src/object_schema.hpp
@@ -25,8 +25,10 @@
 #include <vector>
 
 namespace realm {
+class Descriptor;
 class Group;
 class Schema;
+enum class PropertyType: unsigned char;
 struct ObjectSchemaValidationException;
 struct Property;
 
@@ -60,6 +62,8 @@ public:
     void validate(Schema const& schema, std::vector<ObjectSchemaValidationException>& exceptions) const;
 
     friend bool operator==(ObjectSchema const& a, ObjectSchema const& b);
+
+    static PropertyType from_core_type(Descriptor const& table, size_t col);
 
 private:
     void set_primary_key_property();

--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -102,6 +102,8 @@ void add_index(Table& table, size_t col)
 
 DataType to_core_type(PropertyType type)
 {
+    REALM_ASSERT(type != PropertyType::Object); // Link columns have to be handled differently
+    REALM_ASSERT(type != PropertyType::Any); // Mixed columns can't be created
     switch (type & ~PropertyType::Flags) {
         case PropertyType::Int:    return type_Int;
         case PropertyType::Bool:   return type_Bool;
@@ -110,8 +112,7 @@ DataType to_core_type(PropertyType type)
         case PropertyType::String: return type_String;
         case PropertyType::Date:   return type_Timestamp;
         case PropertyType::Data:   return type_Binary;
-        case PropertyType::Object: return type_Link;
-        default: REALM_TERMINATE("unknown type");
+        default: REALM_COMPILER_HINT_UNREACHABLE();
     }
 }
 

--- a/src/parser/parser.hpp
+++ b/src/parser/parser.hpp
@@ -57,7 +57,7 @@ struct Predicate
         EndsWith,
         Contains
     };
-    
+
     enum class OperatorOption
     {
         None,

--- a/src/parser/query_builder.cpp
+++ b/src/parser/query_builder.cpp
@@ -430,7 +430,7 @@ void do_add_comparison_to_query(Query &query, Predicate::Comparison cmp,
             throw std::logic_error(util::format("Object type '%1' not supported", string_for_property_type(type)));
     }
 }
-  
+
 template<typename T>
 void do_add_null_comparison_to_query(Query &query, Predicate::Operator op, const PropertyExpression &expr)
 {
@@ -446,7 +446,7 @@ void do_add_null_comparison_to_query(Query &query, Predicate::Operator op, const
             throw std::logic_error("Only 'equal' and 'not equal' operators supported when comparing against 'null'.");
     }
 }
-    
+
 template<>
 void do_add_null_comparison_to_query<Binary>(Query &query, Predicate::Operator op, const PropertyExpression &expr)
 {
@@ -463,7 +463,7 @@ void do_add_null_comparison_to_query<Binary>(Query &query, Predicate::Operator o
             throw std::logic_error("Only 'equal' and 'not equal' operators supported when comparing against 'null'.");
     }
 }
-    
+
 template<>
 void do_add_null_comparison_to_query<Link>(Query &query, Predicate::Operator op, const PropertyExpression &expr)
 {
@@ -514,7 +514,7 @@ void do_add_null_comparison_to_query(Query &query, Predicate::Comparison cmp, co
             throw std::logic_error(util::format("Object type '%1' not supported", string_for_property_type(type)));
     }
 }
-    
+
 bool expression_is_null(const parser::Expression &expr, Arguments &args) {
     if (expr.type == parser::Expression::Type::Null) {
         return true;

--- a/src/property.hpp
+++ b/src/property.hpp
@@ -146,19 +146,9 @@ inline constexpr bool is_nullable(PropertyType a)
 static const char *string_for_property_type(PropertyType type)
 {
     if (is_array(type)) {
-        switch (type & ~PropertyType::Flags) {
-            case PropertyType::String: return "[string]";
-            case PropertyType::Int: return "[int]";
-            case PropertyType::Bool: return "[bool]";
-            case PropertyType::Date: return "[date]";
-            case PropertyType::Data: return "[data]";
-            case PropertyType::Double: return "[double]";
-            case PropertyType::Float: return "[float]";
-            case PropertyType::Object: return "[object]";
-            case PropertyType::Any: return "[any]";
-            case PropertyType::LinkingObjects: return "[linking objects]";
-            default: REALM_COMPILER_HINT_UNREACHABLE();
-        }
+        if (type == PropertyType::LinkingObjects)
+            return "linking objects";
+        return "array";
     }
     switch (type & ~PropertyType::Flags) {
         case PropertyType::String: return "string";
@@ -209,8 +199,13 @@ inline bool Property::type_is_nullable() const
 
 inline std::string Property::type_string() const
 {
-    if (is_array(type))
-        return "array<" + object_type + ">";
+    if (is_array(type)) {
+        if (type == PropertyType::Object)
+            return "array<" + object_type + ">";
+        if (type == PropertyType::LinkingObjects)
+            return "linking objects<" + object_type + ">";
+        return std::string("array<") + string_for_property_type(type & ~PropertyType::Flags) + ">";
+    }
     switch (auto base_type = (type & ~PropertyType::Flags)) {
         case PropertyType::Object:
             return "<" + object_type + ">";

--- a/src/property.hpp
+++ b/src/property.hpp
@@ -33,12 +33,13 @@ enum class PropertyType : unsigned char {
     Date   = 4,
     Float  = 5,
     Double = 6,
-    Object = 7,
-    LinkingObjects = 8, // Implies Array
+    Object = 7, // currently must be either Array xor Nullable
+    LinkingObjects = 8, // currently must be Array and not Nullable
 
     // deprecated and remains only for reading old files
     Any    = 9,
 
+    // Flags which can be combined with any of the above types except as noted
     Required  = 0,
     Nullable  = 64,
     Array     = 128,
@@ -203,7 +204,7 @@ inline bool Property::type_is_indexable() const
 
 inline bool Property::type_is_nullable() const
 {
-    return !(is_array(type) && type == PropertyType::Object);
+    return !(is_array(type) && type == PropertyType::Object) && type != PropertyType::LinkingObjects;
 }
 
 inline std::string Property::type_string() const

--- a/src/property.hpp
+++ b/src/property.hpp
@@ -19,145 +19,218 @@
 #ifndef REALM_PROPERTY_HPP
 #define REALM_PROPERTY_HPP
 
+#include "util/compiler.hpp"
+#include "util/tagged_bool.hpp"
+
 #include <string>
 
-#include "util/compiler.hpp"
-
 namespace realm {
-    enum class PropertyType : unsigned char {
-        Int    = 0,
-        Bool   = 1,
-        Float  = 9,
-        Double = 10,
-        String = 2,
-        Data   = 4,
-        Any    = 6, // deprecated and will be removed in the future
-        Date   = 8,
-        Object = 12,
-        Array  = 13,
-        LinkingObjects  = 14,
-    };
+enum class PropertyType : unsigned char {
+    Int    = 0,
+    Bool   = 1,
+    String = 2,
+    Data   = 3,
+    Date   = 4,
+    Float  = 5,
+    Double = 6,
+    Object = 7,
+    LinkingObjects = 8, // Implies Array
 
-    static const char *string_for_property_type(PropertyType type);
+    // deprecated and remains only for reading old files
+    Any    = 9,
 
-    struct Property {
-        std::string name = "";
-        PropertyType type = PropertyType::Int;
-        std::string object_type = "";
-        std::string link_origin_property_name = "";
-        bool is_primary = false;
-        bool is_indexed = false;
-        bool is_nullable = false;
+    Required  = 0,
+    Nullable  = 64,
+    Array     = 128,
+    Flags     = Nullable | Array
+};
 
-        size_t table_column = -1;
-        bool requires_index() const { return is_primary || is_indexed; }
+struct Property {
+    using IsPrimary = util::TaggedBool<class IsPrimaryTag>;
+    using IsIndexed = util::TaggedBool<class IsIndexedTag>;
 
-        bool is_indexable() const
-        {
-            return type == PropertyType::Int
-                || type == PropertyType::Bool
-                || type == PropertyType::Date
-                || type == PropertyType::String;
+    std::string name;
+    PropertyType type = PropertyType::Int;
+    std::string object_type;
+    std::string link_origin_property_name;
+    IsPrimary is_primary = false;
+    IsIndexed is_indexed = false;
+
+    size_t table_column = -1;
+
+    Property() = default;
+
+    Property(std::string name, PropertyType type, IsPrimary primary = false, IsIndexed indexed = false);
+
+    Property(std::string name, PropertyType type, std::string object_type,
+             std::string link_origin_property_name = "");
+
+    Property(Property const&) = default;
+    Property(Property&&) = default;
+    Property& operator=(Property const&) = default;
+    Property& operator=(Property&&) = default;
+
+    bool requires_index() const { return is_primary || is_indexed; }
+
+    bool type_is_indexable() const;
+    bool type_is_nullable() const;
+
+    std::string type_string() const;
+};
+
+template<typename E>
+constexpr auto to_underlying(E e)
+{
+    return static_cast<typename std::underlying_type<E>::type>(e);
+}
+
+inline constexpr PropertyType operator&(PropertyType a, PropertyType b)
+{
+    return static_cast<PropertyType>(to_underlying(a) & to_underlying(b));
+}
+
+inline constexpr PropertyType operator|(PropertyType a, PropertyType b)
+{
+    return static_cast<PropertyType>(to_underlying(a) | to_underlying(b));
+}
+
+inline constexpr PropertyType operator^(PropertyType a, PropertyType b)
+{
+    return static_cast<PropertyType>(to_underlying(a) ^ to_underlying(b));
+}
+
+inline constexpr PropertyType operator~(PropertyType a)
+{
+    return static_cast<PropertyType>(~to_underlying(a));
+}
+
+inline constexpr bool operator==(PropertyType a, PropertyType b)
+{
+    return to_underlying(a & ~PropertyType::Flags) == to_underlying(b & ~PropertyType::Flags);
+}
+
+inline constexpr bool operator!=(PropertyType a, PropertyType b)
+{
+    return !(a == b);
+}
+
+inline PropertyType& operator&=(PropertyType & a, PropertyType b)
+{
+    a = a & b;
+    return a;
+}
+
+inline PropertyType& operator|=(PropertyType & a, PropertyType b)
+{
+    a = a | b;
+    return a;
+}
+
+inline PropertyType& operator^=(PropertyType & a, PropertyType b)
+{
+    a = a ^ b;
+    return a;
+}
+
+inline constexpr bool is_array(PropertyType a)
+{
+    return to_underlying(a & PropertyType::Array) == to_underlying(PropertyType::Array);
+}
+
+inline constexpr bool is_nullable(PropertyType a)
+{
+    return to_underlying(a & PropertyType::Nullable) == to_underlying(PropertyType::Nullable);
+}
+
+static const char *string_for_property_type(PropertyType type)
+{
+    if (is_array(type)) {
+        switch (type & ~PropertyType::Flags) {
+            case PropertyType::String: return "[string]";
+            case PropertyType::Int: return "[int]";
+            case PropertyType::Bool: return "[bool]";
+            case PropertyType::Date: return "[date]";
+            case PropertyType::Data: return "[data]";
+            case PropertyType::Double: return "[double]";
+            case PropertyType::Float: return "[float]";
+            case PropertyType::Object: return "[object]";
+            case PropertyType::Any: return "[any]";
+            case PropertyType::LinkingObjects: return "[linking objects]";
+            default: REALM_COMPILER_HINT_UNREACHABLE();
         }
-
-        bool type_is_nullable() const
-        {
-            return type == PropertyType::Int
-                || type == PropertyType::Bool
-                || type == PropertyType::Float
-                || type == PropertyType::Double
-                || type == PropertyType::Date
-                || type == PropertyType::String
-                || type == PropertyType::Data
-                || type == PropertyType::Object;
-        }
-
-        std::string type_string() const
-        {
-            switch (type) {
-                case PropertyType::Object:
-                    return "<" + object_type + ">";
-                case PropertyType::Array:
-                    return "array<" + object_type + ">";
-                case PropertyType::LinkingObjects:
-                    return "linking objects<" + object_type + ">";
-                default:
-                    return string_for_property_type(type);
-            }
-        }
-
-        enum class Nullable { yes, no };
-        enum class PrimaryKey { yes, no };
-        enum class Indexed { yes, no };
-        static Property make(std::string name, PropertyType type,
-                             PrimaryKey is_primary=PrimaryKey::no,
-                             Indexed is_indexed=Indexed::no,
-                             Nullable is_nullable=Nullable::no)
-        { 
-            return { std::move(name), type, "", "", is_primary == PrimaryKey::yes, is_indexed == Indexed::yes, is_nullable == Nullable::yes };
-        }
-
-#if __GNUC__ < 5
-        // GCC 4.9 does not support C++14 braced-init with NSDMIs
-        Property(std::string name="", PropertyType type=PropertyType::Int,
-                 std::string object_type="", std::string link_origin_property_name="",
-                 bool is_primary=false, bool is_indexed=false, bool is_nullable=false)
-        : name(std::move(name))
-        , type(type)
-        , object_type(std::move(object_type))
-        , link_origin_property_name(std::move(link_origin_property_name))
-        , is_primary(is_primary)
-        , is_indexed(is_indexed)
-        , is_nullable(is_nullable)
-        {
-        }
-#endif
-    };
-
-    inline bool operator==(Property const& lft, Property const& rgt)
-    {
-        // note: not checking table_column
-        // ordered roughly by the cost of the check
-        return lft.type == rgt.type
-            && lft.is_primary == rgt.is_primary
-            && lft.is_nullable == rgt.is_nullable
-            && lft.requires_index() == rgt.requires_index()
-            && lft.name == rgt.name
-            && lft.object_type == rgt.object_type
-            && lft.link_origin_property_name == rgt.link_origin_property_name;
     }
-
-    static const char *string_for_property_type(PropertyType type)
-    {
-        switch (type) {
-            case PropertyType::String:
-                return "string";
-            case PropertyType::Int:
-                return "int";
-            case PropertyType::Bool:
-                return "bool";
-            case PropertyType::Date:
-                return "date";
-            case PropertyType::Data:
-                return "data";
-            case PropertyType::Double:
-                return "double";
-            case PropertyType::Float:
-                return "float";
-            case PropertyType::Any:
-                return "any";
-            case PropertyType::Object:
-                return "object";
-            case PropertyType::Array:
-                return "array";
-            case PropertyType::LinkingObjects:
-                return "linking objects";
-#if __GNUC__ || _MSC_VER
-            default:
-                REALM_COMPILER_HINT_UNREACHABLE();
-#endif
-        }
+    switch (type & ~PropertyType::Flags) {
+        case PropertyType::String: return "string";
+        case PropertyType::Int: return "int";
+        case PropertyType::Bool: return "bool";
+        case PropertyType::Date: return "date";
+        case PropertyType::Data: return "data";
+        case PropertyType::Double: return "double";
+        case PropertyType::Float: return "float";
+        case PropertyType::Object: return "object";
+        case PropertyType::Any: return "any";
+        case PropertyType::LinkingObjects: return "linking objects";
+        default: REALM_COMPILER_HINT_UNREACHABLE();
     }
 }
 
-#endif /* REALM_PROPERTY_HPP */
+inline Property::Property(std::string name, PropertyType type,
+                          IsPrimary primary, IsIndexed indexed)
+: name(std::move(name))
+, type(type)
+, is_primary(primary)
+, is_indexed(indexed)
+{
+}
+
+inline Property::Property(std::string name, PropertyType type,
+                          std::string object_type,
+                          std::string link_origin_property_name)
+: name(std::move(name))
+, type(type)
+, object_type(std::move(object_type))
+, link_origin_property_name(std::move(link_origin_property_name))
+{
+}
+
+inline bool Property::type_is_indexable() const
+{
+    return type == PropertyType::Int
+        || type == PropertyType::Bool
+        || type == PropertyType::Date
+        || type == PropertyType::String;
+}
+
+inline bool Property::type_is_nullable() const
+{
+    return !(is_array(type) && type == PropertyType::Object);
+}
+
+inline std::string Property::type_string() const
+{
+    if (is_array(type))
+        return "array<" + object_type + ">";
+    switch (auto base_type = (type & ~PropertyType::Flags)) {
+        case PropertyType::Object:
+            return "<" + object_type + ">";
+        case PropertyType::LinkingObjects:
+            return "linking objects<" + object_type + ">";
+        default:
+            return string_for_property_type(base_type);
+    }
+}
+
+inline bool operator==(Property const& lft, Property const& rgt)
+{
+    // note: not checking table_column
+    // ordered roughly by the cost of the check
+    return to_underlying(lft.type) == to_underlying(rgt.type)
+        && lft.is_primary == rgt.is_primary
+        && lft.requires_index() == rgt.requires_index()
+        && lft.name == rgt.name
+        && lft.object_type == rgt.object_type
+        && lft.link_origin_property_name == rgt.link_origin_property_name;
+}
+} // namespace realm
+
+#endif // REALM_PROPERTY_HPP

--- a/src/results.cpp
+++ b/src/results.cpp
@@ -641,8 +641,8 @@ Results::OutOfBoundsIndexException::OutOfBoundsIndexException(size_t r, size_t c
 
 Results::UnsupportedColumnTypeException::UnsupportedColumnTypeException(size_t column, const Table* table, const char* operation)
 : std::logic_error(util::format("Cannot %1 property '%2': operation not supported for '%3' properties",
-                                  operation, table->get_column_name(column),
-                                  string_for_property_type(static_cast<PropertyType>(table->get_column_type(column)))))
+                                operation, table->get_column_name(column),
+                                string_for_property_type(ObjectSchema::from_core_type(*table->get_descriptor(), column))))
 , column_index(column)
 , column_name(table->get_column_name(column))
 , column_type(table->get_column_type(column))

--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -116,12 +116,15 @@ static void compare(ObjectSchema const& existing_schema,
             changes.emplace_back(schema_change::RemoveProperty{&existing_schema, &current_prop});
             continue;
         }
-        if (current_prop.type != target_prop->type || current_prop.object_type != target_prop->object_type) {
+        if (current_prop.type != target_prop->type ||
+            current_prop.object_type != target_prop->object_type ||
+            is_array(current_prop.type) != is_array(target_prop->type)) {
+
             changes.emplace_back(schema_change::ChangePropertyType{&existing_schema, &current_prop, target_prop});
             continue;
         }
-        if (current_prop.is_nullable != target_prop->is_nullable) {
-            if (current_prop.is_nullable)
+        if (is_nullable(current_prop.type) != is_nullable(target_prop->type)) {
+            if (is_nullable(current_prop.type))
                 changes.emplace_back(schema_change::MakePropertyRequired{&existing_schema, &current_prop});
             else
                 changes.emplace_back(schema_change::MakePropertyNullable{&existing_schema, &current_prop});

--- a/src/sync/impl/apple/system_configuration.cpp
+++ b/src/sync/impl/apple/system_configuration.cpp
@@ -65,7 +65,7 @@ SCNetworkReachabilityRef SystemConfiguration::network_reachability_create_with_a
 {
     if (m_create_with_address)
         return m_create_with_address(allocator, address);
-    
+
     return nullptr;
 }
 

--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -106,7 +106,7 @@ void remove_nonempty_dir(const std::string& path)
     }
     // Delete the directory itself
     try {
-        util::remove_dir(path);    
+        util::remove_dir(path);
     }
     catch (File::NotFound const&) {
     }
@@ -339,7 +339,7 @@ bool SyncFileManager::copy_realm_file(const std::string& old_path, const std::st
             return false;
         }
         File::copy(old_path, new_path);
-    } 
+    }
     catch (File::NotFound const&) {
         return false;
     }

--- a/src/sync/impl/sync_metadata.hpp
+++ b/src/sync/impl/sync_metadata.hpp
@@ -113,8 +113,8 @@ public:
     std::string original_name() const;
 
     // The meaning of this parameter depends on the `Action` specified.
-    // For `BackUpThenDeleteRealm`, it is the absolute path where the backup copy 
-    // of the Realm file found at `original_name()` will be placed. 
+    // For `BackUpThenDeleteRealm`, it is the absolute path where the backup copy
+    // of the Realm file found at `original_name()` will be placed.
     // For all other `Action`s, it is ignored.
     util::Optional<std::string> new_name() const;
 
@@ -195,7 +195,7 @@ public:
                                                      const std::string& local_uuid,
                                                      SyncFileActionMetadata::Action action,
                                                      util::Optional<std::string> new_name=none) const;
-    
+
     /// Construct the metadata manager.
     ///
     /// If the platform supports it, setting `should_encrypt` to `true` and not specifying an encryption key will make

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -180,7 +180,7 @@ bool SyncManager::run_file_action(const SyncFileActionMetadata& md)
             if (!util::File::exists(original_name)) {
                 // The Realm file doesn't exist anymore.
                 return true;
-            } 
+            }
             if (new_name && !util::File::exists(*new_name) && m_file_manager->copy_realm_file(original_name, *new_name)) {
                 // We successfully copied the Realm file to the recovery directory.
                 m_file_manager->remove_realm(original_name);
@@ -385,7 +385,7 @@ std::vector<std::shared_ptr<SyncUser>> SyncManager::all_logged_in_users() const
 std::shared_ptr<SyncUser> SyncManager::get_current_user() const
 {
     std::lock_guard<std::mutex> lock(m_user_mutex);
-    
+
     auto is_active_user = [](auto& el) { return el.second->state() == SyncUser::State::Active; };
     auto it = std::find_if(m_users.begin(), m_users.end(), is_active_user);
     if (it == m_users.end())
@@ -424,7 +424,7 @@ std::string SyncManager::recovery_directory_path() const
 {
     std::lock_guard<std::mutex> lock(m_file_system_mutex);
     REALM_ASSERT(m_file_manager);
-    return m_file_manager->recovery_directory_path();        
+    return m_file_manager->recovery_directory_path();
 }
 
 std::shared_ptr<SyncSession> SyncManager::get_existing_active_session(const std::string& path) const

--- a/src/sync/sync_permission.cpp
+++ b/src/sync/sync_permission.cpp
@@ -34,10 +34,6 @@
 using namespace realm;
 using namespace std::chrono;
 
-using PrimaryKey = Property::PrimaryKey;
-using Indexed = Property::Indexed;
-using Nullable = Property::Nullable;
-
 // MARK: - Utility
 
 namespace {
@@ -191,16 +187,14 @@ void Permissions::set_permission(std::shared_ptr<SyncUser> user,
     // Write the permission object.
     realm->begin_transaction();
     auto raw = Object::create<util::Any>(context, realm, *realm->schema().find("PermissionChange"), AnyDict{
-        { "id", util::uuid_string() },
-        { "createdAt", Timestamp(s_arg, ns_arg) },
-        { "updatedAt", Timestamp(s_arg, ns_arg) },
-        // Always set userId as it is required but will be empty for
-        // metadata conditions
-        { "userId", permission.condition.user_id },
-        { "realmUrl", realm_url },
-        { "mayRead", permission.access != Permission::AccessLevel::None },
-        { "mayWrite", permission.access == Permission::AccessLevel::Write || permission.access == Permission::AccessLevel::Admin },
-        { "mayManage", permission.access == Permission::AccessLevel::Admin },
+        {"id", util::uuid_string()},
+        {"createdAt", Timestamp(s_arg, ns_arg)},
+        {"updatedAt", Timestamp(s_arg, ns_arg)},
+        {"userId", permission.condition.user_id},
+        {"realmUrl", realm_url},
+        {"mayRead", permission.access != Permission::AccessLevel::None},
+        {"mayWrite", permission.access == Permission::AccessLevel::Write || permission.access == Permission::AccessLevel::Admin},
+        {"mayManage", permission.access == Permission::AccessLevel::Admin},
     }, false);
 
     // Set condition properties based on type
@@ -266,20 +260,20 @@ SharedRealm Permissions::management_realm(std::shared_ptr<SyncUser> user, const 
     Realm::Config config = make_config(user, std::move(realm_url));
     config.sync_config->stop_policy = SyncSessionStopPolicy::Immediately;
     config.schema = Schema{
-        { "PermissionChange", {
-            Property::make("id", PropertyType::String, PrimaryKey::yes, Indexed::yes, Nullable::no),
-            Property::make("createdAt", PropertyType::Date, PrimaryKey::no, Indexed::no, Nullable::no),
-            Property::make("updatedAt", PropertyType::Date, PrimaryKey::no, Indexed::no, Nullable::no),
-            Property::make("statusCode", PropertyType::Int, PrimaryKey::no, Indexed::no, Nullable::yes),
-            Property::make("statusMessage", PropertyType::String, PrimaryKey::no, Indexed::no, Nullable::yes),
-            Property::make("userId", PropertyType::String, PrimaryKey::no, Indexed::no, Nullable::no),
-            Property::make("metadataKey", PropertyType::String, PrimaryKey::no, Indexed::no, Nullable::yes),
-            Property::make("metadataValue", PropertyType::String, PrimaryKey::no, Indexed::no, Nullable::yes),
-            Property::make("metadataNamespace", PropertyType::String, PrimaryKey::no, Indexed::no, Nullable::yes),
-            Property::make("realmUrl", PropertyType::String, PrimaryKey::no, Indexed::no, Nullable::no),
-            Property::make("mayRead", PropertyType::Bool, PrimaryKey::no, Indexed::no, Nullable::yes),
-            Property::make("mayWrite", PropertyType::Bool, PrimaryKey::no, Indexed::no, Nullable::yes),
-            Property::make("mayManage", PropertyType::Bool, PrimaryKey::no, Indexed::no, Nullable::yes),
+        {"PermissionChange", {
+            Property{"id",                PropertyType::String, Property::IsPrimary{true}},
+            Property{"createdAt",         PropertyType::Date},
+            Property{"updatedAt",         PropertyType::Date},
+            Property{"statusCode",        PropertyType::Int|PropertyType::Nullable},
+            Property{"statusMessage",     PropertyType::String|PropertyType::Nullable},
+            Property{"userId",            PropertyType::String},
+            Property{"metadataKey",       PropertyType::String|PropertyType::Nullable},
+            Property{"metadataValue",     PropertyType::String|PropertyType::Nullable},
+            Property{"metadataNamespace", PropertyType::String|PropertyType::Nullable},
+            Property{"realmUrl",          PropertyType::String},
+            Property{"mayRead",           PropertyType::Bool|PropertyType::Nullable},
+            Property{"mayWrite",          PropertyType::Bool|PropertyType::Nullable},
+            Property{"mayManage",         PropertyType::Bool|PropertyType::Nullable},
         }}
     };
     config.schema_version = 0;
@@ -295,13 +289,13 @@ SharedRealm Permissions::permission_realm(std::shared_ptr<SyncUser> user, const 
     Realm::Config config = make_config(user, std::move(realm_url));
     config.sync_config->stop_policy = SyncSessionStopPolicy::Immediately;
     config.schema = Schema{
-        { "Permission", {
-            Property::make("updatedAt", PropertyType::Date),
-            Property::make("userId", PropertyType::String),
-            Property::make("path", PropertyType::String),
-            Property::make("mayRead", PropertyType::Bool),
-            Property::make("mayWrite", PropertyType::Bool),
-            Property::make("mayManage", PropertyType::Bool),
+        {"Permission", {
+            {"updatedAt", PropertyType::Date},
+            {"userId", PropertyType::String},
+            {"path", PropertyType::String},
+            {"mayRead", PropertyType::Bool},
+            {"mayWrite", PropertyType::Bool},
+            {"mayManage", PropertyType::Bool},
         }}
     };
     config.schema_version = 0;

--- a/src/util/generic/event_loop_signal.hpp
+++ b/src/util/generic/event_loop_signal.hpp
@@ -33,7 +33,7 @@ extern void (*s_release_eventloop)(GenericEventLoop);
 template<typename Callback>
 class EventLoopSignal {
 public:
-    EventLoopSignal(Callback&& callback) 
+    EventLoopSignal(Callback&& callback)
     : m_callback(std::move(callback))
     , m_eventloop(s_get_eventloop())
     { }
@@ -41,7 +41,7 @@ public:
     void notify() {
         s_post_on_eventloop(m_eventloop, &on_post, this);
     }
-    
+
     ~EventLoopSignal() {
         s_release_eventloop(m_eventloop);
     }
@@ -49,7 +49,7 @@ private:
     static void on_post(const void* user_data) {
         reinterpret_cast<const EventLoopSignal<Callback>*>(user_data)->m_callback();
     }
-    
+
     const Callback m_callback;
     const GenericEventLoop m_eventloop;
 };

--- a/src/util/tagged_bool.hpp
+++ b/src/util/tagged_bool.hpp
@@ -1,0 +1,60 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2017 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_OS_UTIL_TAGGED_BOOL_HPP
+#define REALM_OS_UTIL_TAGGED_BOOL_HPP
+
+#include <type_traits>
+
+namespace realm {
+namespace util {
+// A type factory which defines a type which is implicitly convertable to and
+// from `bool`, but not to other TaggedBool types
+//
+// Usage:
+// using IsIndexed = util::TaggedBool<class IsIndexedTag>;
+// using IsPrimary = util::TaggedBool<class IsPrimaryTag>;
+// void foo(IsIndexed is_indexed, IsPrimary is_primary);
+//
+// foo(IsIndexed{true}, IsPrimary{false}); // compiles
+// foo(IsPrimary{true}, IsIndexed{false}); // doesn't compile
+template <typename Tag>
+struct TaggedBool {
+    // Allow explicit construction from anything convertible to bool
+    constexpr explicit TaggedBool(bool v) : m_value(v) { }
+
+    // Allow implicit construction from *just* bool and not things convertible
+    // to bool (such as other types of tagged bools)
+    template <typename Bool, typename = typename std::enable_if<std::is_same<Bool, bool>::value>::type>
+    constexpr TaggedBool(Bool v) : m_value(v) {}
+
+    constexpr TaggedBool(TaggedBool const& v) : m_value(v.m_value) {}
+
+    constexpr operator bool() const { return m_value; }
+    constexpr TaggedBool operator!() const { return TaggedBool{!m_value}; }
+
+    friend constexpr bool operator==(TaggedBool l, TaggedBool r) { return l.m_value == r.m_value; }
+    friend constexpr bool operator!=(TaggedBool l, TaggedBool r) { return l.m_value != r.m_value; }
+
+private:
+    bool m_value;
+};
+
+}
+}
+#endif // REALM_OS_UTIL_TAGGED_BOOL_HPP

--- a/tests/list.cpp
+++ b/tests/list.cpp
@@ -47,14 +47,14 @@ TEST_CASE("list") {
     auto r = Realm::get_shared_realm(config);
     r->update_schema({
         {"origin", {
-            {"pk", PropertyType::Int, "", "", true},
-            {"array", PropertyType::Array, "target"}
+            {"pk", PropertyType::Int, Property::IsPrimary{true}},
+            {"array", PropertyType::Array|PropertyType::Object, "target"}
         }},
         {"target", {
             {"value", PropertyType::Int}
         }},
         {"other_origin", {
-            {"array", PropertyType::Array, "other_target"}
+            {"array", PropertyType::Array|PropertyType::Object, "other_target"}
         }},
         {"other_target", {
             {"value", PropertyType::Int}

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -275,7 +275,7 @@ TEST_CASE("migration: Automatic") {
                 }},
             };
             Schema schema2 = remove_property(schema1, "object", "link");
-            Property new_property{"link", PropertyType::LinkingObjects, "object2", "inverse"};
+            Property new_property{"link", PropertyType::LinkingObjects|PropertyType::Array, "object2", "inverse"};
             schema2.find("object")->computed_properties.emplace_back(new_property);
 
             REQUIRE_UPDATE_SUCCEEDS(*realm, schema1, 0);
@@ -720,7 +720,7 @@ TEST_CASE("migration: Automatic") {
             {"link target", {
                 {"value", PropertyType::Int},
             }, {
-                {"origin", PropertyType::LinkingObjects, "all types", "object"},
+                {"origin", PropertyType::LinkingObjects|PropertyType::Array, "all types", "object"},
             }},
             {"array target", {
                 {"value", PropertyType::Int},

--- a/tests/object.cpp
+++ b/tests/object.cpp
@@ -47,7 +47,6 @@ struct TestContext : CppContext {
     std::map<std::string, AnyDict> defaults;
 
     using CppContext::CppContext;
-
     TestContext(TestContext& parent, realm::Property const& prop)
     : CppContext(parent, prop)
     , defaults(parent.defaults)
@@ -84,7 +83,7 @@ TEST_CASE("object") {
             {"value 2", PropertyType::Int},
         }},
         {"all types", {
-            {"pk", PropertyType::Int, "", "", true},
+            {"pk", PropertyType::Int, Property::IsPrimary{true}},
             {"bool", PropertyType::Bool},
             {"int", PropertyType::Int},
             {"float", PropertyType::Float},
@@ -92,8 +91,8 @@ TEST_CASE("object") {
             {"string", PropertyType::String},
             {"data", PropertyType::Data},
             {"date", PropertyType::Date},
-            {"object", PropertyType::Object, "link target", "", false, false, true},
-            {"array", PropertyType::Array, "array target"},
+            {"object", PropertyType::Object|PropertyType::Nullable, "link target"},
+            {"array", PropertyType::Object|PropertyType::Array, "array target"},
         }},
         {"link target", {
             {"value", PropertyType::Int},
@@ -104,17 +103,17 @@ TEST_CASE("object") {
             {"value", PropertyType::Int},
         }},
         {"pk after list", {
-            {"array 1", PropertyType::Array, "array target"},
+            {"array 1", PropertyType::Array|PropertyType::Object, "array target"},
             {"int 1", PropertyType::Int},
-            {"pk", PropertyType::Int, "", "", true},
+            {"pk", PropertyType::Int, Property::IsPrimary{true}},
             {"int 2", PropertyType::Int},
-            {"array 2", PropertyType::Array, "array target"},
+            {"array 2", PropertyType::Array|PropertyType::Object, "array target"},
         }},
         {"nullable int pk", {
-            {"pk", PropertyType::Int, "", "", true, true, true},
+            {"pk", PropertyType::Int|PropertyType::Nullable, Property::IsPrimary{true}},
         }},
         {"nullable string pk", {
-            {"pk", PropertyType::String, "", "", true, true, true},
+            {"pk", PropertyType::String|PropertyType::Nullable, Property::IsPrimary{true}},
         }},
     };
     config.schema_version = 0;

--- a/tests/object.cpp
+++ b/tests/object.cpp
@@ -97,7 +97,7 @@ TEST_CASE("object") {
         {"link target", {
             {"value", PropertyType::Int},
         }, {
-            {"origin", PropertyType::LinkingObjects, "all types", "object"},
+            {"origin", PropertyType::LinkingObjects|PropertyType::Array, "all types", "object"},
         }},
         {"array target", {
             {"value", PropertyType::Int},

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -30,6 +30,7 @@
 #include "schema.hpp"
 
 #include "impl/realm_coordinator.hpp"
+#include "util/format.hpp"
 
 #include <realm/group.hpp>
 
@@ -55,7 +56,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
     config.schema_version = 1;
     config.schema = Schema{
         {"object", {
-            {"value", PropertyType::Int, "", "", false, false, false}
+            {"value", PropertyType::Int}
         }},
     };
 
@@ -132,8 +133,8 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
             auto realm = Realm::get_shared_realm(config);
             config.schema = Schema{
                 {"object", {
-                    {"value", PropertyType::Int, "", "", false, false, false},
-                    {"value2", PropertyType::Int, "", "", false, false, false}
+                    {"value", PropertyType::Int},
+                    {"value2", PropertyType::Int}
                 }},
             };
             REQUIRE_THROWS(Realm::get_shared_realm(config));
@@ -165,8 +166,8 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
         config.schema_version = 2;
         config.schema = Schema{
             {"object", {
-                {"value", PropertyType::Int, "", "", false, false, false},
-                {"value2", PropertyType::Int, "", "", false, false, false}
+                {"value", PropertyType::Int},
+                {"value2", PropertyType::Int}
             }},
         };
         bool migration_called = false;
@@ -185,8 +186,8 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
         config.schema_version = 2;
         config.schema = Schema{
             {"object", {
-                {"value", PropertyType::Int, "", "", false, false, false},
-                {"value2", PropertyType::Int, "", "", false, false, false}
+                {"value", PropertyType::Int},
+                {"value2", PropertyType::Int}
             }},
         };
         bool migration_called = false;
@@ -235,10 +236,10 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
 
         config.schema = Schema{
             {"object", {
-                {"value", PropertyType::Int, "", "", false, false, false}
+                {"value", PropertyType::Int}
             }},
             {"object1", {
-                {"value", PropertyType::Int, "", "", false, false, false}
+                {"value", PropertyType::Int}
             }},
         };
         config.schema_version = 1;
@@ -292,7 +293,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
 
         config.schema = Schema{
             {"object 2", {
-                {"value", PropertyType::Int, "", "", false, false, false}
+                {"value", PropertyType::Int}
             }},
         };
         auto realm2 = Realm::get_shared_realm(config);
@@ -302,7 +303,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
 
         config.schema = Schema{
             {"object", {
-                {"value", PropertyType::Int, "", "", false, false, false}
+                {"value", PropertyType::Int}
             }},
         };
         auto realm4 = Realm::get_shared_realm(config);
@@ -392,7 +393,7 @@ TEST_CASE("SharedRealm: notifications") {
     config.schema_version = 0;
     config.schema = Schema{
         {"object", {
-            {"value", PropertyType::Int, "", "", false, false, false}
+            {"value", PropertyType::Int}
         }},
     };
 
@@ -521,8 +522,8 @@ TEST_CASE("SharedRealm: schema updating from external changes") {
     config.schema_mode = SchemaMode::Additive;
     config.schema = Schema{
         {"object", {
-            {"value", PropertyType::Int, "", "", true, false, false},
-            {"value 2", PropertyType::Int, "", "", false, true, false},
+            {"value", PropertyType::Int, Property::IsPrimary{true}},
+            {"value 2", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{true}},
         }},
     };
 
@@ -601,7 +602,7 @@ TEST_CASE("SharedRealm: closed realm") {
     config.schema_version = 1;
     config.schema = Schema{
         {"object", {
-            {"value", PropertyType::Int, "", "", false, false, false}
+            {"value", PropertyType::Int}
         }},
     };
 
@@ -626,7 +627,7 @@ TEST_CASE("ShareRealm: in-memory mode from buffer") {
     config.schema_version = 1;
     config.schema = Schema{
         {"object", {
-            {"value", PropertyType::Int, "", "", false, false, false}
+            {"value", PropertyType::Int}
         }},
     };
 
@@ -672,7 +673,7 @@ TEST_CASE("ShareRealm: realm closed in did_change callback") {
     config.schema_version = 1;
     config.schema = Schema{
         {"object", {
-            {"value", PropertyType::Int, "", "", false, false, false}
+            {"value", PropertyType::Int}
         }},
     };
     config.cache = false;
@@ -1080,8 +1081,8 @@ TEST_CASE("SharedRealm: dynamic schema mode doesn't invalidate object schema poi
     config_with_schema.schema_mode = SchemaMode::Automatic;
     config_with_schema.schema = Schema{
         {"object", {
-            {"value", PropertyType::Int, "", "", true, false, false},
-            {"value 2", PropertyType::Int, "", "", false, true, false},
+            {"value", PropertyType::Int, Property::IsPrimary{true}},
+            {"value 2", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{true}},
         }}
     };
     auto r1 = Realm::get_shared_realm(config_with_schema);
@@ -1113,15 +1114,15 @@ TEST_CASE("SharedRealm: compact on launch") {
     };
     config.schema = Schema{
         {"object", {
-            {"value", PropertyType::String, "", "", false, false, false}
+            {"value", PropertyType::String}
         }},
     };
     auto r = Realm::get_shared_realm(config);
     r->begin_transaction();
     auto table = r->read_group().get_table("class_object");
-    int count = 1000;
+    size_t count = 1000;
     table->add_empty_row(count);
-    for (int i = 0; i < count; ++i)
+    for (size_t i = 0; i < count; ++i)
         table->set_string(0, i, util::format("Foo_%1", i % 10).c_str());
     r->commit_transaction();
     REQUIRE(table->size() == count);
@@ -1173,7 +1174,7 @@ TEMPLATE_TEST_CASE("SharedRealm: update_schema with initialization_function",
 
     Schema schema{
         {"object", {
-            {"value", PropertyType::String, "", "", false, false, false}
+            {"value", PropertyType::String}
         }},
     };
 

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -145,7 +145,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
         config.schema = Schema{
             {"object",
                 {{"value", PropertyType::Int}},
-                {{"invalid backlink", PropertyType::LinkingObjects, "object", "value"}}
+                {{"invalid backlink", PropertyType::LinkingObjects|PropertyType::Array, "object", "value"}}
             }
         };
         REQUIRE_THROWS_WITH(Realm::get_shared_realm(config),

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -1091,13 +1091,13 @@ TEST_CASE("notifications: results") {
     r->update_schema({
         {"object", {
             {"value", PropertyType::Int},
-            {"link", PropertyType::Object, "linked to object", "", false, false, true}
+            {"link", PropertyType::Object|PropertyType::Nullable, "linked to object"}
         }},
         {"other object", {
             {"value", PropertyType::Int}
         }},
         {"linking object", {
-            {"link", PropertyType::Object, "object", "", false, false, true}
+            {"link", PropertyType::Object|PropertyType::Nullable, "object"}
         }},
         {"linked to object", {
             {"value", PropertyType::Int}
@@ -1788,7 +1788,7 @@ TEST_CASE("results: snapshots") {
     config.schema = Schema{
         {"object", {
             {"value", PropertyType::Int},
-            {"array", PropertyType::Array, "linked to object"}
+            {"array", PropertyType::Array|PropertyType::Object, "linked to object"}
         }},
         {"linked to object", {
             {"value", PropertyType::Int}
@@ -2517,13 +2517,13 @@ TEMPLATE_TEST_CASE("results: aggregate", ResultsFromTable, ResultsFromQuery, Res
     auto r = Realm::get_shared_realm(config);
     r->update_schema({
         {"object", {
-            {"int", PropertyType::Int, "", "", false, false, true},
-            {"float", PropertyType::Float,  "", "", false, false, true},
-            {"double", PropertyType::Double, "", "", false, false, true},
-            {"date", PropertyType::Date, "", "", false, false, true},
+            {"int", PropertyType::Int|PropertyType::Nullable},
+            {"float", PropertyType::Float|PropertyType::Nullable},
+            {"double", PropertyType::Double|PropertyType::Nullable},
+            {"date", PropertyType::Date|PropertyType::Nullable},
         }},
         {"linking_object", {
-            {"link", PropertyType::Array, "object", "", false, false, false}
+            {"link", PropertyType::Array|PropertyType::Object, "object"}
         }},
     });
 

--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -143,40 +143,40 @@ TEST_CASE("ObjectSchema") {
         REQUIRE(os.property_for_name("nonexistent property") == nullptr);
 
         // bools are (primary, indexed, nullable)
-        REQUIRE_PROPERTY("pk", Int, "", "",true, false, false);
+        REQUIRE_PROPERTY("pk", Int, Property::IsPrimary{true});
 
-        REQUIRE_PROPERTY("int", Int, "", "", false, false, false);
-        REQUIRE_PROPERTY("bool", Bool, "", "", false, false, false);
-        REQUIRE_PROPERTY("float", Float, "", "", false, false, false);
-        REQUIRE_PROPERTY("double", Double, "", "", false, false, false);
-        REQUIRE_PROPERTY("string", String, "", "", false, false, false);
-        REQUIRE_PROPERTY("data", Data, "", "", false, false, false);
-        REQUIRE_PROPERTY("date", Date, "", "", false, false, false);
+        REQUIRE_PROPERTY("int", Int);
+        REQUIRE_PROPERTY("bool", Bool);
+        REQUIRE_PROPERTY("float", Float);
+        REQUIRE_PROPERTY("double", Double);
+        REQUIRE_PROPERTY("string", String);
+        REQUIRE_PROPERTY("data", Data);
+        REQUIRE_PROPERTY("date", Date);
 
-        REQUIRE_PROPERTY("object", Object, "target", "", false, false, true);
-        REQUIRE_PROPERTY("array", Array, "target", "", false, false, false);
+        REQUIRE_PROPERTY("object", Object|PropertyType::Nullable, "target");
+        REQUIRE_PROPERTY("array", Array|PropertyType::Object, "target");
 
-        REQUIRE_PROPERTY("int?", Int, "", "", false, false, true);
-        REQUIRE_PROPERTY("bool?", Bool, "", "", false, false, true);
-        REQUIRE_PROPERTY("float?", Float, "", "", false, false, true);
-        REQUIRE_PROPERTY("double?", Double, "", "", false, false, true);
-        REQUIRE_PROPERTY("string?", String, "", "", false, false, true);
-        REQUIRE_PROPERTY("data?", Data, "", "", false, false, true);
-        REQUIRE_PROPERTY("date?", Date, "", "", false, false, true);
+        REQUIRE_PROPERTY("int?", Int|PropertyType::Nullable);
+        REQUIRE_PROPERTY("bool?", Bool|PropertyType::Nullable);
+        REQUIRE_PROPERTY("float?", Float|PropertyType::Nullable);
+        REQUIRE_PROPERTY("double?", Double|PropertyType::Nullable);
+        REQUIRE_PROPERTY("string?", String|PropertyType::Nullable);
+        REQUIRE_PROPERTY("data?", Data|PropertyType::Nullable);
+        REQUIRE_PROPERTY("date?", Date|PropertyType::Nullable);
 
         // Unsupported column type should be skipped entirely
         REQUIRE(os.property_for_name("subtable") == nullptr);
         ++expected_col;
 
-        REQUIRE_PROPERTY("indexed int", Int, "", "", false, true, false);
-        REQUIRE_PROPERTY("indexed bool", Bool, "", "", false, true, false);
-        REQUIRE_PROPERTY("indexed string", String, "", "", false, true, false);
-        REQUIRE_PROPERTY("indexed date", Date, "", "", false, true, false);
+        REQUIRE_PROPERTY("indexed int", Int, Property::IsPrimary{false}, Property::IsIndexed{true});
+        REQUIRE_PROPERTY("indexed bool", Bool, Property::IsPrimary{false}, Property::IsIndexed{true});
+        REQUIRE_PROPERTY("indexed string", String, Property::IsPrimary{false}, Property::IsIndexed{true});
+        REQUIRE_PROPERTY("indexed date", Date, Property::IsPrimary{false}, Property::IsIndexed{true});
 
-        REQUIRE_PROPERTY("indexed int?", Int, "", "", false, true, true);
-        REQUIRE_PROPERTY("indexed bool?", Bool, "", "", false, true, true);
-        REQUIRE_PROPERTY("indexed string?", String, "", "", false, true, true);
-        REQUIRE_PROPERTY("indexed date?", Date, "", "", false, true, true);
+        REQUIRE_PROPERTY("indexed int?", Int|PropertyType::Nullable, Property::IsPrimary{false}, Property::IsIndexed{true});
+        REQUIRE_PROPERTY("indexed bool?", Bool|PropertyType::Nullable, Property::IsPrimary{false}, Property::IsIndexed{true});
+        REQUIRE_PROPERTY("indexed string?", String|PropertyType::Nullable, Property::IsPrimary{false}, Property::IsIndexed{true});
+        REQUIRE_PROPERTY("indexed date?", Date|PropertyType::Nullable, Property::IsPrimary{false}, Property::IsIndexed{true});
 
         pk->set_string(1, 0, "nonexistent property");
         REQUIRE(ObjectSchema(g, "table").primary_key_property() == nullptr);
@@ -188,7 +188,7 @@ TEST_CASE("Schema") {
         SECTION("rejects link properties with no target object") {
             Schema schema = {
                 {"object", {
-                    {"link", PropertyType::Object, "", "", false, false, true}
+                    {"link", PropertyType::Object|PropertyType::Nullable}
                 }},
             };
             REQUIRE_THROWS(schema.validate());
@@ -197,7 +197,7 @@ TEST_CASE("Schema") {
         SECTION("rejects array properties with no target object") {
             Schema schema = {
                 {"object", {
-                    {"array", PropertyType::Array, "", "", false, false, true}
+                    {"array", PropertyType::Array|PropertyType::Object|PropertyType::Nullable}
                 }},
             };
             REQUIRE_THROWS(schema.validate());
@@ -206,7 +206,7 @@ TEST_CASE("Schema") {
         SECTION("rejects link properties with a target not in the schema") {
             Schema schema = {
                 {"object", {
-                    {"link", PropertyType::Object, "invalid target", "", false, false, true}
+                    {"link", PropertyType::Object|PropertyType::Nullable, "invalid target"}
                 }}
             };
             REQUIRE_THROWS(schema.validate());
@@ -215,7 +215,7 @@ TEST_CASE("Schema") {
         SECTION("rejects array properties with a target not in the schema") {
             Schema schema = {
                 {"object", {
-                    {"array", PropertyType::Array, "invalid target", "", false, false, true}
+                    {"array", PropertyType::Array|PropertyType::Object|PropertyType::Nullable, "invalid target"}
                 }}
             };
             REQUIRE_THROWS(schema.validate());
@@ -224,12 +224,12 @@ TEST_CASE("Schema") {
         SECTION("rejects target object types for non-link properties") {
             Schema schema = {
                 {"object", {
-                    {"int", PropertyType::Int, "", "", false, false, false},
-                    {"bool", PropertyType::Bool, "", "", false, false, false},
-                    {"float", PropertyType::Float, "", "", false, false, false},
-                    {"double", PropertyType::Double, "", "", false, false, false},
-                    {"string", PropertyType::String, "", "", false, false, false},
-                    {"date", PropertyType::Date, "", "", false, false, false},
+                    {"int", PropertyType::Int},
+                    {"bool", PropertyType::Bool},
+                    {"float", PropertyType::Float},
+                    {"double", PropertyType::Double},
+                    {"string", PropertyType::String},
+                    {"date", PropertyType::Date},
                 }}
             };
             for (auto& prop : schema.begin()->persisted_properties) {
@@ -243,7 +243,7 @@ TEST_CASE("Schema") {
         SECTION("rejects non-nullable link properties") {
             Schema schema = {
                 {"object", {
-                    {"link", PropertyType::Object, "target", "", false, false, false}
+                    {"link", PropertyType::Object, "target"}
                 }},
                 {"target", {
                     {"value", PropertyType::Int}
@@ -255,7 +255,7 @@ TEST_CASE("Schema") {
         SECTION("rejects nullable array properties") {
             Schema schema = {
                 {"object", {
-                    {"array", PropertyType::Array, "target", "", false, false, true}
+                    {"array", PropertyType::Array|PropertyType::Object|PropertyType::Nullable, "target"}
                 }},
                 {"target", {
                     {"value", PropertyType::Int}
@@ -267,8 +267,8 @@ TEST_CASE("Schema") {
         SECTION("rejects duplicate primary keys") {
             Schema schema = {
                 {"object", {
-                    {"pk1", PropertyType::Int, "", "", true, false, false},
-                    {"pk2", PropertyType::Int, "", "", true, false, false},
+                    {"pk1", PropertyType::Int, Property::IsPrimary{true}},
+                    {"pk2", PropertyType::Int, Property::IsPrimary{true}},
                 }}
             };
             REQUIRE_THROWS(schema.validate());
@@ -277,11 +277,11 @@ TEST_CASE("Schema") {
         SECTION("rejects indexes for types that cannot be indexed") {
             Schema schema = {
                 {"object", {
-                    {"float", PropertyType::Float, "", "", false, false, false},
-                    {"double", PropertyType::Double, "", "", false, false, false},
-                    {"data", PropertyType::Data, "", "", false, false, false},
-                    {"object", PropertyType::Object, "object", "", false, false, true},
-                    {"array", PropertyType::Array, "object", "", false, false, false},
+                    {"float", PropertyType::Float},
+                    {"double", PropertyType::Double},
+                    {"data", PropertyType::Data},
+                    {"object", PropertyType::Object|PropertyType::Nullable, "object"},
+                    {"array", PropertyType::Array|PropertyType::Object, "object"},
                 }}
             };
             for (auto& prop : schema.begin()->persisted_properties) {
@@ -295,10 +295,10 @@ TEST_CASE("Schema") {
         SECTION("allows indexing types that can be indexed") {
             Schema schema = {
                 {"object", {
-                    {"int", PropertyType::Int, "", "", false, true, false},
-                    {"bool", PropertyType::Bool, "", "", false, true, false},
-                    {"string", PropertyType::String, "", "", false, true, false},
-                    {"date", PropertyType::Date, "", "", false, true, false},
+                    {"int", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{true}},
+                    {"bool", PropertyType::Bool, Property::IsPrimary{false}, Property::IsIndexed{true}},
+                    {"string", PropertyType::String, Property::IsPrimary{false}, Property::IsIndexed{true}},
+                    {"date", PropertyType::Date, Property::IsPrimary{false}, Property::IsIndexed{true}},
                 }}
             };
             REQUIRE_NOTHROW(schema.validate());
@@ -311,15 +311,15 @@ TEST_CASE("Schema") {
         SECTION("add table") {
             Schema schema1 = {
                 {"object 1", {
-                    {"int", PropertyType::Int, "", "", false, false, false},
+                    {"int", PropertyType::Int},
                 }}
             };
             Schema schema2 = {
                 {"object 1", {
-                    {"int", PropertyType::Int, "", "", false, false, false},
+                    {"int", PropertyType::Int},
                 }},
                 {"object 2", {
-                    {"int", PropertyType::Int, "", "", false, false, false},
+                    {"int", PropertyType::Int},
                 }}
             };
             auto obj = &*schema2.find("object 2");
@@ -330,13 +330,13 @@ TEST_CASE("Schema") {
         SECTION("add property") {
             Schema schema1 = {
                 {"object", {
-                    {"int 1", PropertyType::Int, "", "", false, false, false},
+                    {"int 1", PropertyType::Int},
                 }}
             };
             Schema schema2 = {
                 {"object", {
-                    {"int 1", PropertyType::Int, "", "", false, false, false},
-                    {"int 2", PropertyType::Int, "", "", false, false, false},
+                    {"int 1", PropertyType::Int},
+                    {"int 2", PropertyType::Int},
                 }}
             };
             REQUIRE(schema1.compare(schema2) == vec{(AddProperty{&*schema1.find("object"), &schema2.find("object")->persisted_properties[1]})});
@@ -345,13 +345,13 @@ TEST_CASE("Schema") {
         SECTION("remove property") {
             Schema schema1 = {
                 {"object", {
-                    {"int 1", PropertyType::Int, "", "", false, false, false},
-                    {"int 2", PropertyType::Int, "", "", false, false, false},
+                    {"int 1", PropertyType::Int},
+                    {"int 2", PropertyType::Int},
                 }}
             };
             Schema schema2 = {
                 {"object", {
-                    {"int 1", PropertyType::Int, "", "", false, false, false},
+                    {"int 1", PropertyType::Int},
                 }}
             };
             REQUIRE(schema1.compare(schema2) == vec{(RemoveProperty{&*schema1.find("object"), &schema1.find("object")->persisted_properties[1]})});
@@ -360,12 +360,12 @@ TEST_CASE("Schema") {
         SECTION("change property type") {
             Schema schema1 = {
                 {"object", {
-                    {"value", PropertyType::Int, "", "", false, false, false},
+                    {"value", PropertyType::Int},
                 }}
             };
             Schema schema2 = {
                 {"object", {
-                    {"value", PropertyType::Double, "", "", false, false, false},
+                    {"value", PropertyType::Double},
                 }}
             };
             REQUIRE(schema1.compare(schema2) == vec{(ChangePropertyType{
@@ -377,24 +377,24 @@ TEST_CASE("Schema") {
         SECTION("change link target") {
             Schema schema1 = {
                 {"object", {
-                    {"value", PropertyType::Object, "target 1", "", false, false, false},
+                    {"value", PropertyType::Object, "target 1"},
                 }},
                 {"target 1", {
-                    {"value", PropertyType::Int, "", "", false, false, false},
+                    {"value", PropertyType::Int},
                 }},
                 {"target 2", {
-                    {"value", PropertyType::Int, "", "", false, false, false},
+                    {"value", PropertyType::Int},
                 }},
             };
             Schema schema2 = {
                 {"object", {
-                    {"value", PropertyType::Object, "target 2", "", false, false, false},
+                    {"value", PropertyType::Object, "target 2"},
                 }},
                 {"target 1", {
-                    {"value", PropertyType::Int, "", "", false, false, false},
+                    {"value", PropertyType::Int},
                 }},
                 {"target 2", {
-                    {"value", PropertyType::Int, "", "", false, false, false},
+                    {"value", PropertyType::Int},
                 }},
             };
             REQUIRE(schema1.compare(schema2) == vec{(ChangePropertyType{
@@ -406,12 +406,12 @@ TEST_CASE("Schema") {
         SECTION("add index") {
             Schema schema1 = {
                 {"object", {
-                    {"int", PropertyType::Int, "", "", false, false, false},
+                    {"int", PropertyType::Int},
                 }}
             };
             Schema schema2 = {
                 {"object", {
-                    {"int", PropertyType::Int, "", "", false, true, false},
+                    {"int", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{true}},
                 }}
             };
             auto object_schema = &*schema1.find("object");
@@ -421,12 +421,12 @@ TEST_CASE("Schema") {
         SECTION("remove index") {
             Schema schema1 = {
                 {"object", {
-                    {"int", PropertyType::Int, "", "", false, true, false},
+                    {"int", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{true}},
                 }}
             };
             Schema schema2 = {
                 {"object", {
-                    {"int", PropertyType::Int, "", "", false, false, false},
+                    {"int", PropertyType::Int},
                 }}
             };
             auto object_schema = &*schema1.find("object");
@@ -436,12 +436,12 @@ TEST_CASE("Schema") {
         SECTION("add index and make nullable") {
             Schema schema1 = {
                 {"object", {
-                    {"int", PropertyType::Int, "", "", false, false, false},
+                    {"int", PropertyType::Int},
                 }}
             };
             Schema schema2 = {
                 {"object", {
-                    {"int", PropertyType::Int, "", "", false, true, true},
+                    {"int", PropertyType::Int|PropertyType::Nullable, Property::IsPrimary{false}, Property::IsIndexed{true}},
                 }}
             };
             auto object_schema = &*schema1.find("object");
@@ -453,12 +453,12 @@ TEST_CASE("Schema") {
         SECTION("add index and change type") {
             Schema schema1 = {
                 {"object", {
-                    {"value", PropertyType::Int, "", "", false, false, false},
+                    {"value", PropertyType::Int},
                 }}
             };
             Schema schema2 = {
                 {"object", {
-                    {"value", PropertyType::Double, "", "", false, true, false},
+                    {"value", PropertyType::Double, Property::IsPrimary{false}, Property::IsIndexed{true}},
                 }}
             };
             REQUIRE(schema1.compare(schema2) == vec{(ChangePropertyType{
@@ -470,12 +470,12 @@ TEST_CASE("Schema") {
         SECTION("make nullable and change type") {
             Schema schema1 = {
                 {"object", {
-                    {"value", PropertyType::Int, "", "", false, false, false},
+                    {"value", PropertyType::Int},
                 }}
             };
             Schema schema2 = {
                 {"object", {
-                    {"value", PropertyType::Double, "", "", false, false, true},
+                    {"value", PropertyType::Double|PropertyType::Nullable},
                 }}
             };
             REQUIRE(schema1.compare(schema2) == vec{(ChangePropertyType{

--- a/tests/sync/metadata.cpp
+++ b/tests/sync/metadata.cpp
@@ -35,25 +35,6 @@ using SyncAction = SyncFileActionMetadata::Action;
 static const std::string base_path = tmp_dir() + "/realm_objectstore_sync_metadata/";
 static const std::string metadata_path = base_path + "/metadata.realm";
 
-namespace {
-
-Property make_nullable_string_property(const char* name)
-{
-    Property p = {name, PropertyType::String};
-    p.is_nullable = true;
-    return p;
-}
-
-Property make_primary_key_property(const char* name)
-{
-    Property p = {name, PropertyType::String};
-    p.is_indexed = true;
-    p.is_primary = true;
-    return p;
-}
-
-}
-
 TEST_CASE("sync_metadata: migration", "[sync]") {
     reset_test_directory(base_path);
     const std::string identity_1 = "id_1";
@@ -64,15 +45,15 @@ TEST_CASE("sync_metadata: migration", "[sync]") {
 
     const Schema v0_schema{
         {"UserMetadata", {
-            make_primary_key_property("identity"),
+            {"identity", PropertyType::String, Property::IsPrimary{true}},
             {"marked_for_removal", PropertyType::Bool},
-            make_nullable_string_property("auth_server_url"),
-            make_nullable_string_property("user_token"),
+            {"auth_server_url", PropertyType::String|PropertyType::Nullable},
+            {"user_token", PropertyType::String|PropertyType::Nullable},
         }},
         {"FileActionMetadata", {
-            make_primary_key_property("original_name"),
+            {"original_name", PropertyType::String, Property::IsPrimary{true}},
             {"action", PropertyType::Int},
-            make_nullable_string_property("new_name"),
+            {"new_name", PropertyType::String|PropertyType::Nullable},
             {"url", PropertyType::String},
             {"identity", PropertyType::String},
         }},
@@ -80,16 +61,16 @@ TEST_CASE("sync_metadata: migration", "[sync]") {
 
     const Schema v1_schema{
         {"UserMetadata", {
-            make_primary_key_property("identity"),
+            {"identity", PropertyType::String, Property::IsPrimary{true}},
             {"marked_for_removal", PropertyType::Bool},
-            make_nullable_string_property("auth_server_url"),
-            make_nullable_string_property("user_token"),
+            {"auth_server_url", PropertyType::String|PropertyType::Nullable},
+            {"user_token", PropertyType::String|PropertyType::Nullable},
             {"user_is_admin", PropertyType::Bool},
         }},
         {"FileActionMetadata", {
-            make_primary_key_property("original_name"),
+            {"original_name", PropertyType::String, Property::IsPrimary{true}},
             {"action", PropertyType::Int},
-            make_nullable_string_property("new_name"),
+            {"new_name", PropertyType::String|PropertyType::Nullable},
             {"url", PropertyType::String},
             {"identity", PropertyType::String},
         }},

--- a/tests/sync/permission.cpp
+++ b/tests/sync/permission.cpp
@@ -41,7 +41,7 @@ TEST_CASE("`Permission` class", "[sync]") {
 		CHECK(!Permission::paths_are_equivalent("/~/foo", "/~/bar", "user1", "user1"));
 		// Different non-tilde paths.
 		CHECK(!Permission::paths_are_equivalent("/user1/foo", "/user2/bar", "user1", "user1"));
-		// Identical paths and different users for tilde-paths. 
+		// Identical paths and different users for tilde-paths.
 		CHECK(!Permission::paths_are_equivalent("/~/foo", "/~/foo", "user1", "user2"));
 		// First path cannot be turned into second path.
 		CHECK(!Permission::paths_are_equivalent("/~/foo", "/user1/foo", "user2", "user2"));

--- a/tests/sync/session/session.cpp
+++ b/tests/sync/session/session.cpp
@@ -337,7 +337,7 @@ TEST_CASE("sync: error handling", "[sync]") {
     auto user = SyncManager::shared().get_user({ user_id, "https://realm.example.org" }, "not_a_real_token");
     auto session = sync_session(server, user, "/test1e",
                                  [](auto&, auto&) { return s_test_token; },
-                                 [&](auto session, SyncError error) { 
+                                 [&](auto session, SyncError error) {
                                     error_handler(std::move(session), std::move(error));
                                  },
                                  SyncSessionStopPolicy::AfterChangesUploaded,
@@ -591,7 +591,7 @@ TEST_CASE("sync: stable IDs", "[sync]") {
         config.schema_version = 1;
         config.schema = Schema{
             {"object", {
-                {"value", PropertyType::Int, "", "", false, false, false}
+                {"value", PropertyType::Int}
             }},
         };
 

--- a/tests/sync/session/session_util.hpp
+++ b/tests/sync/session/session_util.hpp
@@ -37,7 +37,7 @@ inline bool sessions_are_active(const SyncSession& session)
 inline bool sessions_are_inactive(const SyncSession& session)
 {
     return session.state() == SyncSession::PublicState::Inactive;
-} 
+}
 
 template <typename... S>
 bool sessions_are_active(const SyncSession& session, const S&... s)
@@ -102,7 +102,7 @@ std::shared_ptr<SyncSession> sync_session(SyncServer& server, std::shared_ptr<Sy
         [&, fetch_access_token=std::forward<FetchAccessToken>(fetch_access_token)](const auto& path, const auto& config, auto session) {
             auto token = fetch_access_token(path, config.realm_url);
             session->refresh_access_token(std::move(token), config.realm_url);
-        }, 
+        },
         std::forward<ErrorHandler>(error_handler),
         stop_policy, on_disk_path, std::move(schema), out_config);
 }

--- a/tests/thread_safe_reference.cpp
+++ b/tests/thread_safe_reference.cpp
@@ -49,11 +49,6 @@ static List get_list(Object&& object, size_t column_ndx) {
     return List(object.realm(), object.row().get_linklist(column_ndx));
 }
 
-static Property nullable(Property p) {
-    p.is_nullable = true;
-    return p;
-}
-
 TEST_CASE("thread safe reference") {
     InMemoryTestFile config;
     config.cache = false;
@@ -65,13 +60,13 @@ TEST_CASE("thread safe reference") {
         {"ignore_me", PropertyType::Int}, // Used in tests cases that don't care about the value.
     }});
     static const ObjectSchema string_object({"string_object", {
-        nullable({"value", PropertyType::String}),
+        {"value", PropertyType::String|PropertyType::Nullable},
     }});
     static const ObjectSchema int_object({"int_object", {
         {"value", PropertyType::Int},
     }});
     static const ObjectSchema int_array_object({"int_array_object", {
-        {"value", PropertyType::Array, "int_object"}
+        {"value", PropertyType::Array|PropertyType::Object, "int_object"}
     }});
     r->update_schema({foo_object, string_object, int_object, int_array_object});
 

--- a/tests/transaction_log_parsing.cpp
+++ b/tests/transaction_log_parsing.cpp
@@ -135,7 +135,7 @@ TEST_CASE("Transaction log parsing: schema change validation") {
     r->update_schema({
         {"table", {
             {"unindexed", PropertyType::Int},
-            {"indexed", PropertyType::Int, "", "", false, true}
+            {"indexed", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{true}}
         }},
     });
     r->read_group();
@@ -384,7 +384,7 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
         auto r = Realm::get_shared_realm(config);
         r->update_schema({
             {"table", {
-                {"pk", PropertyType::Int, "", "", true, true},
+                {"pk", PropertyType::Int, Property::IsPrimary{true}},
                 {"value", PropertyType::Int}
             }},
         });
@@ -608,7 +608,7 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
         auto r = Realm::get_shared_realm(config);
         r->update_schema({
             {"origin", {
-                {"array", PropertyType::Array, "target"}
+                {"array", PropertyType::Array|PropertyType::Object, "target"}
             }},
             {"target", {
                 {"value", PropertyType::Int}
@@ -1256,17 +1256,17 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
         auto realm = Realm::get_shared_realm(config);
         realm->update_schema({
             {"origin", {
-                {"pk", PropertyType::Int, "", "", true, true},
-                {"link", PropertyType::Object, "target", "", false, false, true},
-                {"array", PropertyType::Array, "target"}
+                {"pk", PropertyType::Int, Property::IsPrimary{true}},
+                {"link", PropertyType::Object|PropertyType::Nullable, "target"},
+                {"array", PropertyType::Array|PropertyType::Object, "target"}
             }},
             {"origin 2", {
-                {"pk", PropertyType::Int, "", "", true, true},
-                {"link", PropertyType::Object, "target", "", false, false, true},
-                {"array", PropertyType::Array, "target"}
+                {"pk", PropertyType::Int, Property::IsPrimary{true}},
+                {"link", PropertyType::Object|PropertyType::Nullable, "target"},
+                {"array", PropertyType::Array|PropertyType::Object, "target"}
             }},
             {"target", {
-                {"pk", PropertyType::Int, "", "", true, true},
+                {"pk", PropertyType::Int, Property::IsPrimary{true}},
                 {"value 1", PropertyType::Int},
                 {"value 2", PropertyType::Int},
             }},
@@ -1987,9 +1987,9 @@ TEST_CASE("DeepChangeChecker") {
     r->update_schema({
         {"table", {
             {"int", PropertyType::Int},
-            {"link1", PropertyType::Object, "table", "", false, false, true},
-            {"link2", PropertyType::Object, "table", "", false, false, true},
-            {"array", PropertyType::Array, "table"}
+            {"link1", PropertyType::Object|PropertyType::Nullable, "table"},
+            {"link2", PropertyType::Object|PropertyType::Nullable, "table"},
+            {"array", PropertyType::Array|PropertyType::Object, "table"}
         }},
     });
     auto table = r->read_group().get_table("class_table");


### PR DESCRIPTION
More prep work to support arrays of primitives that should have no functional impact.

The primary change here is to turn `PropertyType::Array` into a bitflag that can be added to any of the other property types, rather than its own type which implies `Object`. Since this makes it so that there's no longer a 1:1 correspondence between `PropertyType` and the core data types, it also goes ahead and renumbers the enum values and also makes the nullability another flag rather than a separate boolean on the `Property`.

This also changes how `is_indexed` and `is_primary` are set on `Property` to use a tagged bool type that makes it a compile-time error to pass them in the wrong order. This change isn't directly related, but untangling it from all the changes to the schema definitions in the tests would have taken a while so it's lumped in.