### PR TITLE
Build coverage-enabled tests with CATCH_CONFIG_FAST_COMPILE

### DIFF
--- a/CMake/CodeCoverage.cmake
+++ b/CMake/CodeCoverage.cmake
@@ -20,7 +20,7 @@ find_program(LCOV_PATH lcov)
 find_program(GENHTML_PATH genhtml)
 find_program(GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/tests)
 
-set(CMAKE_CXX_FLAGS_COVERAGE "-g -O0 -fprofile-arcs -ftest-coverage"
+set(CMAKE_CXX_FLAGS_COVERAGE "-g -O0 -fprofile-arcs -ftest-coverage -DCATCH_CONFIG_FAST_COMPILE"
     CACHE STRING "Flags used by the C++ compiler during coverage builds.")
 mark_as_advanced(CMAKE_CXX_FLAGS_COVERAGE)
 

--- a/src/util/any.hpp
+++ b/src/util/any.hpp
@@ -19,9 +19,10 @@
 #ifndef REALM_OS_UTIL_ANY_HPP
 #define REALM_OS_UTIL_ANY_HPP
 
-#include <typeinfo>
-#include <type_traits>
+#include <memory>
 #include <stdexcept>
+#include <type_traits>
+#include <typeinfo>
 
 namespace realm {
 namespace util {


### PR DESCRIPTION
This improves compile time (159s -> 145s on my machine) and more importantly makes the object files less unreasonably big (1.2 GB total -> 850 MB) which should also reduce the amount of ram needed to link the executable, which has been a problem in the past.

This comes at the cost of making error reporting when unexpected exceptions are thrown significantly worse, but that doesn't really matter for coverage runs.

There's a bunch of other changes from updating from catch 1.7.0 to 1.9.6 but none of them appear to be relevant to us.