### PR TITLE
Silence a warning about REALM_VERSION_MAJOR being undefined

### DIFF
--- a/src/feature_checks.hpp
+++ b/src/feature_checks.hpp
@@ -21,6 +21,10 @@
 
 #include <realm/version.hpp>
 
+#ifndef REALM_VERSION_MAJOR
+#define REALM_VERSION_MAJOR REALM_VER_MAJOR
+#endif
+
 #define REALM_HAVE_COMPOSABLE_DISTINCT (REALM_VERSION_MAJOR > 2)
 
 #if REALM_ENABLE_SYNC


### PR DESCRIPTION
This was seen when building realm-js with core v2.8.x.

Core v3.0 renamed `REALM_VER_MAJOR` to `REALM_VERSION_MAJOR`. If the latter isn't defined, we'll #define it to the former so that our version checks see the expected core version value.