### PR TITLE
Add support for sorting Lists and Results on keypaths

### DIFF
--- a/src/list.cpp
+++ b/src/list.cpp
@@ -221,6 +221,12 @@ Results List::sort(SortDescriptor order) const
     return Results(m_realm, m_link_view, util::none, std::move(order));
 }
 
+Results List::sort(std::vector<std::pair<std::string, bool>> const& keypaths) const
+{
+    verify_attached();
+    return as_results().sort(keypaths);
+}
+
 Results List::filter(Query q) const
 {
     verify_attached();

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -83,6 +83,7 @@ public:
     void delete_all();
 
     Results sort(SortDescriptor order) const;
+    Results sort(std::vector<std::pair<std::string, bool>> const& keypaths) const;
     Results filter(Query q) const;
 
     // Return a Results representing a live view of this List.

--- a/src/results.cpp
+++ b/src/results.cpp
@@ -528,14 +528,13 @@ static std::vector<size_t> parse_keypath(StringData keypath, Schema const& schem
                                                      keypath, util::format(fmt, args...)));
         }
     };
-    auto sortable_type = [](PropertyType type) {
+    auto is_sortable_type = [](PropertyType type) {
         return !is_array(type) && type != PropertyType::LinkingObjects && type != PropertyType::Data;
     };
 
     const char* begin = keypath.data();
     const char* end = keypath.data() + keypath.size();
     check(begin != end, "missing property name");
-    check(std::find(begin, end, '@') == end, "sorting on collection operators is not implemented");
 
     std::vector<size_t> indices;
     while (begin != end) {
@@ -546,13 +545,13 @@ static std::vector<size_t> parse_keypath(StringData keypath, Schema const& schem
 
         auto prop = object_schema->property_for_name(key);
         check(prop, "property '%1.%2' does not exist", object_schema->name, key);
-        check(sortable_type(prop->type), "property '%1.%2' is of unsupported type '%3'",
+        check(is_sortable_type(prop->type), "property '%1.%2' is of unsupported type '%3'",
               object_schema->name, key, string_for_property_type(prop->type));
         if (prop->type == PropertyType::Object)
             check(begin != end, "property '%1.%2' of type 'object' cannot be the final property in the key path",
                   object_schema->name, key);
         else
-            check(begin == end, "property '%1.%2' of type '%3' must be the final property in the key path",
+            check(begin == end, "property '%1.%2' of type '%3' may only be the final property in the key path",
                   object_schema->name, key, prop->type_string());
 
         indices.push_back(prop->table_column);

--- a/src/results.hpp
+++ b/src/results.hpp
@@ -119,6 +119,7 @@ public:
     // Create a new Results by further filtering or sorting this Results
     Results filter(Query&& q) const;
     Results sort(SortDescriptor&& sort) const;
+    Results sort(std::vector<std::pair<std::string, bool>> const& keypaths) const;
 
     // Create a new Results by removing duplicates
     Results distinct(DistinctDescriptor&& uniqueness);

--- a/src/util/format.cpp
+++ b/src/util/format.cpp
@@ -20,12 +20,9 @@
 
 #include <sstream>
 
-#include <realm/string_data.hpp>
 #include <realm/util/assert.hpp>
 
 namespace realm { namespace _impl {
-Printable::Printable(StringData value) : m_type(Type::String), m_string(value.data()) { }
-
 void Printable::print(std::ostream& out) const
 {
     switch (m_type) {

--- a/src/util/format.hpp
+++ b/src/util/format.hpp
@@ -19,6 +19,8 @@
 #ifndef REALM_UTIL_FORMAT_HPP
 #define REALM_UTIL_FORMAT_HPP
 
+#include <realm/string_data.hpp>
+
 #include <cstdint>
 #include <iosfwd>
 #include <initializer_list>
@@ -40,8 +42,8 @@ public:
     Printable(long value) : m_type(Type::Int), m_int(value) { }
     Printable(long long value) : m_type(Type::Int), m_int(value) { }
     Printable(const char* value) : m_type(Type::String), m_string(value) { }
-    Printable(std::string const& value) : m_type(Type::String), m_string(value.c_str()) { }
-    Printable(StringData value);
+    Printable(std::string const& value) : m_type(Type::String), m_string(value) { }
+    Printable(StringData value) : m_type(Type::String), m_string(value) { }
 
     void print(std::ostream& out) const;
 
@@ -56,7 +58,7 @@ private:
     union {
         uintmax_t m_uint;
         intmax_t m_int;
-        const char* m_string;
+        StringData m_string;
     };
 };
 std::string format(const char* fmt, std::initializer_list<Printable>);

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -2516,13 +2516,9 @@ TEST_CASE("results: sort") {
             REQUIRE_THROWS_WITH(r.sort({{"link.not a property", true}}),
                                 "Cannot sort on key path 'link.not a property': property 'object 2.not a property' does not exist.");
         }
-        SECTION("collection operator") {
-            REQUIRE_THROWS_WITH(r.sort({{"@count", true}}),
-                                "Cannot sort on key path '@count': sorting on collection operators is not implemented.");
-        }
         SECTION("subscript primitive") {
             REQUIRE_THROWS_WITH(r.sort({{"value.link", true}}),
-                                "Cannot sort on key path 'value.link': property 'object.value' of type 'int' must be the final property in the key path.");
+                                "Cannot sort on key path 'value.link': property 'object.value' of type 'int' may only be the final property in the key path.");
         }
         SECTION("end in link") {
             REQUIRE_THROWS_WITH(r.sort({{"link", true}}),


### PR DESCRIPTION
Mostly just a port of the SortDescriptor building code from Cocoa, since the existing obj-c code doesn't work for primitive arrays and JS (and maybe other bindings) could use this too.