### PR TITLE
Add basic handling for subtable columns

### DIFF
--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -243,11 +243,6 @@ protected:
     size_t current_table() const noexcept { return m_current_table; }
 
 public:
-    bool select_descriptor(int levels, const size_t*)
-    {
-        // subtables not supported
-        return levels == 0;
-    }
 
     bool select_table(size_t group_level_ndx, int, const size_t*) noexcept
     {
@@ -277,6 +272,7 @@ public:
 
     // Non-schema changes are all allowed
     void parse_complete() { }
+    bool select_descriptor(int, const size_t*) { return true; }
     bool select_link_list(size_t, size_t, size_t) { return true; }
     bool insert_empty_rows(size_t, size_t, size_t, bool) { return true; }
     bool erase_rows(size_t, size_t, size_t, bool) { return true; }
@@ -362,25 +358,24 @@ void adjust_ge(std::vector<size_t>& values, size_t i)
 // Extends TransactLogValidator to track changes made to LinkViews
 class TransactLogObserver : public TransactLogValidationMixin, public MarkDirtyMixin<TransactLogObserver> {
     _impl::TransactionChangeInfo& m_info;
-    _impl::CollectionChangeBuilder* m_active = nullptr;
+    _impl::CollectionChangeBuilder* m_active_list = nullptr;
+    _impl::CollectionChangeBuilder* m_active_table = nullptr;
+    _impl::CollectionChangeBuilder* m_active_descriptor = nullptr;
 
-    _impl::CollectionChangeBuilder* get_change()
+    bool m_need_move_info = false;
+    bool m_is_top_level_table = true;
+
+    _impl::CollectionChangeBuilder* find_list(size_t tbl, size_t col, size_t row)
     {
-        auto tbl_ndx = current_table();
-        if (!m_info.track_all && (tbl_ndx >= m_info.table_modifications_needed.size() || !m_info.table_modifications_needed[tbl_ndx]))
-            return nullptr;
-        if (m_info.tables.size() <= tbl_ndx) {
-            m_info.tables.resize(std::max(m_info.tables.size() * 2, tbl_ndx + 1));
+        // When there are multiple source versions there could be multiple
+        // change objects for a single LinkView, in which case we need to use
+        // the last one
+        for (auto it = m_info.lists.rbegin(), end = m_info.lists.rend(); it != end; ++it) {
+            if (it->table_ndx == tbl && it->row_ndx == row && it->col_ndx == col)
+                return it->changes;
         }
-        return &m_info.tables[tbl_ndx];
+        return nullptr;
     }
-
-    bool need_move_info() const
-    {
-        auto tbl_ndx = current_table();
-        return m_info.track_all || (tbl_ndx < m_info.table_moves_needed.size() && m_info.table_moves_needed[tbl_ndx]);
-    }
-
 
 public:
     TransactLogObserver(_impl::TransactionChangeInfo& info)
@@ -388,55 +383,78 @@ public:
 
     void mark_dirty(size_t row, size_t col)
     {
-        if (auto change = get_change())
-            change->modify(row, col);
+        if (m_active_table)
+            m_active_table->modify(row, col);
     }
 
     void parse_complete()
     {
-        for (auto& table : m_info.tables) {
+        for (auto& table : m_info.tables)
             table.parse_complete();
-        }
-        for (auto& list : m_info.lists) {
+        for (auto& list : m_info.lists)
             list.changes->clean_up_stale_moves();
+    }
+
+    bool select_descriptor(int levels, const size_t*) noexcept
+    {
+        if (levels == 0) // schema of selected table is being modified
+            m_active_descriptor = m_active_table;
+        else // schema of subtable is being modified; currently don't need to track this
+            m_active_descriptor = nullptr;
+        return true;
+    }
+
+    bool select_table(size_t group_level_ndx, int len, size_t const* path) noexcept
+    {
+        TransactLogValidationMixin::select_table(group_level_ndx, len, path);
+        m_active_table = nullptr;
+        m_active_descriptor = nullptr;
+        m_is_top_level_table = true;
+
+        if (len > 0) {
+            // ignore changes to subtables for now
+            m_is_top_level_table = false;
+            return true;
         }
+
+        auto tbl_ndx = current_table();
+        if (!m_info.track_all && (tbl_ndx >= m_info.table_modifications_needed.size() || !m_info.table_modifications_needed[tbl_ndx]))
+            return true;
+
+        m_need_move_info = m_info.track_all || (tbl_ndx < m_info.table_moves_needed.size() &&
+                                                m_info.table_moves_needed[tbl_ndx]);
+        if (m_info.tables.size() <= tbl_ndx)
+            m_info.tables.resize(std::max(m_info.tables.size() * 2, tbl_ndx + 1));
+        m_active_table = &m_info.tables[tbl_ndx];
+
+        return true;
     }
 
     bool select_link_list(size_t col, size_t row, size_t)
     {
         mark_dirty(row, col);
-
-        m_active = nullptr;
-        // When there are multiple source versions there could be multiple
-        // change objects for a single LinkView, in which case we need to use
-        // the last one
-        for (auto it = m_info.lists.rbegin(), end = m_info.lists.rend(); it != end; ++it) {
-            if (it->table_ndx == current_table() && it->row_ndx == row && it->col_ndx == col) {
-                m_active = it->changes;
-                break;
-            }
-        }
+        m_active_list = find_list(current_table(), col, row);
         return true;
     }
 
     bool link_list_set(size_t index, size_t, size_t)
     {
-        if (m_active)
-            m_active->modify(index);
+        if (m_active_list)
+            m_active_list->modify(index);
         return true;
     }
 
     bool link_list_insert(size_t index, size_t, size_t)
     {
-        if (m_active)
-            m_active->insert(index);
+        if (m_active_list)
+            m_active_list->insert(index);
         return true;
     }
 
     bool link_list_erase(size_t index, size_t)
     {
-        if (m_active)
-            m_active->erase(index);
+        if (m_active_list)
+            m_active_list->erase(index);
         return true;
     }
 
@@ -454,22 +472,24 @@ public:
 
     bool link_list_clear(size_t old_size)
     {
-        if (m_active)
-            m_active->clear(old_size);
+        if (m_active_list)
+            m_active_list->clear(old_size);
         return true;
     }
 
     bool link_list_move(size_t from, size_t to)
     {
-        if (m_active)
-            m_active->move(from, to);
+        if (m_active_list)
+            m_active_list->move(from, to);
         return true;
     }
 
     bool insert_empty_rows(size_t row_ndx, size_t num_rows_to_insert, size_t, bool)
     {
-        if (auto change = get_change())
-            change->insert(row_ndx, num_rows_to_insert, need_move_info());
+        if (m_active_table)
+            m_active_table->insert(row_ndx, num_rows_to_insert, m_need_move_info);
+        if (!m_is_top_level_table)
+            return true;
         for (auto& list : m_info.lists) {
             if (list.table_ndx == current_table() && list.row_ndx >= row_ndx)
                 list.row_ndx += num_rows_to_insert;
@@ -480,13 +500,17 @@ public:
     bool erase_rows(size_t row_ndx, size_t, size_t prior_num_rows, bool unordered)
     {
         if (!unordered) {
-            if (auto change = get_change())
-                change->deletions.add(row_ndx);
+            if (m_active_table)
+                m_active_table->deletions.add(row_ndx);
             return true;
         }
         REALM_ASSERT(unordered);
         size_t last_row = prior_num_rows - 1;
+        if (m_active_table)
+            m_active_table->move_over(row_ndx, last_row, m_need_move_info);
 
+        if (!m_is_top_level_table)
+            return true;
         for (size_t i = 0; i < m_info.lists.size(); ++i) {
             auto& list = m_info.lists[i];
             if (list.table_ndx != current_table())
@@ -501,13 +525,16 @@ public:
                 list.row_ndx = row_ndx;
         }
 
-        if (auto change = get_change())
-            change->move_over(row_ndx, last_row, need_move_info());
         return true;
     }
 
     bool swap_rows(size_t row_ndx_1, size_t row_ndx_2) {
         REALM_ASSERT(row_ndx_1 < row_ndx_2);
+        if (m_active_table)
+            m_active_table->swap(row_ndx_1, row_ndx_2, m_need_move_info);
+        if (!m_is_top_level_table)
+            return true;
+
         for (auto& list : m_info.lists) {
             if (list.table_ndx == current_table()) {
                 if (list.row_ndx == row_ndx_1)
@@ -516,37 +543,41 @@ public:
                     list.row_ndx = row_ndx_1;
             }
         }
-        if (auto change = get_change())
-            change->swap(row_ndx_1, row_ndx_2, need_move_info());
         return true;
     }
 
     bool merge_rows(size_t from, size_t to)
     {
+        if (m_active_table)
+            m_active_table->subsume(from, to, m_need_move_info);
+        if (!m_is_top_level_table)
+            return true;
         for (auto& list : m_info.lists) {
             if (list.table_ndx == current_table() && list.row_ndx == from)
                 list.row_ndx = to;
         }
-        if (auto change = get_change())
-            change->subsume(from, to, need_move_info());
         return true;
     }
 
     bool clear_table()
     {
         auto tbl_ndx = current_table();
+        if (m_active_table)
+            m_active_table->clear(std::numeric_limits<size_t>::max());
+        if (!m_is_top_level_table)
+            return true;
         auto it = remove_if(begin(m_info.lists), end(m_info.lists),
                             [&](auto const& lv) { return lv.table_ndx == tbl_ndx; });
         m_info.lists.erase(it, end(m_info.lists));
-        if (auto change = get_change())
-            change->clear(std::numeric_limits<size_t>::max());
         return true;
     }
 
     bool insert_column(size_t ndx, DataType, StringData, bool)
     {
-        if (auto change = get_change())
-            change->insert_column(ndx);
+        if (m_active_descriptor)
+            m_active_descriptor->insert_column(ndx);
+        if (m_active_descriptor != m_active_table || !m_is_top_level_table)
+            return true;
         for (auto& list : m_info.lists) {
             if (list.table_ndx == current_table() && list.col_ndx >= ndx)
                 ++list.col_ndx;
@@ -584,8 +615,10 @@ public:
 
     bool move_column(size_t from, size_t to)
     {
-        if (auto change = get_change())
-            change->move_column(from, to);
+        if (m_active_descriptor)
+            m_active_descriptor->move_column(from, to);
+        if (m_active_descriptor != m_active_table || !m_is_top_level_table)
+            return true;
         for (auto& list : m_info.lists) {
             if (list.table_ndx == current_table())
                 adjust_for_move(list.col_ndx, from, to);

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -78,6 +78,9 @@ ObjectSchema::ObjectSchema(Group const& group, StringData name, size_t index) : 
     size_t count = table->get_column_count();
     persisted_properties.reserve(count);
     for (size_t col = 0; col < count; col++) {
+        if (table->get_column_type(col) == type_Table)
+            continue;
+
         Property property;
         property.name = table->get_column_name(col).data();
         property.type = (PropertyType)table->get_column_type(col);

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -575,7 +575,7 @@ TEST_CASE("migration: Automatic") {
                 realm->read_group().get_table("class_object")->add_column(type_Table, "subtable");
                 realm->commit_transaction();
             }
-            // close and reopen the Realm tu ensure it rereads the schema from
+            // close and reopen the Realm to ensure it rereads the schema from
             // the group
 
             auto realm = Realm::get_shared_realm(config);

--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -22,6 +22,7 @@
 #include "property.hpp"
 #include "schema.hpp"
 
+#include <realm/descriptor.hpp>
 #include <realm/group.hpp>
 #include <realm/table.hpp>
 
@@ -110,6 +111,9 @@ TEST_CASE("ObjectSchema") {
         table->add_column(type_Binary, "data?", true);
         table->add_column(type_Timestamp, "date?", true);
 
+        size_t col = table->add_column(type_Table, "subtable");
+        table->get_subdescriptor(col)->add_column(type_Int, "value");
+
         size_t indexed_start = table->get_column_count();
         table->add_column(type_Int, "indexed int");
         table->add_column(type_Bool, "indexed bool");
@@ -158,6 +162,10 @@ TEST_CASE("ObjectSchema") {
         REQUIRE_PROPERTY("string?", String, "", "", false, false, true);
         REQUIRE_PROPERTY("data?", Data, "", "", false, false, true);
         REQUIRE_PROPERTY("date?", Date, "", "", false, false, true);
+
+        // Unsupported column type should be skipped entirely
+        REQUIRE(os.property_for_name("subtable") == nullptr);
+        ++expected_col;
 
         REQUIRE_PROPERTY("indexed int", Int, "", "", false, true, false);
         REQUIRE_PROPERTY("indexed bool", Bool, "", "", false, true, false);


### PR DESCRIPTION
This makes it so that the schema handling and notification code doesn't break entirely when given a file with subtable columns. It doesn't make it possible to actually interact with them, but it should be enough to be able to open a file containing them without any issues.