### PR TITLE
Allow changing primary keys inside migrations

### DIFF
--- a/src/impl/object_accessor_impl.hpp
+++ b/src/impl/object_accessor_impl.hpp
@@ -138,6 +138,7 @@ private:
 
 inline util::Any CppContext::box(RowExpr row) const
 {
+    REALM_ASSERT(object_schema);
     return Object(realm, *object_schema, row);
 }
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -21,6 +21,7 @@
 #include "impl/object_notifier.hpp"
 #include "impl/realm_coordinator.hpp"
 #include "object_schema.hpp"
+#include "object_store.hpp"
 #include "util/format.hpp"
 
 using namespace realm;
@@ -51,6 +52,12 @@ ReadOnlyPropertyException::ReadOnlyPropertyException(const std::string& object_t
 
 Object::Object(SharedRealm r, ObjectSchema const& s, RowExpr const& o)
 : m_realm(std::move(r)), m_object_schema(&s), m_row(o) { }
+
+Object::Object(SharedRealm r, StringData object_type, size_t ndx)
+: m_realm(std::move(r))
+, m_object_schema(&*m_realm->schema().find(object_type))
+, m_row(ObjectStore::table_for_object_type(m_realm->read_group(), object_type)->get(ndx))
+{ }
 
 Object::Object() = default;
 Object::~Object() = default;

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -36,6 +36,7 @@ class Object {
 public:
     Object();
     Object(std::shared_ptr<Realm> r, ObjectSchema const& s, RowExpr const& o);
+    Object(std::shared_ptr<Realm> r, StringData object_type, size_t ndx);
 
     Object(Object const&);
     Object(Object&&);
@@ -70,12 +71,23 @@ public:
     template<typename ValueType, typename ContextType>
     static Object create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
                          const ObjectSchema &object_schema, ValueType value,
-                         bool try_update, Row* = nullptr);
+                         bool try_update = false, Row* = nullptr);
+
+    template<typename ValueType, typename ContextType>
+    static Object create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
+                         StringData object_type, ValueType value,
+                         bool try_update = false, Row* = nullptr);
 
     template<typename ValueType, typename ContextType>
     static Object get_for_primary_key(ContextType& ctx,
                                       std::shared_ptr<Realm> const& realm,
                                       const ObjectSchema &object_schema,
+                                      ValueType primary_value);
+
+    template<typename ValueType, typename ContextType>
+    static Object get_for_primary_key(ContextType& ctx,
+                                      std::shared_ptr<Realm> const& realm,
+                                      StringData object_type,
                                       ValueType primary_value);
 
 private:

--- a/src/object_accessor.hpp
+++ b/src/object_accessor.hpp
@@ -163,6 +163,16 @@ ValueType Object::get_property_value_impl(ContextType& ctx, const Property &prop
 
 template<typename ValueType, typename ContextType>
 Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
+                      StringData object_type, ValueType value,
+                      bool try_update, Row* out_row)
+{
+    auto object_schema = realm->schema().find(object_type);
+    REALM_ASSERT(object_schema != realm->schema().end());
+    return create(ctx, realm, *object_schema, value, try_update, out_row);
+}
+
+template<typename ValueType, typename ContextType>
+Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
                       ObjectSchema const& object_schema, ValueType value,
                       bool try_update, Row* out_row)
 {
@@ -240,6 +250,15 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
             object.set_property_value_impl(ctx, prop, *v, try_update, is_default);
     }
     return object;
