### PR TITLE
Omit sync's __OID column from the schema

### DIFF
--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -21,12 +21,17 @@
 #include "object_store.hpp"
 #include "property.hpp"
 #include "schema.hpp"
+#include "sync/sync_features.hpp"
 
 #include "util/format.hpp"
 
 #include <realm/data_type.hpp>
 #include <realm/group.hpp>
 #include <realm/table.hpp>
+
+#if REALM_HAVE_SYNC_STABLE_IDS
+#include <realm/sync/object.hpp>
+#endif
 
 using namespace realm;
 
@@ -81,8 +86,17 @@ ObjectSchema::ObjectSchema(Group const& group, StringData name, size_t index) : 
         if (table->get_column_type(col) == type_Table)
             continue;
 
+        StringData column_name = table->get_column_name(col);
+
+#if REALM_HAVE_SYNC_STABLE_IDS
+        // The object ID column is an implementation detail, and is omitted from the schema.
+        // FIXME: Consider filtering out all column names starting with `__`.
+        if (column_name == sync::object_id_column_name)
+            continue;
+#endif
+
         Property property;
-        property.name = table->get_column_name(col).data();
+        property.name = column_name;
         property.type = (PropertyType)table->get_column_type(col);
         property.is_indexed = table->has_search_index(col);
         property.is_nullable = table->is_nullable(col) || property.type == PropertyType::Object;


### PR DESCRIPTION
This column is an implementation detail and shouldn't be exposed directly like this.

I noticed this because the column was appearing in Realm Browser. At some point we may want to expose the object ID in the Browser, but I don't think it'll be as a mysterious `__OID` column.