### PR TITLE
Add an explicit conversion from List to Results

### DIFF
--- a/src/list.cpp
+++ b/src/list.cpp
@@ -227,30 +227,35 @@ Results List::filter(Query q) const
     return Results(m_realm, m_link_view, get_query().and_query(std::move(q)));
 }
 
-Results List::snapshot() const
+Results List::as_results() const
 {
     verify_attached();
-    return Results(m_realm, m_link_view).snapshot();
+    return Results(m_realm, m_link_view);
+}
+
+Results List::snapshot() const
+{
+    return as_results().snapshot();
 }
 
 util::Optional<Mixed> List::max(size_t column)
 {
-    return Results(m_realm, m_link_view).max(column);
+    return as_results().max(column);
 }
 
 util::Optional<Mixed> List::min(size_t column)
 {
-    return Results(m_realm, m_link_view).min(column);
+    return as_results().min(column);
 }
 
 util::Optional<Mixed> List::sum(size_t column)
 {
-    return Results(m_realm, m_link_view).sum(column);
+    return as_results().sum(column);
 }
 
 util::Optional<Mixed> List::average(size_t column)
 {
-    return Results(m_realm, m_link_view).average(column);
+    return as_results().average(column);
 }
 
 // These definitions rely on that LinkViews are interned by core

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -85,6 +85,9 @@ public:
     Results sort(SortDescriptor order) const;
     Results filter(Query q) const;
 
+    // Return a Results representing a live view of this List.
+    Results as_results() const;
+
     // Return a Results representing a snapshot of this List.
     Results snapshot() const;
 


### PR DESCRIPTION
There were various hacky things done to work around the lack of this like sorting by zero columns, so just add the ability to do it directly.