### PR TITLE
Change object store to allow sync user auth URL to be modified

### DIFF
--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -299,8 +299,9 @@ std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& identity,
         return new_user;
     } else {
         auto user = it->second;
+        util::Optional<std::string> new_server_url;
         if (auth_server_url && *auth_server_url != user->server_url()) {
-            throw std::invalid_argument("Cannot retrieve an existing user specifying a different auth server.");
+            new_server_url = std::move(auth_server_url);
         }
         if (user->token_type() != token_type) {
             throw std::invalid_argument("Cannot retrieve a user specifying a different token type.");
@@ -308,7 +309,7 @@ std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& identity,
         if (user->state() == SyncUser::State::Error) {
             return nullptr;
         }
-        user->update_refresh_token(std::move(refresh_token));
+        user->update_user_data(std::move(refresh_token), std::move(new_server_url));
         return user;
     }
 }

--- a/src/sync/sync_user.hpp
+++ b/src/sync/sync_user.hpp
@@ -75,7 +75,7 @@ public:
 
     // Update the user's refresh token. If the user is logged out, it will log itself back in.
     // Note that this is called by the SyncManager, and should not be directly called.
-    void update_refresh_token(std::string token);
+    void update_user_data(std::string token, util::Optional<std::string> new_server_url=none);
 
     // Log the user out and mark it as such. This will also close its associated Sessions.
     void log_out();
@@ -102,11 +102,7 @@ public:
         return m_identity;
     }
 
-    // FIXME: remove this APIs once the new token system is implemented.
-    const std::string& server_url() const noexcept
-    {
-        return m_server_url;
-    }
+    std::string server_url() const noexcept;
 
     std::string refresh_token() const;
     State state() const;
@@ -142,7 +138,6 @@ private:
 
     // The auth server URL. Bindings should set this appropriately when they retrieve
     // instances of `SyncUser`s.
-    // FIXME: once the new token system is implemented, this can be removed completely.
     std::string m_server_url;
 
     // Mark the user as invalid, since a fatal user-related error was encountered.


### PR DESCRIPTION
With this PR, getting a user with a different auth URL than the one it was originally given updates the URL, instead of throwing an exception.

This fixes the issue (commonly encountered during development) when a user is opened with one URL, persisted, the server is moved or SSL is enabled, and an attempt to log in the user with the new address is made.

This does not fix the corner case where two different ROSes have users with the same user ID, and the user wishes to be logged into both simultaneously, but this case wasn't supported before, nor is it supported by any of the other subsystem code.