### PR TITLE
Fix double-setting the primary key

### DIFF
--- a/src/object_accessor.hpp
+++ b/src/object_accessor.hpp
@@ -189,7 +189,7 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
     size_t row_index = realm::not_found;
     TableRef table = ObjectStore::table_for_object_type(realm->read_group(), object_schema.name);
 
-    bool skip_primary = false;
+    bool skip_primary = true;
     if (auto primary_prop = object_schema.primary_key_property()) {
         // search for existing object based on primary key type
         auto primary_value = ctx.value_for_property(value, primary_prop->name,


### PR DESCRIPTION
`skip_primary` was initialized to the wrong value, so it was never actually skipped. This appears to have not caused any functional problems (I couldn't find a way to write a test that would fail as a result), but it is a small performance hit.