### PR TITLE
Add support for deleting Realm upon permission error

### DIFF
--- a/src/sync/impl/sync_metadata.hpp
+++ b/src/sync/impl/sync_metadata.hpp
@@ -93,7 +93,7 @@ public:
         // The Realm files at the given directory will be deleted.
         DeleteRealm,
         // The Realm file will be copied to a 'recovery' directory, and the original Realm files will be deleted.
-        HandleRealmForClientReset
+        BackUpThenDeleteRealm
     };
 
     static util::Optional<SyncFileActionMetadata> metadata_for_path(const std::string&, const SyncMetadataManager&);
@@ -102,7 +102,7 @@ public:
     std::string original_name() const;
 
     // The meaning of this parameter depends on the `Action` specified.
-    // For `HandleRealmForClientReset`, it is the absolute path where the backup copy 
+    // For `BackUpThenDeleteRealm`, it is the absolute path where the backup copy 
     // of the Realm file found at `original_name()` will be placed. 
     // For all other `Action`s, it is ignored.
     util::Optional<std::string> new_name() const;
@@ -170,6 +170,10 @@ public:
 
     // Return a Results object containing all pending actions.
     SyncFileActionMetadataResults all_pending_actions() const;
+
+    // Delete an existing metadata action given the original name of the Realm it involves.
+    // Returns true iff there was an existing metadata action and it was deleted.
+    bool delete_metadata_action(const std::string&) const;
 
     Realm::Config get_configuration() const;
 

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -171,7 +171,7 @@ bool SyncManager::run_file_action(const SyncFileActionMetadata& md)
             // Delete all the files for the given Realm.
             m_file_manager->remove_realm(md.original_name());
             return true;
-        case SyncFileActionMetadata::Action::HandleRealmForClientReset:
+        case SyncFileActionMetadata::Action::BackUpThenDeleteRealm:
             // Copy the primary Realm file to the recovery dir, and then delete the Realm.
             auto new_name = md.new_name();
             auto original_name = md.original_name();

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -422,9 +422,8 @@ void SyncSession::update_error_and_mark_file_for_deletion(SyncError& error, Shou
         recovery_path = get_recovery_file_path();
         error.user_info[SyncError::c_recovery_file_path_key] = recovery_path;
     }
-    auto action = ((should_backup == ShouldBackup::yes)
-                   ? SyncFileActionMetadata::Action::BackUpThenDeleteRealm
-                   : SyncFileActionMetadata::Action::DeleteRealm);
+    using Action = SyncFileActionMetadata::Action;
+    auto action = should_backup == ShouldBackup::yes ? Action::BackUpThenDeleteRealm : Action::DeleteRealm;
     SyncManager::shared().perform_metadata_update([this,
                                                    action,
                                                    original_path=std::move(original_path),
@@ -441,6 +440,7 @@ void SyncSession::update_error_and_mark_file_for_deletion(SyncError& error, Shou
 // This method should only be called from within the error handler callback registered upon the underlying `m_session`.
 void SyncSession::handle_error(SyncError error)
 {
+    enum class NextStateAfterError { none, inactive, error };
     auto next_state = error.is_fatal ? NextStateAfterError::error : NextStateAfterError::none;
     auto error_code = error.error_code;
 

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -229,7 +229,10 @@ private:
     SyncSession(_impl::SyncClient&, std::string realm_path, SyncConfig);
     // }
 
+
     void handle_error(SyncError);
+    enum class ShouldBackup { yes, no };
+    void update_error_and_mark_file_for_deletion(SyncError&, ShouldBackup);
     static std::string get_recovery_file_path();
     void handle_progress_update(uint64_t, uint64_t, uint64_t, uint64_t, bool);
 

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -320,8 +320,6 @@ private:
 
     class ExternalReference;
     std::weak_ptr<ExternalReference> m_external_reference;
-
-    enum class NextStateAfterError { none, inactive, error };
 };
 
 }

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -320,6 +320,8 @@ private:
 
     class ExternalReference;
     std::weak_ptr<ExternalReference> m_external_reference;
+
+    enum class NextStateAfterError { none, inactive, error };
 };
 
 }

