### PR TITLE
Better message to show the mismatched schema

### DIFF
--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -210,7 +210,7 @@ static void validate_property(Schema const& schema,
     if (prop.type != PropertyType::Object && prop.type != PropertyType::LinkingObjects) {
         if (!prop.object_type.empty()) {
             exceptions.emplace_back("Property '%1.%2' of type '%3' cannot have an object type.",
-                                    object_name, prop.name, string_for_property_type(prop.type));
+                                    object_name, prop.name, prop.type_string());
         }
         return;
     }

--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -352,8 +352,8 @@ struct SchemaDifferenceExplainer {
     {
         errors.emplace_back("Property '%1.%2' has been changed from '%3' to '%4'.",
                             op.object->name, op.new_property->name,
-                            string_for_property_type(op.old_property->type),
-                            string_for_property_type(op.new_property->type));
+                            op.old_property->type_string(),
+                            op.new_property->type_string());
     }
 
     void operator()(schema_change::MakePropertyNullable op)

--- a/src/parser/query_builder.cpp
+++ b/src/parser/query_builder.cpp
@@ -427,7 +427,7 @@ void do_add_comparison_to_query(Query &query, Predicate::Comparison cmp,
             add_link_constraint_to_query(query, cmp.op, expr, link_argument(lhs, rhs, args));
             break;
         default:
-            throw std::logic_error(util::format("Object type '%1' not supported", string_for_property_type(type)));
+            throw std::logic_error(util::format("Object type '%1' not supported", expr.prop->type_string()));
     }
 }
 
@@ -511,7 +511,7 @@ void do_add_null_comparison_to_query(Query &query, Predicate::Comparison cmp, co
         case realm::PropertyType::Array:
             throw std::logic_error("Comparing Lists to 'null' is not supported");
         default:
-            throw std::logic_error(util::format("Object type '%1' not supported", string_for_property_type(type)));
+            throw std::logic_error(util::format("Object type '%1' not supported", expr.prop->type_string()));
     }
 }
 


### PR DESCRIPTION
Property 'CatOwner.cats' has been changed from `array` to
`array`."
->
Property 'CatOwner.cats' has been changed from `array<Dog>` to
`array<Cat>`."