+}
+
+template<typename ValueType, typename ContextType>
+Object Object::get_for_primary_key(ContextType& ctx, std::shared_ptr<Realm> const& realm,
+                      StringData object_type, ValueType primary_value)
+{
+    auto object_schema = realm->schema().find(object_type);
+    REALM_ASSERT(object_schema != realm->schema().end());
+    return get_for_primary_key(ctx, realm, *object_schema, primary_value);
 }
 
 template<typename ValueType, typename ContextType>

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -432,9 +432,11 @@ void Realm::update_schema(Schema schema, uint64_t version,
         // migration function needs to see the target schema on the "new" Realm
         std::swap(m_schema, schema);
         std::swap(m_schema_version, version);
+        m_in_migration = true;
         auto restore = util::make_scope_exit([&]() noexcept {
             std::swap(m_schema, schema);
             std::swap(m_schema_version, version);
+            m_in_migration = false;
         });
 
         ObjectStore::apply_schema_changes(read_group(), version, m_schema, m_schema_version,

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -145,7 +145,6 @@ public:
         // User-supplied encryption key. Must be either empty or 64 bytes.
         std::vector<char> encryption_key;
 
-
         bool in_memory = false;
         SchemaMode schema_mode = SchemaMode::Automatic;
 
@@ -229,6 +228,8 @@ public:
     void cancel_transaction();
     bool is_in_transaction() const noexcept;
     bool is_in_read_transaction() const { return !!m_group; }
+
+    bool is_in_migration() const noexcept { return m_in_migration; }
 
     bool refresh();
     void set_auto_refresh(bool auto_refresh) { m_auto_refresh = auto_refresh; }
@@ -341,6 +342,11 @@ private:
     // True while sending the notifications caused by advancing the read
     // transaction version, to avoid recursive notifications where possible
     bool m_is_sending_notifications = false;
+
+    // True while we're performing a schema migration via this Realm instance
+    // to allow for different behavior (such as allowing modifications to
+    // primary key values)
+    bool m_in_migration = false;
 
     void begin_read(VersionID);
 

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -25,6 +25,8 @@
 #include "property.hpp"
 #include "schema.hpp"
 
+#include "impl/object_accessor_impl.hpp"
+
 #include <realm/descriptor.hpp>
 #include <realm/group.hpp>
 #include <realm/table.hpp>
@@ -674,6 +676,224 @@ TEST_CASE("migration: Automatic") {
             auto& properties = schema2.find("object")->persisted_properties;
             std::swap(properties[0], properties[1]);
             VERIFY_SCHEMA_IN_MIGRATION(schema2);
+        }
+    }
+
+    SECTION("object accessors inside migrations") {
+        using namespace std::string_literals;
+
+        Schema schema{
+            {"all types", {
+                {"pk", PropertyType::Int, "", "", true},
+                {"bool", PropertyType::Bool},
+                {"int", PropertyType::Int},
+                {"float", PropertyType::Float},
+                {"double", PropertyType::Double},
+                {"string", PropertyType::String},
+                {"data", PropertyType::Data},
+                {"date", PropertyType::Date},
+                {"object", PropertyType::Object, "link target", "", false, false, true},
+                {"array", PropertyType::Array, "array target"},
+            }},
+            {"link target", {
+                {"value", PropertyType::Int},
+            }, {
+                {"origin", PropertyType::LinkingObjects, "all types", "object"},
+            }},
+            {"array target", {
+                {"value", PropertyType::Int},
+            }},
+        };
+
+        InMemoryTestFile config;
+        config.schema_mode = SchemaMode::Automatic;
+        config.schema = schema;
+        auto realm = Realm::get_shared_realm(config);
+
+        CppContext ctx(realm);
+        util::Any values = AnyDict{
+            {"pk", INT64_C(1)},
+            {"bool", true},
+            {"int", INT64_C(5)},
+            {"float", 2.2f},
+            {"double", 3.3},
+            {"string", "hello"s},
+            {"data", "olleh"s},
+            {"date", Timestamp(10, 20)},
+            {"object", AnyDict{{"value", INT64_C(10)}}},
+            {"array", AnyVector{AnyDict{{"value", INT64_C(20)}}}},
+        };
+        realm->begin_transaction();
+        Object::create(ctx, realm, *realm->schema().find("all types"), values, false);
+        realm->commit_transaction();
+
+        SECTION("read values from old realm") {
+            Schema schema{
+                {"all types", {
+                    {"pk", PropertyType::Int, "", "", true},
+                }},
+            };
+            realm->update_schema(schema, 2, [](auto old_realm, auto new_realm, Schema&) {
+                CppContext ctx(old_realm);
+                Object obj = Object::get_for_primary_key(ctx, old_realm, "all types",
+                                                         util::Any(INT64_C(1)));
+                REQUIRE(obj.is_valid());
+
+                REQUIRE(any_cast<bool>(obj.get_property_value<util::Any>(ctx, "bool")) == true);
+                REQUIRE(any_cast<int64_t>(obj.get_property_value<util::Any>(ctx, "int")) == 5);
+                REQUIRE(any_cast<float>(obj.get_property_value<util::Any>(ctx, "float")) == 2.2f);
+                REQUIRE(any_cast<double>(obj.get_property_value<util::Any>(ctx, "double")) == 3.3);
+                REQUIRE(any_cast<std::string>(obj.get_property_value<util::Any>(ctx, "string")) == "hello");
+                REQUIRE(any_cast<std::string>(obj.get_property_value<util::Any>(ctx, "data")) == "olleh");
+                REQUIRE(any_cast<Timestamp>(obj.get_property_value<util::Any>(ctx, "date")) == Timestamp(10, 20));
+
+                auto link = any_cast<Object>(obj.get_property_value<util::Any>(ctx, "object"));
+                REQUIRE(link.is_valid());
+                REQUIRE(any_cast<int64_t>(link.get_property_value<util::Any>(ctx, "value")) == 10);
+
+                auto list = any_cast<List>(obj.get_property_value<util::Any>(ctx, "array"));
+                REQUIRE(list.size() == 1);
+
+                CppContext list_ctx(ctx, *obj.get_object_schema().property_for_name("array"));
+                link = any_cast<Object>(list.get(list_ctx, 0));
+                REQUIRE(link.is_valid());
+                REQUIRE(any_cast<int64_t>(link.get_property_value<util::Any>(list_ctx, "value")) == 20);
+
+                CppContext ctx2(new_realm);
+                obj = Object::get_for_primary_key(ctx, new_realm, "all types",
+                                                  util::Any(INT64_C(1)));
+                REQUIRE(obj.is_valid());
+                REQUIRE_THROWS(obj.get_property_value<util::Any>(ctx, "bool"));
+            });
+        }
+
+        SECTION("cannot mutate old realm") {
+            realm->update_schema(schema, 2, [](auto old_realm, auto, Schema&) {
+                CppContext ctx(old_realm);
+                Object obj = Object::get_for_primary_key(ctx, old_realm, "all types",
+                                                         util::Any(INT64_C(1)));
+                REQUIRE(obj.is_valid());
+                REQUIRE_THROWS(obj.set_property_value(ctx, "bool", util::Any(false), false));
+                REQUIRE_THROWS(old_realm->begin_transaction());
+            });
+        }
+
+        SECTION("cannot read values for removed properties from new realm") {
+            Schema schema{
+                {"all types", {
+                    {"pk", PropertyType::Int, "", "", true},
+                }},
+            };
+            realm->update_schema(schema, 2, [](auto, auto new_realm, Schema&) {
+                CppContext ctx(new_realm);
+                Object obj = Object::get_for_primary_key(ctx, new_realm, "all types",
+                                                         util::Any(INT64_C(1)));
+                REQUIRE(obj.is_valid());
+                REQUIRE_THROWS(obj.get_property_value<util::Any>(ctx, "bool"));
+                REQUIRE_THROWS(obj.get_property_value<util::Any>(ctx, "object"));
+                REQUIRE_THROWS(obj.get_property_value<util::Any>(ctx, "array"));
+            });
+        }
+
+        SECTION("read values from new object") {
+            realm->update_schema(schema, 2, [](auto, auto new_realm, Schema&) {
+                CppContext ctx(new_realm);
+                Object obj = Object::get_for_primary_key(ctx, new_realm, "all types",
+                                                         util::Any(INT64_C(1)));
+                REQUIRE(obj.is_valid());
+
+
+                auto link = any_cast<Object>(obj.get_property_value<util::Any>(ctx, "object"));
+                REQUIRE(link.is_valid());
+                REQUIRE(any_cast<int64_t>(link.get_property_value<util::Any>(ctx, "value")) == 10);
+
+                auto list = any_cast<List>(obj.get_property_value<util::Any>(ctx, "array"));
+                REQUIRE(list.size() == 1);
+
+                CppContext list_ctx(ctx, *obj.get_object_schema().property_for_name("array"));
+                link = any_cast<Object>(list.get(list_ctx, 0));
+                REQUIRE(link.is_valid());
+                REQUIRE(any_cast<int64_t>(link.get_property_value<util::Any>(list_ctx, "value")) == 20);
+            });
+        }
+
+        SECTION("read and write values in new object") {
+            realm->update_schema(schema, 2, [](auto, auto new_realm, Schema&) {
+                CppContext ctx(new_realm);
+                Object obj = Object::get_for_primary_key(ctx, new_realm, "all types",
+                                                         util::Any(INT64_C(1)));
+                REQUIRE(obj.is_valid());
+
+                REQUIRE(any_cast<bool>(obj.get_property_value<util::Any>(ctx, "bool")) == true);
+                obj.set_property_value(ctx, "bool", util::Any(false), false);
+                REQUIRE(any_cast<bool>(obj.get_property_value<util::Any>(ctx, "bool")) == false);
+
+                REQUIRE(any_cast<int64_t>(obj.get_property_value<util::Any>(ctx, "int")) == 5);
+                obj.set_property_value(ctx, "int", util::Any(INT64_C(6)), false);
+                REQUIRE(any_cast<int64_t>(obj.get_property_value<util::Any>(ctx, "int")) == 6);
+
+                REQUIRE(any_cast<float>(obj.get_property_value<util::Any>(ctx, "float")) == 2.2f);
+                obj.set_property_value(ctx, "float", util::Any(1.23f), false);
+                REQUIRE(any_cast<float>(obj.get_property_value<util::Any>(ctx, "float")) == 1.23f);
+
+                REQUIRE(any_cast<double>(obj.get_property_value<util::Any>(ctx, "double")) == 3.3);
+                obj.set_property_value(ctx, "double", util::Any(1.23), false);
+                REQUIRE(any_cast<double>(obj.get_property_value<util::Any>(ctx, "double")) == 1.23);
+
+                REQUIRE(any_cast<std::string>(obj.get_property_value<util::Any>(ctx, "string")) == "hello");
+                obj.set_property_value(ctx, "string", util::Any("abc"s), false);
+                REQUIRE(any_cast<std::string>(obj.get_property_value<util::Any>(ctx, "string")) == "abc");
+
+                REQUIRE(any_cast<std::string>(obj.get_property_value<util::Any>(ctx, "data")) == "olleh");
+                obj.set_property_value(ctx, "data", util::Any("abc"s), false);
+                REQUIRE(any_cast<std::string>(obj.get_property_value<util::Any>(ctx, "data")) == "abc");
+
+                REQUIRE(any_cast<Timestamp>(obj.get_property_value<util::Any>(ctx, "date")) == Timestamp(10, 20));
+                obj.set_property_value(ctx, "date", util::Any(Timestamp(1, 2)), false);
+                REQUIRE(any_cast<Timestamp>(obj.get_property_value<util::Any>(ctx, "date")) == Timestamp(1, 2));
+
+                Object linked_obj(new_realm, "link target", 0);
+                Object new_obj(new_realm, "link target", get_table(new_realm, "link target")->add_empty_row());
+
+                auto linking = any_cast<Results>(linked_obj.get_property_value<util::Any>(ctx, "origin"));
+                REQUIRE(linking.size() == 1);
+
+                REQUIRE(any_cast<Object>(obj.get_property_value<util::Any>(ctx, "object")).row().get_index()
+                        == linked_obj.row().get_index());
+                obj.set_property_value(ctx, "object", util::Any(new_obj), false);
+                REQUIRE(any_cast<Object>(obj.get_property_value<util::Any>(ctx, "object")).row().get_index()
+                        == new_obj.row().get_index());
+
+                REQUIRE(linking.size() == 0);
+            });
+        }
+
+        SECTION("create object in new realm") {
+            realm->update_schema(schema, 2, [&values](auto, auto new_realm, Schema&) {
+                REQUIRE(new_realm->is_in_transaction());
+
+                CppContext ctx(new_realm);
+                any_cast<AnyDict&>(values)["pk"] = INT64_C(2);
+                Object obj = Object::create(ctx, new_realm, "all types", values, false);
+
+                REQUIRE(get_table(new_realm, "all types")->size() == 2);
+                REQUIRE(get_table(new_realm, "link target")->size() == 2);
+                REQUIRE(get_table(new_realm, "array target")->size() == 2);
+                REQUIRE(any_cast<int64_t>(obj.get_property_value<util::Any>(ctx, "pk")) == 2);
+            });
+        }
+
+        SECTION("upsert in new realm") {
+            realm->update_schema(schema, 2, [&values](auto, auto new_realm, Schema&) {
+                REQUIRE(new_realm->is_in_transaction());
+                CppContext ctx(new_realm);
+                any_cast<AnyDict&>(values)["bool"] = false;
+                Object obj = Object::create(ctx, new_realm, "all types", values, true);
+                REQUIRE(get_table(new_realm, "all types")->size() == 1);
+                REQUIRE(get_table(new_realm, "link target")->size() == 2);
+                REQUIRE(get_table(new_realm, "array target")->size() == 2);
+                REQUIRE(any_cast<bool>(obj.get_property_value<util::Any>(ctx, "bool")) == false);
+            });
         }
     }
 


### PR DESCRIPTION
And add some tests for using the object accessor functionality at all inside migration functions.

This takes a different approach from what Cocoa did (just modify the schema to make it so that nothing's a primary key), as that had some unpleasant side effects such that the schema reported to the user inside the migration was wrong, and functionality which required a primary key such as upserting and fetching items by primary key didn't work. This should match the old Cocoa behavior in the key ways, though (PKs can be changed and objects with duplicate PK values can be created as long as there's no duplicates at the end of the migration).