--- a/tests/sync/metadata.cpp
+++ b/tests/sync/metadata.cpp
@@ -244,10 +244,10 @@ TEST_CASE("sync_metadata: file action metadata", "[sync]") {
 
     SECTION("can be properly constructed") {
         const auto original_name = tmp_dir() + "foobar/test1";
-        auto user_metadata = SyncFileActionMetadata(manager, SyncAction::HandleRealmForClientReset, original_name, url_1, identity_1);
+        auto user_metadata = SyncFileActionMetadata(manager, SyncAction::BackUpThenDeleteRealm, original_name, url_1, identity_1);
         REQUIRE(user_metadata.original_name() == original_name);
         REQUIRE(user_metadata.new_name() == none);
-        REQUIRE(user_metadata.action() == SyncAction::HandleRealmForClientReset);
+        REQUIRE(user_metadata.action() == SyncAction::BackUpThenDeleteRealm);
         REQUIRE(user_metadata.url() == url_1);
         REQUIRE(user_metadata.user_identity() == identity_1);
     }
@@ -256,10 +256,10 @@ TEST_CASE("sync_metadata: file action metadata", "[sync]") {
         const auto original_name = tmp_dir() + "foobar/test2a";
         const std::string new_name_1 = tmp_dir() + "foobar/test2b";
         const std::string new_name_2 = tmp_dir() + "foobar/test2c";
-        auto user_metadata_1 = SyncFileActionMetadata(manager, SyncAction::HandleRealmForClientReset, original_name, url_1, identity_1, new_name_1);
+        auto user_metadata_1 = SyncFileActionMetadata(manager, SyncAction::BackUpThenDeleteRealm, original_name, url_1, identity_1, new_name_1);
         REQUIRE(user_metadata_1.original_name() == original_name);
         REQUIRE(user_metadata_1.new_name() == new_name_1);
-        REQUIRE(user_metadata_1.action() == SyncAction::HandleRealmForClientReset);
+        REQUIRE(user_metadata_1.action() == SyncAction::BackUpThenDeleteRealm);
         REQUIRE(user_metadata_1.url() == url_1);
         REQUIRE(user_metadata_1.user_identity() == identity_1);
 
@@ -282,9 +282,9 @@ TEST_CASE("sync_metadata: file action metadata APIs", "[sync]") {
         const auto filename1 = tmp_dir() + "foobar/file1";
         const auto filename2 = tmp_dir() + "foobar/file2";
         const auto filename3 = tmp_dir() + "foobar/file3";
-        auto first = SyncFileActionMetadata(manager, SyncAction::HandleRealmForClientReset, filename1, "asdf", "realm://realm.example.com/1");
-        auto second = SyncFileActionMetadata(manager, SyncAction::HandleRealmForClientReset, filename2, "asdf", "realm://realm.example.com/2");
-        auto third = SyncFileActionMetadata(manager, SyncAction::HandleRealmForClientReset, filename3, "asdf", "realm://realm.example.com/3");
+        auto first = SyncFileActionMetadata(manager, SyncAction::BackUpThenDeleteRealm, filename1, "asdf", "realm://realm.example.com/1");
+        auto second = SyncFileActionMetadata(manager, SyncAction::BackUpThenDeleteRealm, filename2, "asdf", "realm://realm.example.com/2");
+        auto third = SyncFileActionMetadata(manager, SyncAction::BackUpThenDeleteRealm, filename3, "asdf", "realm://realm.example.com/3");
         auto actions = manager.all_pending_actions();
         REQUIRE(actions.size() == 3);
         REQUIRE(results_contains_original_name(actions, filename1));

--- a/tests/sync/session/session.cpp
+++ b/tests/sync/session/session.cpp
@@ -250,7 +250,9 @@ TEST_CASE("sync: token refreshing", "[sync]") {
                                         bind_function_called = true;
                                         return s_test_token;
                                     },
-                                    [](auto, auto) { },
+                                    [](auto, SyncError err) {
+                                        printf("DEBUG: test received an error: %s\n", err.message.c_str());
+                                    },
                                     SyncSessionStopPolicy::AfterChangesUploaded);
         EventLoop::main().run_until([&] { return sessions_are_active(*session); });
         REQUIRE(!session->is_in_error_state());

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -313,15 +313,15 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
         }
     }
 
