### PR TITLE
Allow permission results to register proper notification blocks

### DIFF
--- a/src/sync/sync_permission.hpp
+++ b/src/sync/sync_permission.hpp
@@ -110,6 +110,12 @@ public:
         return m_results.async(std::move(target));
     }
 
+    // Add a notification callback to this Results.
+    NotificationToken add_notification_callback(CollectionChangeCallback cb) &
+    {
+        return m_results.add_notification_callback(std::move(cb));
+    }
+
     // Create a new instance by further filtering this instance.
     PermissionResults filter(Query&& q) const
     {


### PR DESCRIPTION
Very minor preliminary work for https://github.com/realm/realm-cocoa/issues/5076. All the tests for this functionality live in the binding layers right now.