### PR TITLE
Support for initialization function

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -120,7 +120,7 @@ void RealmCoordinator::set_config(const Realm::Config& config)
     if (config.schema_mode == SchemaMode::ReadOnly && config.migration_function)
         throw std::logic_error("Realms opened in read-only mode do not use a migration function");
     if (config.schema_mode == SchemaMode::ReadOnly && config.initialization_function)
-        throw std::logic_error("Realms opened in read-only mode do not use a initialization function");
+        throw std::logic_error("Realms opened in read-only mode do not use an initialization function");
     if (config.schema && config.schema_version == ObjectStore::NotVersioned)
         throw std::logic_error("A schema version must be specified when the schema is specified");
     if (!config.realm_data.is_null() && (!config.read_only() || !config.in_memory))

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -119,6 +119,8 @@ void RealmCoordinator::set_config(const Realm::Config& config)
         throw std::logic_error("Realms opened in Additive-only schema mode do not use a migration function");
     if (config.schema_mode == SchemaMode::ReadOnly && config.migration_function)
         throw std::logic_error("Realms opened in read-only mode do not use a migration function");
+    if (config.schema_mode == SchemaMode::ReadOnly && config.initialization_function)
+        throw std::logic_error("Realms opened in read-only mode do not use a initialization function");
     if (config.schema && config.schema_version == ObjectStore::NotVersioned)
         throw std::logic_error("A schema version must be specified when the schema is specified");
     if (!config.realm_data.is_null() && (!config.read_only() || !config.in_memory))
@@ -195,6 +197,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
 
     auto schema = std::move(config.schema);
     auto migration_function = std::move(config.migration_function);
+    auto initialization_function = std::move(config.initialization_function);
     config.schema = {};
 
     if (config.cache) {
@@ -236,7 +239,8 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
 
     if (schema) {
         lock.unlock();
-        realm->update_schema(std::move(*schema), config.schema_version, std::move(migration_function));
+        realm->update_schema(std::move(*schema), config.schema_version, std::move(migration_function),
+                             std::move(initialization_function));
     }
 
     return realm;

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -127,7 +127,7 @@ public:
     // functions which take a Schema from within the migration function.
     using MigrationFunction = std::function<void (SharedRealm old_realm, SharedRealm realm, Schema&)>;
 
-    // A callback function to be called after the first time when schema is created.
+    // A callback function to be called the first time when a schema is created.
     // It is passed a SharedRealm with in-transaction state at the version after schema
     // is created. So it is possible to create some initial objects inside the callback
     // with the given SharedRealm. Those changes will be committed together with the

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -128,8 +128,8 @@ public:
     using MigrationFunction = std::function<void (SharedRealm old_realm, SharedRealm realm, Schema&)>;
 
     // A callback function to be called the first time when a schema is created.
-    // It is passed a SharedRealm with in-transaction state at the version after schema
-    // is created. So it is possible to create some initial objects inside the callback
+    // It is passed a SharedRealm which is in a write transaction with the schema
+    // initialized. So it is possible to create some initial objects inside the callback
     // with the given SharedRealm. Those changes will be committed together with the
     // schema creation in a single transaction.
     using DataInitializationFunction = std::function<void (SharedRealm realm)>;

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -127,6 +127,13 @@ public:
     // functions which take a Schema from within the migration function.
     using MigrationFunction = std::function<void (SharedRealm old_realm, SharedRealm realm, Schema&)>;
 
+    // A callback function to be called after the first time when schema is created.
+    // It is passed a SharedRealm with in-transaction state at the version after schema
+    // is created. So it is possible to create some initial objects inside the callback
+    // with the given SharedRealm. Those changes will be committed together with the
+    // schema creation in a single transaction.
+    using DataInitializationFunction = std::function<void (SharedRealm realm)>;
+
     // A callback function called when opening a SharedRealm when no cached
     // version of this Realm exists. It is passed the total bytes allocated for
     // the file (file size) and the total bytes used by data in the file.
@@ -155,6 +162,8 @@ public:
         util::Optional<Schema> schema;
         uint64_t schema_version = -1;
         MigrationFunction migration_function;
+
+        DataInitializationFunction initialization_function;
 
         // A callback function called when opening a SharedRealm when no cached
         // version of this Realm exists. It is passed the total bytes allocated for
@@ -207,6 +216,7 @@ public:
     // Updates a Realm to a given schema, using the Realm's pre-set schema mode.
     void update_schema(Schema schema, uint64_t version=0,
                        MigrationFunction migration_function=nullptr,
+                       DataInitializationFunction initialization_function=nullptr,
                        bool in_transaction=false);
 
     // Set the schema used for this Realm, but do not update the file's schema


### PR DESCRIPTION
This is a feature for realm-java which has been implemented in java side
before, see https://github.com/realm/realm-java/issues/2254

This gives user possibility to create some initial data only when the
Realm file is created at the first time.

By implementing this in Object Store:
- realm-java can use ResetFile schema mode for
  RealmConfigration.deleteIfMigrationNeeded()
- realm-java doesn't have to start a transaction anymore when calling
  update_schema().
- in_transaction param of update_schema() can be finally removed from
  Object Store.