-    SECTION("Action::HandleRealmForClientReset") {
+    SECTION("Action::BackUpThenDeleteRealm") {
         const auto recovery_dir = file_manager.recovery_directory_path();
         // Create some file actions
         const std::string recovery_1 = util::file_path_by_appending_component(recovery_dir, "recovery-1");
         const std::string recovery_2 = util::file_path_by_appending_component(recovery_dir, "recovery-2");
         const std::string recovery_3 = util::file_path_by_appending_component(recovery_dir, "recovery-3");
-        auto a1 = SyncFileActionMetadata(manager, Action::HandleRealmForClientReset, realm_path_1, realm_url, "user1", recovery_1);
-        auto a2 = SyncFileActionMetadata(manager, Action::HandleRealmForClientReset, realm_path_2, realm_url, "user2", recovery_2);
-        auto a3 = SyncFileActionMetadata(manager, Action::HandleRealmForClientReset, realm_path_3, realm_url, "user3", recovery_3);
+        auto a1 = SyncFileActionMetadata(manager, Action::BackUpThenDeleteRealm, realm_path_1, realm_url, "user1", recovery_1);
+        auto a2 = SyncFileActionMetadata(manager, Action::BackUpThenDeleteRealm, realm_path_2, realm_url, "user2", recovery_2);
+        auto a3 = SyncFileActionMetadata(manager, Action::BackUpThenDeleteRealm, realm_path_3, realm_url, "user3", recovery_3);
 
         SECTION("should properly copy the Realm file and delete the Realm") {
             // Create some Realms
@@ -351,7 +351,7 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
             REQUIRE_REALM_EXISTS(realm_base_path);
             REQUIRE(!File::exists(recovery_path));
             // Manually create a file action metadata entry to simulate a client reset.
-            auto a = SyncFileActionMetadata(manager, Action::HandleRealmForClientReset, realm_base_path, realm_url, identity, recovery_path);
+            auto a = SyncFileActionMetadata(manager, Action::BackUpThenDeleteRealm, realm_base_path, realm_url, identity, recovery_path);
             auto pending_actions = manager.all_pending_actions();
             REQUIRE(pending_actions.size() == 4);
 
@@ -389,7 +389,7 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
             // Add a file action after the system is configured.
             REQUIRE_REALM_EXISTS(realm_path_4);
             REQUIRE(File::exists(file_manager.recovery_directory_path()));
-            auto a4 = SyncFileActionMetadata(manager, Action::HandleRealmForClientReset, realm_path_4, realm_url, "user4", recovery_1);
+            auto a4 = SyncFileActionMetadata(manager, Action::BackUpThenDeleteRealm, realm_path_4, realm_url, "user4", recovery_1);
             CHECK(pending_actions.size() == 1);
             // Force the recovery. (In a real application, the user would have closed the files by now.)
             REQUIRE(SyncManager::shared().immediately_run_file_actions(realm_path_4));


### PR DESCRIPTION
Changes:
- 'Permission denied' error now triggers the Realm file to be deleted upon next launch
- Refactored helper method for deleting Realm files
- Added a method for deleting a metadata action directly
- Renamed enum case 'HandleRealmForClientReset' to 'BackUpThenDeleteRealm' to better reflect what it does

Note: the corresponding binding work will introduce a system similar to client reset, allowing users to immediately delete or to keep the Realm file permanently.