### PR TITLE
Only use sync's object and table creation APIs if we're using a new enough version of sync

### DIFF
--- a/src/object_accessor.hpp
+++ b/src/object_accessor.hpp
@@ -27,15 +27,16 @@
 #include "object_store.hpp"
 #include "results.hpp"
 #include "schema.hpp"
+#include "sync/sync_features.hpp"
 #include "util/format.hpp"
 
 #include <realm/link_view.hpp>
 #include <realm/util/assert.hpp>
 #include <realm/table_view.hpp>
 
-#if REALM_ENABLE_SYNC
+#if REALM_HAVE_SYNC_STABLE_IDS
 #include <realm/sync/object.hpp>
-#endif // REALM_ENABLE_SYNC
+#endif // REALM_HAVE_SYNC_STABLE_IDS
 
 #include <string>
 
@@ -195,7 +196,7 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
         if (row_index == realm::not_found) {
             created = true;
             if (primary_prop->type == PropertyType::Int) {
-#if REALM_ENABLE_SYNC
+#if REALM_HAVE_SYNC_STABLE_IDS
                 row_index = sync::create_object_with_primary_key(realm->read_group(), *table, ctx.template unbox<util::Optional<int64_t>>(*primary_value));
 #else
                 row_index = table->add_empty_row();
@@ -203,16 +204,16 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
                     table->set_null_unique(primary_prop->table_column, row_index);
                 else
                     table->set_unique(primary_prop->table_column, row_index, ctx.template unbox<int64_t>(*primary_value));
-#endif // REALM_ENABLE_SYNC
+#endif // REALM_HAVE_SYNC_STABLE_IDS
             }
             else if (primary_prop->type == PropertyType::String) {
                 auto value = ctx.template unbox<StringData>(*primary_value);
-#if REALM_ENABLE_SYNC
+#if REALM_HAVE_SYNC_STABLE_IDS
                 row_index = sync::create_object_with_primary_key(realm->read_group(), *table, value);
 #else
                 row_index = table->add_empty_row();
                 table->set_unique(primary_prop->table_column, row_index, value);
-#endif // REALM_ENABLE_SYNC
+#endif // REALM_HAVE_SYNC_STABLE_IDS
             }
             else {
                 REALM_TERMINATE("Unsupported primary key type.");
@@ -224,11 +225,11 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
         }
     }
     else {
-#if REALM_ENABLE_SYNC
+#if REALM_HAVE_SYNC_STABLE_IDS
         row_index = sync::create_object(realm->read_group(), *table);
 #else
         row_index = table->add_empty_row();
-#endif // REALM_ENABLE_SYNC
+#endif // REALM_HAVE_SYNC_STABLE_IDS
         created = true;
     }
 

--- a/src/sync/sync_features.hpp
+++ b/src/sync/sync_features.hpp
@@ -1,0 +1,33 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2017 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifdef REALM_OS_SYNC_FEATURES_HPP
+#define REALM_OS_SYNC_FEATURES_HPP
+
+#if REALM_ENABLE_SYNC
+
+#include <realm/sync/version.hpp>
+#define REALM_HAVE_SYNC_STABLE_IDS (REALM_SYNC_VER_MAJOR > 1)
+
+#else
+
+#define REALM_HAVE_SYNC_STABLE_IDS 0
+
+#endif // REALM_ENABLE_SYNC
+
+#endif // REALM_OS_SYNC_FEATURES_HPP

--- a/tests/object.cpp
+++ b/tests/object.cpp
@@ -27,6 +27,7 @@
 #include "object_accessor.hpp"
 #include "property.hpp"
 #include "schema.hpp"
+#include "sync/sync_features.hpp"
 
 #include "impl/realm_coordinator.hpp"
 #include "impl/object_accessor_impl.hpp"
@@ -540,11 +541,22 @@ TEST_CASE("object") {
             return r1->read_group().get_table("class_array target")->size() == 4;
         });
 
+#if REALM_HAVE_SYNC_STABLE_IDS
+        // With stable IDs, sync creates the primary key column at index 0.
         REQUIRE(obj.row().get_int(0) == 7); // pk
         REQUIRE(obj.row().get_linklist(1)->size() == 2);
         REQUIRE(obj.row().get_int(2) == 1); // non-default from r1
         REQUIRE(obj.row().get_int(3) == 2); // non-default from r2
         REQUIRE(obj.row().get_linklist(4)->size() == 2);
+#else
+        // Without stable IDs, the primary key column ends up in schema order.
+        REQUIRE(obj.row().get_linklist(0)->size() == 2);
+        REQUIRE(obj.row().get_int(1) == 1); // non-default from r1
+        REQUIRE(obj.row().get_int(2) == 7); // pk
+        REQUIRE(obj.row().get_int(3) == 2); // non-default from r2
+        REQUIRE(obj.row().get_linklist(4)->size() == 2);
+#endif // REALM_HAVE_SYNC_STABLE_IDS
+
     }
 #endif
 }


### PR DESCRIPTION
This allows us to support sync v1.x and v2.x with the same version of the object store.

The motivation is twofold:
1. Allow bindings to integrate the changes from #434 ahead of being able to switch to v2.x.
2. To allow for the possibility of making objects store fixes for binding version using sync v1.x without having to branch the object store.

Note that this targets the branch for #434.