### PR TITLE
Check null for migration callback

### DIFF
--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -704,7 +704,9 @@ void ObjectStore::apply_schema_changes(Group& group, uint64_t schema_version,
 
     if (mode == SchemaMode::Manual) {
         set_schema_columns(group, target_schema);
-        migration_function();
+        if (migration_function) {
+            migration_function();
+        }
 
         verify_no_changes_required(schema_from_group(group).compare(target_schema));
         validate_primary_column_uniqueness(group);

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -1768,6 +1768,6 @@ TEST_CASE("migration: Manual") {
 
     SECTION("null migration callback should throw SchemaMismatchException") {
         Schema new_schema = remove_property(schema, "object", "value");
-        REQUIRE_THROWS_AS(realm->update_schema(schema, 1, nullptr), SchemaMismatchException);
+        REQUIRE_THROWS_AS(realm->update_schema(new_schema, 1, nullptr), SchemaMismatchException);
     }
 }

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -1765,4 +1765,9 @@ TEST_CASE("migration: Manual") {
         REQUIRE_NOTHROW(realm2->update_schema(schema));
         REQUIRE_THROWS(realm2->update_schema(remove_property(schema, "object", "value")));
     }
+
+    SECTION("null migration callback should throw SchemaMismatchException") {
+        Schema new_schema = remove_property(schema, "object", "value");
+        REQUIRE_THROWS_AS(realm->update_schema(schema, 1, nullptr), SchemaMismatchException);
+    }
 }


### PR DESCRIPTION
null migration callback should be treated as same as empty migration
callback in manual mode, throw a SchemaMismatchException if migration
is needed.