### PR TITLE
Don't attempt to compact on launch if we're opening a Realm file without a Realm instance

### DIFF
--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -161,7 +161,7 @@ void Realm::open_with_config(const Config& config,
             };
             shared_group = std::make_unique<SharedGroup>(*history, options);
 
-            if (config.should_compact_on_launch_function) {
+            if (realm && config.should_compact_on_launch_function) {
                 size_t free_space = -1;
                 size_t used_space = -1;
                 // getting stats requires committing a write transaction beforehand.

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -1129,5 +1129,9 @@ TEST_CASE("SharedRealm: compact on launch") {
 
     // Validate that the file still contains what it should
     REQUIRE(r->read_group().get_table("class_object")->size() == count);
+
+    // Registering for a collection notification shouldn't crash when compact on launch is used.
+    Results results(r, *r->read_group().get_table("class_object"));
+    results.async([](std::exception_ptr) { });
 }
 #endif


### PR DESCRIPTION
We need a `Realm` instance in order to perform the compaction, and we likely don't care to perform a compaction if it's not being opened as part of creating a `Realm` instance.

Reported in realm/realm-cocoa#4972.

Needs:
- [x] Regression test
