### PR TITLE
Refactor sync user subsystem to support multiple servers

### DIFF
--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -254,14 +254,15 @@ std::string SyncFileManager::user_directory(const std::string& local_identity,
                                             util::Optional<SyncUserIdentifier> user_info) const
 {
     REALM_ASSERT(local_identity.length() > 0);
-    if (filename_is_reserved(local_identity))
+    std::string escaped = util::make_percent_encoded_string(local_identity);
+    if (filename_is_reserved(escaped))
         throw std::invalid_argument("A user can't have an identifier reserved by the filesystem.");
 
     auto user_path = file_path_by_appending_component(get_base_sync_directory(),
-                                                      local_identity,
+                                                      escaped,
                                                       util::FilePathType::Directory);
     bool dir_created = util::try_make_dir(user_path);
-    if (dir_created && user_info && user_info->user_id != local_identity) {
+    if (dir_created && user_info) {
         // Add a text file in the user directory containing the user identity, for backup purposes.
         // Only do this the first time the directory is created.
         auto info_path = util::file_path_by_appending_component(user_path, c_user_info_file);
@@ -282,9 +283,28 @@ void SyncFileManager::remove_user_directory(const std::string& local_identity) c
         throw std::invalid_argument("A user can't have an identifier reserved by the filesystem.");
 
     auto user_path = file_path_by_appending_component(get_base_sync_directory(),
-                                                      local_identity,
+                                                      util::make_percent_encoded_string(local_identity),
                                                       util::FilePathType::Directory);
     util::remove_nonempty_dir(user_path);
+}
+
+bool SyncFileManager::try_rename_user_directory(const std::string& old_name, const std::string& new_name) const
+{
+    REALM_ASSERT_DEBUG(old_name.length() > 0 && new_name.length() > 0);
+    const std::string& base = get_base_sync_directory();
+    auto old_path = file_path_by_appending_component(base,
+                                                     util::make_percent_encoded_string(old_name),
+                                                     util::FilePathType::Directory);
+    auto new_path = file_path_by_appending_component(base,
+                                                     util::make_percent_encoded_string(new_name),
+                                                     util::FilePathType::Directory);
+
+    try {
+        File::move(old_path, new_path);
+    } catch (File::NotFound const&) {
+        return false;
+    }
+    return true;
 }
 
 bool SyncFileManager::remove_realm(const std::string& absolute_path) const
@@ -331,9 +351,9 @@ bool SyncFileManager::remove_realm(const std::string& local_identity, const std:
 {
     REALM_ASSERT(local_identity.length() > 0);
     REALM_ASSERT(raw_realm_path.length() > 0);
-    if (filename_is_reserved(local_identity) || filename_is_reserved(raw_realm_path)) {
+    if (filename_is_reserved(local_identity) || filename_is_reserved(raw_realm_path))
         throw std::invalid_argument("A user or Realm can't have an identifier reserved by the filesystem.");
-    }
+
     auto escaped = util::make_percent_encoded_string(raw_realm_path);
     auto realm_path = util::file_path_by_appending_component(user_directory(local_identity), escaped);
     return remove_realm(realm_path);
@@ -344,9 +364,9 @@ std::string SyncFileManager::path(const std::string& local_identity, const std::
 {
     REALM_ASSERT(local_identity.length() > 0);
     REALM_ASSERT(raw_realm_path.length() > 0);
-    if (filename_is_reserved(local_identity) || filename_is_reserved(raw_realm_path)) {
+    if (filename_is_reserved(local_identity) || filename_is_reserved(raw_realm_path))
         throw std::invalid_argument("A user or Realm can't have an identifier reserved by the filesystem.");
-    }
+
     auto escaped = util::make_percent_encoded_string(raw_realm_path);
     auto realm_path = util::file_path_by_appending_component(user_directory(local_identity, user_info), escaped);
     return realm_path;

--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -267,8 +267,10 @@ std::string SyncFileManager::user_directory(const std::string& local_identity,
         auto info_path = util::file_path_by_appending_component(user_path, c_user_info_file);
         std::ofstream info_file;
         info_file.open(info_path.c_str());
-        info_file << std::get<0>(*user_info) << "\n" << std::get<1>(*user_info) << "\n";
-        info_file.close();
+        if (info_file.is_open()) {
+            info_file << std::get<0>(*user_info) << "\n" << std::get<1>(*user_info) << "\n";
+            info_file.close();
+        }
     }
     return user_path;
 }

--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -26,6 +26,7 @@
 #include <iomanip>
 #include <sstream>
 #include <system_error>
+#include <fstream>
 
 #ifdef _WIN32
 #include <io.h>
@@ -229,6 +230,7 @@ constexpr const char SyncFileManager::c_utility_directory[];
 constexpr const char SyncFileManager::c_recovery_directory[];
 constexpr const char SyncFileManager::c_metadata_directory[];
 constexpr const char SyncFileManager::c_metadata_realm[];
+constexpr const char SyncFileManager::c_user_info_file[];
 
 std::string SyncFileManager::get_special_directory(std::string directory_name) const
 {
@@ -248,27 +250,37 @@ std::string SyncFileManager::get_base_sync_directory() const
     return sync_path;
 }
 
-std::string SyncFileManager::user_directory(const std::string& user_identity) const
+std::string SyncFileManager::user_directory(const std::string& local_identity,
+                                            util::Optional<StringPair> user_info) const
 {
-    REALM_ASSERT(user_identity.length() > 0);
-    if (filename_is_reserved(user_identity)) {
+    REALM_ASSERT(local_identity.length() > 0);
+    if (filename_is_reserved(local_identity))
         throw std::invalid_argument("A user can't have an identifier reserved by the filesystem.");
-    }
+
     auto user_path = file_path_by_appending_component(get_base_sync_directory(),
-                                                      user_identity,
+                                                      local_identity,
                                                       util::FilePathType::Directory);
-    util::try_make_dir(user_path);
+    bool success = util::try_make_dir(user_path);
+
+    if (success && user_info && std::get<0>(*user_info) != local_identity) {
+        // Add a text file in the user directory containing the user identity, for backup purposes.
+        auto info_path = util::file_path_by_appending_component(user_path, c_user_info_file);
+        std::ofstream info_file;
+        info_file.open(info_path.c_str());
+        info_file << std::get<0>(*user_info) << "\n" << std::get<1>(*user_info) << "\n";
+        info_file.close();
+    }
     return user_path;
 }
 
-void SyncFileManager::remove_user_directory(const std::string& user_identity) const
+void SyncFileManager::remove_user_directory(const std::string& local_identity) const
 {
-    REALM_ASSERT(user_identity.length() > 0);
-    if (filename_is_reserved(user_identity)) {
+    REALM_ASSERT(local_identity.length() > 0);
+    if (filename_is_reserved(local_identity))
         throw std::invalid_argument("A user can't have an identifier reserved by the filesystem.");
-    }
+
     auto user_path = file_path_by_appending_component(get_base_sync_directory(),
-                                                      user_identity,
+                                                      local_identity,
                                                       util::FilePathType::Directory);
     util::remove_nonempty_dir(user_path);
 }
@@ -313,27 +325,28 @@ bool SyncFileManager::copy_realm_file(const std::string& old_path, const std::st
     return true;
 }
 
-bool SyncFileManager::remove_realm(const std::string& user_identity, const std::string& raw_realm_path) const
+bool SyncFileManager::remove_realm(const std::string& local_identity, const std::string& raw_realm_path) const
 {
-    REALM_ASSERT(user_identity.length() > 0);
+    REALM_ASSERT(local_identity.length() > 0);
     REALM_ASSERT(raw_realm_path.length() > 0);
-    if (filename_is_reserved(user_identity) || filename_is_reserved(raw_realm_path)) {
+    if (filename_is_reserved(local_identity) || filename_is_reserved(raw_realm_path)) {
         throw std::invalid_argument("A user or Realm can't have an identifier reserved by the filesystem.");
     }
     auto escaped = util::make_percent_encoded_string(raw_realm_path);
-    auto realm_path = util::file_path_by_appending_component(user_directory(user_identity), escaped);
+    auto realm_path = util::file_path_by_appending_component(user_directory(local_identity), escaped);
     return remove_realm(realm_path);
 }
 
-std::string SyncFileManager::path(const std::string& user_identity, const std::string& raw_realm_path) const
+std::string SyncFileManager::path(const std::string& local_identity, const std::string& raw_realm_path,
+                                  util::Optional<StringPair> user_info) const
 {
-    REALM_ASSERT(user_identity.length() > 0);
+    REALM_ASSERT(local_identity.length() > 0);
     REALM_ASSERT(raw_realm_path.length() > 0);
-    if (filename_is_reserved(user_identity) || filename_is_reserved(raw_realm_path)) {
+    if (filename_is_reserved(local_identity) || filename_is_reserved(raw_realm_path)) {
         throw std::invalid_argument("A user or Realm can't have an identifier reserved by the filesystem.");
     }
     auto escaped = util::make_percent_encoded_string(raw_realm_path);
-    auto realm_path = util::file_path_by_appending_component(user_directory(user_identity), escaped);
+    auto realm_path = util::file_path_by_appending_component(user_directory(local_identity, user_info), escaped);
     return realm_path;
 }
 

--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -251,7 +251,7 @@ std::string SyncFileManager::get_base_sync_directory() const
 }
 
 std::string SyncFileManager::user_directory(const std::string& local_identity,
-                                            util::Optional<StringPair> user_info) const
+                                            util::Optional<SyncUserIdentifier> user_info) const
 {
     REALM_ASSERT(local_identity.length() > 0);
     if (filename_is_reserved(local_identity))
@@ -262,13 +262,13 @@ std::string SyncFileManager::user_directory(const std::string& local_identity,
                                                       util::FilePathType::Directory);
     bool success = util::try_make_dir(user_path);
 
-    if (success && user_info && std::get<0>(*user_info) != local_identity) {
+    if (success && user_info && user_info->user_id != local_identity) {
         // Add a text file in the user directory containing the user identity, for backup purposes.
         auto info_path = util::file_path_by_appending_component(user_path, c_user_info_file);
         std::ofstream info_file;
         info_file.open(info_path.c_str());
         if (info_file.is_open()) {
-            info_file << std::get<0>(*user_info) << "\n" << std::get<1>(*user_info) << "\n";
+            info_file << user_info->user_id << "\n" << user_info->auth_server_url << "\n";
             info_file.close();
         }
     }
@@ -340,7 +340,7 @@ bool SyncFileManager::remove_realm(const std::string& local_identity, const std:
 }
 
 std::string SyncFileManager::path(const std::string& local_identity, const std::string& raw_realm_path,
-                                  util::Optional<StringPair> user_info) const
+                                  util::Optional<SyncUserIdentifier> user_info) const
 {
     REALM_ASSERT(local_identity.length() > 0);
     REALM_ASSERT(raw_realm_path.length() > 0);

--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -260,10 +260,10 @@ std::string SyncFileManager::user_directory(const std::string& local_identity,
     auto user_path = file_path_by_appending_component(get_base_sync_directory(),
                                                       local_identity,
                                                       util::FilePathType::Directory);
-    bool success = util::try_make_dir(user_path);
-
-    if (success && user_info && user_info->user_id != local_identity) {
+    bool dir_created = util::try_make_dir(user_path);
+    if (dir_created && user_info && user_info->user_id != local_identity) {
         // Add a text file in the user directory containing the user identity, for backup purposes.
+        // Only do this the first time the directory is created.
         auto info_path = util::file_path_by_appending_component(user_path, c_user_info_file);
         std::ofstream info_file;
         info_file.open(info_path.c_str());

--- a/src/sync/impl/sync_file.hpp
+++ b/src/sync/impl/sync_file.hpp
@@ -72,6 +72,11 @@ public:
     /// Remove the user directory for a given user.
     void remove_user_directory(const std::string& local_identity) const;       // throws
 
+    /// Rename a user directory. Returns true if a directory at `old_name` existed
+    /// and was successfully renamed to `new_name`. Returns false if no directory
+    /// exists at `old_name`.
+    bool try_rename_user_directory(const std::string& old_name, const std::string& new_name) const;
+
     /// Return the path for a given Realm, creating the user directory if it does not already exist.
     std::string path(const std::string&, const std::string&,
                      util::Optional<SyncUserIdentifier> user_info=none) const;

--- a/src/sync/impl/sync_file.hpp
+++ b/src/sync/impl/sync_file.hpp
@@ -21,6 +21,8 @@
 
 #include <string>
 
+#include <realm/util/optional.hpp>
+
 namespace realm {
 
 namespace util {
@@ -59,19 +61,21 @@ void remove_nonempty_dir(const std::string& path);
 
 class SyncFileManager {
 public:
+    using StringPair = std::tuple<std::string, std::string>;
+
     SyncFileManager(std::string base_path) : m_base_path(std::move(base_path)) { }
 
     /// Return the user directory for a given user, creating it if it does not already exist.
-    std::string user_directory(const std::string& user_identity) const;
+    std::string user_directory(const std::string& local_identity, util::Optional<StringPair> user_info=none) const;
 
     /// Remove the user directory for a given user.
-    void remove_user_directory(const std::string& user_identity) const;       // throws
+    void remove_user_directory(const std::string& local_identity) const;       // throws
 
     /// Return the path for a given Realm, creating the user directory if it does not already exist.
-    std::string path(const std::string& user_identity, const std::string& raw_realm_path) const;
+    std::string path(const std::string&, const std::string&, util::Optional<StringPair> user_info=none) const;
 
     /// Remove the Realm at a given path for a given user. Returns `true` if the remove operation fully succeeds.
-    bool remove_realm(const std::string& user_identity, const std::string& raw_realm_path) const;
+    bool remove_realm(const std::string& local_identity, const std::string& raw_realm_path) const;
 
     /// Remove the Realm whose primary Realm file is located at `absolute_path`. Returns `true` if the remove
     /// operation fully succeeds.
@@ -104,6 +108,7 @@ private:
     static constexpr const char c_recovery_directory[] = "io.realm.object-server-recovered-realms";
     static constexpr const char c_metadata_directory[] = "metadata";
     static constexpr const char c_metadata_realm[] = "sync_metadata.realm";
+    static constexpr const char c_user_info_file[] = "__user_info";
 
     std::string get_special_directory(std::string directory_name) const;
 

--- a/src/sync/impl/sync_file.hpp
+++ b/src/sync/impl/sync_file.hpp
@@ -21,6 +21,8 @@
 
 #include <string>
 
+#include "sync/sync_user.hpp"
+
 #include <realm/util/optional.hpp>
 
 namespace realm {
@@ -61,18 +63,18 @@ void remove_nonempty_dir(const std::string& path);
 
 class SyncFileManager {
 public:
-    using StringPair = std::tuple<std::string, std::string>;
-
     SyncFileManager(std::string base_path) : m_base_path(std::move(base_path)) { }
 
     /// Return the user directory for a given user, creating it if it does not already exist.
-    std::string user_directory(const std::string& local_identity, util::Optional<StringPair> user_info=none) const;
+    std::string user_directory(const std::string& local_identity,
+                               util::Optional<SyncUserIdentifier> user_info=none) const;
 
     /// Remove the user directory for a given user.
     void remove_user_directory(const std::string& local_identity) const;       // throws
 
     /// Return the path for a given Realm, creating the user directory if it does not already exist.
-    std::string path(const std::string&, const std::string&, util::Optional<StringPair> user_info=none) const;
+    std::string path(const std::string&, const std::string&,
+                     util::Optional<SyncUserIdentifier> user_info=none) const;
 
     /// Remove the Realm at a given path for a given user. Returns `true` if the remove operation fully succeeds.
     bool remove_realm(const std::string& local_identity, const std::string& raw_realm_path) const;

--- a/src/sync/impl/sync_metadata.cpp
+++ b/src/sync/impl/sync_metadata.cpp
@@ -23,6 +23,7 @@
 #include "property.hpp"
 #include "results.hpp"
 #include "schema.hpp"
+#include "util/uuid.hpp"
 #if REALM_PLATFORM_APPLE
 #include "impl/apple/keychain_helper.hpp"
 #endif
@@ -35,6 +36,7 @@ namespace realm {
 static const char * const c_sync_userMetadata = "UserMetadata";
 static const char * const c_sync_marked_for_removal = "marked_for_removal";
 static const char * const c_sync_identity = "identity";
+static const char * const c_sync_local_uuid = "local_uuid";
 static const char * const c_sync_auth_server_url = "auth_server_url";
 static const char * const c_sync_user_token = "user_token";
 static const char * const c_sync_user_is_admin = "user_is_admin";
@@ -66,9 +68,10 @@ Schema make_schema()
 {
     return Schema{
         {c_sync_userMetadata, {
-            make_primary_key_property(c_sync_identity),
+            {c_sync_identity, PropertyType::String},
+            {c_sync_local_uuid, PropertyType::String},
             {c_sync_marked_for_removal, PropertyType::Bool},
-            make_nullable_string_property(c_sync_auth_server_url),
+            {c_sync_auth_server_url, PropertyType::String},
             make_nullable_string_property(c_sync_user_token),
             {c_sync_user_is_admin, PropertyType::Bool},
         }},
@@ -90,8 +93,7 @@ SyncMetadataManager::SyncMetadataManager(std::string path,
                                          bool should_encrypt,
                                          util::Optional<std::vector<char>> encryption_key)
 {
-    constexpr uint64_t SCHEMA_VERSION = 1;
-    std::lock_guard<std::mutex> lock(m_metadata_lock);
+    constexpr uint64_t SCHEMA_VERSION = 2;
 
     Realm::Config config;
     config.path = std::move(path);
@@ -110,6 +112,32 @@ SyncMetadataManager::SyncMetadataManager(std::string path,
         config.encryption_key = std::move(*encryption_key);
     }
 
+    config.migration_function = [](SharedRealm old_realm, SharedRealm realm, Schema&) {
+        if (old_realm->schema_version() < 2) {
+            TableRef old_table = ObjectStore::table_for_object_type(old_realm->read_group(), c_sync_userMetadata);
+            TableRef table = ObjectStore::table_for_object_type(realm->read_group(), c_sync_userMetadata);
+
+            // Get all the SyncUserMetadata objects.
+            Results results(old_realm, *old_table);
+
+            // Column indices.
+            size_t old_idx_identity = old_table->get_column_index(c_sync_identity);
+            size_t old_idx_url = old_table->get_column_index(c_sync_auth_server_url);
+            size_t idx_local_uuid = table->get_column_index(c_sync_local_uuid);
+            size_t idx_url = table->get_column_index(c_sync_auth_server_url);
+
+            for (size_t i=0; i<results.size(); i++) {
+                RowExpr entry = results.get(i);
+                // Set the UUID equal to the user identity for existing users.
+                auto identity = entry.get_string(old_idx_identity);
+                table->set_string(idx_local_uuid, entry.get_index(), identity);
+                // Migrate the auth server URLs to a non-nullable property.
+                auto url = entry.get_string(old_idx_url);
+                table->set_string(idx_url, entry.get_index(), url.is_null() ? "" : url);
+            }
+        }
+    };
+
     // Open the Realm.
     SharedRealm realm = Realm::get_shared_realm(config);
 
@@ -118,6 +146,7 @@ SyncMetadataManager::SyncMetadataManager(std::string path,
                                                                   c_sync_userMetadata)->get_descriptor();
     m_user_schema = {
         descriptor->get_column_index(c_sync_identity),
+        descriptor->get_column_index(c_sync_local_uuid),
         descriptor->get_column_index(c_sync_marked_for_removal),
         descriptor->get_column_index(c_sync_user_token),
         descriptor->get_column_index(c_sync_auth_server_url),
@@ -136,12 +165,6 @@ SyncMetadataManager::SyncMetadataManager(std::string path,
     m_metadata_config = std::move(config);
 }
 
-Realm::Config SyncMetadataManager::get_configuration() const
-{
-    std::lock_guard<std::mutex> lock(m_metadata_lock);
-    return m_metadata_config;
-}
-
 SyncUserMetadataResults SyncMetadataManager::all_unmarked_users() const
 {
     return get_users(false);
@@ -155,7 +178,7 @@ SyncUserMetadataResults SyncMetadataManager::all_users_marked_for_removal() cons
 SyncUserMetadataResults SyncMetadataManager::get_users(bool marked) const
 {
     // Open the Realm.
-    SharedRealm realm = Realm::get_shared_realm(get_configuration());
+    SharedRealm realm = Realm::get_shared_realm(m_metadata_config);
 
     TableRef table = ObjectStore::table_for_object_type(realm->read_group(), c_sync_userMetadata);
     Query query = table->where().equal(m_user_schema.idx_marked_for_removal, marked);
@@ -166,7 +189,7 @@ SyncUserMetadataResults SyncMetadataManager::get_users(bool marked) const
 
 SyncFileActionMetadataResults SyncMetadataManager::all_pending_actions() const
 {
-    SharedRealm realm = Realm::get_shared_realm(get_configuration());
+    SharedRealm realm = Realm::get_shared_realm(m_metadata_config);
     TableRef table = ObjectStore::table_for_object_type(realm->read_group(), c_sync_fileActionMetadata);
     Results results(realm, table->where());
     return SyncFileActionMetadataResults(std::move(results), std::move(realm), m_file_action_schema);
@@ -174,7 +197,7 @@ SyncFileActionMetadataResults SyncMetadataManager::all_pending_actions() const
 
 bool SyncMetadataManager::delete_metadata_action(const std::string& original_name) const
 {
-    auto shared_realm = Realm::get_shared_realm(get_configuration());
+    auto shared_realm = Realm::get_shared_realm(m_metadata_config);
 
     // Retrieve the row for this object.
     TableRef table = ObjectStore::table_for_object_type(shared_realm->read_group(), c_sync_fileActionMetadata);
@@ -189,65 +212,133 @@ bool SyncMetadataManager::delete_metadata_action(const std::string& original_nam
     return true;
 }
 
+util::Optional<SyncUserMetadata> SyncMetadataManager::get_or_make_user_metadata(const std::string& identity,
+                                                                                const std::string& url,
+                                                                                bool make_if_absent) const
+{
+    // Open the Realm.
+    auto realm = Realm::get_shared_realm(m_metadata_config);
+    auto& schema = m_user_schema;
+
+    // Retrieve or create the row for this object.
+    TableRef table = ObjectStore::table_for_object_type(realm->read_group(), c_sync_userMetadata);
+    Query query = table->where().equal(schema.idx_identity, identity).equal(schema.idx_auth_server_url, url);
+    Results results(realm, std::move(query));
+    REALM_ASSERT_DEBUG(results.size() < 2);
+    auto maybe_row_expr = results.first();
+    size_t row_idx = not_found;
+
+    if (!maybe_row_expr) {
+        if (!make_if_absent) {
+            return none;
+        }
+        realm->begin_transaction();
+        // Check the results again.
+        auto maybe_row_expr = results.first();
+        if (!maybe_row_expr) {
+            row_idx = table->add_empty_row();
+            std::string uuid = util::uuid_string();
+            table->set_string(schema.idx_identity, row_idx, identity);
+            table->set_string(schema.idx_auth_server_url, row_idx, url);
+            table->set_string(schema.idx_local_uuid, row_idx, uuid);
+            table->set_bool(schema.idx_user_is_admin, row_idx, false);
+            table->set_bool(schema.idx_marked_for_removal, row_idx, false);
+            realm->commit_transaction();
+        } else {
+            // Someone beat us to adding this user.
+            row_idx = maybe_row_expr->get_index();
+            realm->cancel_transaction();
+        }
+    } else {
+        row_idx = maybe_row_expr->get_index();
+    }
+    REALM_ASSERT(row_idx != not_found);
+    auto row = table->get(row_idx);
+    if (make_if_absent || !row.get_bool(schema.idx_marked_for_removal)) {
+        realm->begin_transaction();
+        // If make_is_absent is true, the user might have been marked for removal before.
+        table->set_bool(schema.idx_marked_for_removal, row_idx, false);
+        realm->commit_transaction();
+        return SyncUserMetadata(schema, std::move(realm), std::move(row));
+    }
+    return none;
+}
+
+SyncFileActionMetadata SyncMetadataManager::make_file_action_metadata(const std::string &original_name,
+                                                                      const std::string &url,
+                                                                      const std::string &local_uuid,
+                                                                      SyncFileActionMetadata::Action action,
+                                                                      util::Optional<std::string> new_name) const
+{
+    size_t raw_action = static_cast<size_t>(action);
+
+    // Open the Realm.
+    auto realm = Realm::get_shared_realm(m_metadata_config);
+    auto& schema = m_file_action_schema;
+
+    // Retrieve or create the row for this object.
+    TableRef table = ObjectStore::table_for_object_type(realm->read_group(), c_sync_fileActionMetadata);
+    realm->begin_transaction();
+    size_t row_idx = table->find_first_string(schema.idx_original_name, original_name);
+    if (row_idx == not_found) {
+        row_idx = table->add_empty_row();
+        table->set_string(schema.idx_original_name, row_idx, original_name);
+    }
+    table->set_string(schema.idx_new_name, row_idx, new_name);
+    table->set_int(schema.idx_action, row_idx, raw_action);
+    table->set_string(schema.idx_url, row_idx, url);
+    table->set_string(schema.idx_user_identity, row_idx, local_uuid);
+    realm->commit_transaction();
+    return SyncFileActionMetadata(schema, std::move(realm), table->get(row_idx));
+}
+
+util::Optional<SyncFileActionMetadata> SyncMetadataManager::get_file_action_metadata(const std::string& original_name) const
+{
+    auto realm = Realm::get_shared_realm(m_metadata_config);
+    auto schema = m_file_action_schema;
+    TableRef table = ObjectStore::table_for_object_type(realm->read_group(), c_sync_fileActionMetadata);
+    size_t row_idx = table->find_first_string(schema.idx_original_name, original_name);
+    if (row_idx == not_found)
+        return none;
+
+    return SyncFileActionMetadata(std::move(schema), std::move(realm), table->get(row_idx));
+}
+
 // MARK: - Sync user metadata
 
 SyncUserMetadata::SyncUserMetadata(Schema schema, SharedRealm realm, RowExpr row)
-: m_invalid(row.get_bool(schema.idx_marked_for_removal))
+: m_realm(std::move(realm))
 , m_schema(std::move(schema))
-, m_realm(std::move(realm))
 , m_row(row)
 { }
-
-SyncUserMetadata::SyncUserMetadata(const SyncMetadataManager& manager, std::string identity, bool make_if_absent)
-: m_schema(manager.m_user_schema)
-{
-    // Open the Realm.
-    m_realm = Realm::get_shared_realm(manager.get_configuration());
-
-    // Retrieve or create the row for this object.
-    TableRef table = ObjectStore::table_for_object_type(m_realm->read_group(), c_sync_userMetadata);
-    size_t row_idx = table->find_first_string(m_schema.idx_identity, identity);
-    if (row_idx == not_found) {
-        if (!make_if_absent) {
-            m_invalid = true;
-            m_realm = nullptr;
-            return;
-        }
-        m_realm->begin_transaction();
-        row_idx = table->find_first_string(m_schema.idx_identity, identity);
-        if (row_idx == not_found) {
-            row_idx = table->add_empty_row();
-            table->set_string(m_schema.idx_identity, row_idx, identity);
-            table->set_bool(m_schema.idx_user_is_admin, row_idx, false);
-            m_realm->commit_transaction();
-        } else {
-            // Someone beat us to adding this user.
-            m_realm->cancel_transaction();
-        }
-    }
-    m_row = table->get(row_idx);
-    if (make_if_absent) {
-        // User existed in the table, but had been marked for deletion. Unmark it.
-        m_realm->begin_transaction();
-        table->set_bool(m_schema.idx_marked_for_removal, row_idx, false);
-        m_realm->commit_transaction();
-        m_invalid = false;
-    } else {
-        m_invalid = m_row.get_bool(m_schema.idx_marked_for_removal);
-    }
-}
-
-bool SyncUserMetadata::is_valid() const
-{
-    return !m_invalid;
-}
 
 std::string SyncUserMetadata::identity() const
 {
     REALM_ASSERT(m_realm);
     m_realm->verify_thread();
-    StringData result = m_row.get_string(m_schema.idx_identity);
-    return result;
+    return m_row.get_string(m_schema.idx_identity);
+}
+
+std::string SyncUserMetadata::local_uuid() const
+{
+    REALM_ASSERT(m_realm);
+    m_realm->verify_thread();
+    return m_row.get_string(m_schema.idx_local_uuid);
+}
+
+util::Optional<std::string> SyncUserMetadata::user_token() const
+{
+    REALM_ASSERT(m_realm);
+    m_realm->verify_thread();
+    StringData result = m_row.get_string(m_schema.idx_user_token);
+    return result.is_null() ? util::none : util::make_optional(std::string(result));
+}
+
+std::string SyncUserMetadata::auth_server_url() const
+{
+    REALM_ASSERT(m_realm);
+    m_realm->verify_thread();
+    return m_row.get_string(m_schema.idx_auth_server_url);
 }
 
 bool SyncUserMetadata::is_admin() const
@@ -257,42 +348,23 @@ bool SyncUserMetadata::is_admin() const
     return m_row.get_bool(m_schema.idx_user_is_admin);
 }
 
-util::Optional<std::string> SyncUserMetadata::get_optional_string_field(size_t col_idx) const
+void SyncUserMetadata::set_user_token(util::Optional<std::string> user_token)
 {
-    REALM_ASSERT(m_realm);
-    m_realm->verify_thread();
-    StringData result = m_row.get_string(col_idx);
-    return result.is_null() ? util::none : util::make_optional(std::string(result));
-}
-
-util::Optional<std::string> SyncUserMetadata::server_url() const
-{
-    return get_optional_string_field(m_schema.idx_auth_server_url);
-}
-
-util::Optional<std::string> SyncUserMetadata::user_token() const
-{
-    return get_optional_string_field(m_schema.idx_user_token);
-}
-
-void SyncUserMetadata::set_state(util::Optional<std::string> server_url, util::Optional<std::string> user_token)
-{
-    if (m_invalid) {
+    if (m_invalid)
         return;
-    }
+
     REALM_ASSERT_DEBUG(m_realm);
     m_realm->verify_thread();
     m_realm->begin_transaction();
     m_row.set_string(m_schema.idx_user_token, *user_token);
-    m_row.set_string(m_schema.idx_auth_server_url, *server_url);
     m_realm->commit_transaction();
 }
 
 void SyncUserMetadata::set_is_admin(bool is_admin)
 {
-    if (m_invalid) {
+    if (m_invalid)
         return;
-    }
+
     REALM_ASSERT_DEBUG(m_realm);
     m_realm->verify_thread();
     m_realm->begin_transaction();
@@ -302,9 +374,9 @@ void SyncUserMetadata::set_is_admin(bool is_admin)
 
 void SyncUserMetadata::mark_for_removal()
 {
-    if (m_invalid) {
+    if (m_invalid)
         return;
-    }
+
     m_realm->verify_thread();
     m_realm->begin_transaction();
     m_row.set_bool(m_schema.idx_marked_for_removal, true);
@@ -323,50 +395,9 @@ void SyncUserMetadata::remove()
 
 // MARK: - File action metadata
 
-util::Optional<SyncFileActionMetadata> SyncFileActionMetadata::metadata_for_path(const std::string& original_name, const SyncMetadataManager& manager)
-{
-    auto realm = Realm::get_shared_realm(manager.get_configuration());
-    auto schema = manager.m_file_action_schema;
-    TableRef table = ObjectStore::table_for_object_type(realm->read_group(), c_sync_fileActionMetadata);
-    size_t row_idx = table->find_first_string(schema.idx_original_name, original_name);
-    if (row_idx == not_found) {
-        return none;
-    }
-    return SyncFileActionMetadata(std::move(schema), std::move(realm), table->get(row_idx));
-}                   
-
-SyncFileActionMetadata::SyncFileActionMetadata(const SyncMetadataManager& manager,
-                                               Action action,
-                                               const std::string& original_name,
-                                               const std::string& url,
-                                               const std::string& user_identity,
-                                               util::Optional<std::string> new_name)
-: m_schema(manager.m_file_action_schema)
-{
-    size_t raw_action = static_cast<size_t>(action);
-
-    // Open the Realm.
-    m_realm = Realm::get_shared_realm(manager.get_configuration());
-
-    // Retrieve or create the row for this object.
-    TableRef table = ObjectStore::table_for_object_type(m_realm->read_group(), c_sync_fileActionMetadata);
-    m_realm->begin_transaction();
-    size_t row_idx = table->find_first_string(m_schema.idx_original_name, original_name);
-    if (row_idx == not_found) {
-        row_idx = table->add_empty_row();
-        table->set_string(m_schema.idx_original_name, row_idx, original_name);
-    }
-    table->set_string(m_schema.idx_new_name, row_idx, new_name);
-    table->set_int(m_schema.idx_action, row_idx, raw_action);
-    table->set_string(m_schema.idx_url, row_idx, url);
-    table->set_string(m_schema.idx_user_identity, row_idx, user_identity);
-    m_realm->commit_transaction();
-    m_row = table->get(row_idx);
-}
-
 SyncFileActionMetadata::SyncFileActionMetadata(Schema schema, SharedRealm realm, RowExpr row)
-: m_schema(std::move(schema))
-, m_realm(std::move(realm))
+: m_realm(std::move(realm))
+, m_schema(std::move(schema))
 , m_row(row)
 { }
 
@@ -385,6 +416,13 @@ util::Optional<std::string> SyncFileActionMetadata::new_name() const
     return result.is_null() ? util::none : util::make_optional(std::string(result));
 }
 
+std::string SyncFileActionMetadata::user_local_uuid() const
+{
+    REALM_ASSERT(m_realm);
+    m_realm->verify_thread();
+    return m_row.get_string(m_schema.idx_user_identity);
+}
+
 SyncFileActionMetadata::Action SyncFileActionMetadata::action() const
 {
     REALM_ASSERT(m_realm);
@@ -397,13 +435,6 @@ std::string SyncFileActionMetadata::url() const
     REALM_ASSERT(m_realm);
     m_realm->verify_thread();
     return m_row.get_string(m_schema.idx_url);
-}
-
-std::string SyncFileActionMetadata::user_identity() const
-{
-    REALM_ASSERT(m_realm);
-    m_realm->verify_thread();
-    return m_row.get_string(m_schema.idx_user_identity);
 }
 
 void SyncFileActionMetadata::remove()

--- a/src/sync/impl/sync_metadata.hpp
+++ b/src/sync/impl/sync_metadata.hpp
@@ -33,59 +33,72 @@ template<typename T> class BasicRowExpr;
 using RowExpr = BasicRowExpr<Table>;
 class SyncMetadataManager;
 
+// A facade for a metadata Realm object representing a sync user.
 class SyncUserMetadata {
 public:
     struct Schema {
+        // The ROS identity of the user. This, plus the auth server URL, uniquely identifies a user.
         size_t idx_identity;
+        // A locally issued UUID for the user. This is used to generate the on-disk user directory.
+        size_t idx_local_uuid;
+        // Whether or not this user has been marked for removal.
         size_t idx_marked_for_removal;
+        // The cached refresh token for this user.
         size_t idx_user_token;
+        // The URL of the authentication server this user resides upon.
         size_t idx_auth_server_url;
+        // Whether or not the auth server reported that this user is marked as an administrator.
         size_t idx_user_is_admin;
     };
 
+    // Cannot be set after creation.
     std::string identity() const;
-    bool is_admin() const;
-    util::Optional<std::string> server_url() const;
-    util::Optional<std::string> user_token() const;
 
-    void set_state(util::Optional<std::string> server_url, util::Optional<std::string> user_token);
+    // Cannot be set after creation.
+    std::string local_uuid() const;
+
+    util::Optional<std::string> user_token() const;
+    void set_user_token(util::Optional<std::string>);
+
+    // Cannot be set after creation.
+    std::string auth_server_url() const;
+
+    bool is_admin() const;
     void set_is_admin(bool);
 
-    // Remove the user from the metadata database.
-    void remove();
     // Mark the user as "ready for removal". Since Realm files cannot be safely deleted after being opened, the actual
     // deletion of a user must be deferred until the next time the host application is launched.
     void mark_for_removal();
 
-    bool is_valid() const;
+    void remove();
 
-    // Construct a new user.
-    //
-    // If `make_if_absent` is false and the user is absent or removed, a 'removed' user will be returned for which all
-    // set operations are no-ops and all get operations cause an assert to fail.
-    //
-    // If `make_if_absent` is true and the user was previously marked for deletion, it will be unmarked.
-    SyncUserMetadata(const SyncMetadataManager&, std::string, bool make_if_absent=true);
+    bool is_valid() const
+    {
+        return !m_invalid;
+    }
 
+    // INTERNAL USE ONLY
     SyncUserMetadata(Schema schema, SharedRealm realm, RowExpr row);
-
 private:
     bool m_invalid = false;
-
-    util::Optional<std::string> get_optional_string_field(size_t col_idx) const;
-
-    Schema m_schema;
     SharedRealm m_realm;
+    Schema m_schema;
     Row m_row;
 };
 
+// A facade for a metadata Realm object representing a pending action to be carried out upon a specific file(s).
 class SyncFileActionMetadata {
 public:
     struct Schema {
+        // The original path on disk of the file (generally, the main file for an on-disk Realm).
         size_t idx_original_name;
+        // A new path on disk for a file to be written to. Context-dependent.
         size_t idx_new_name;
+        // An enum describing the action to take.
         size_t idx_action;
+        // The full remote URL of the Realm on the ROS.
         size_t idx_url;
+        // The local UUID of the user to whom the file action applies (despite the internal column name).
         size_t idx_user_identity;
     };
 
@@ -96,8 +109,6 @@ public:
         BackUpThenDeleteRealm
     };
 
-    static util::Optional<SyncFileActionMetadata> metadata_for_path(const std::string&, const SyncMetadataManager&);
-
     // The absolute path to the Realm file in question.
     std::string original_name() const;
 
@@ -107,24 +118,18 @@ public:
     // For all other `Action`s, it is ignored.
     util::Optional<std::string> new_name() const;
 
+    // Get the local UUID of the user associated with this file action metadata.
+    std::string user_local_uuid() const;
+
     Action action() const;
     std::string url() const;
-    std::string user_identity() const;
-
-    // Remove the action from the metadata database, because it was completed or is now invalid.
     void remove();
 
-    SyncFileActionMetadata(const SyncMetadataManager& manager,
-                           Action action,
-                           const std::string& original_name,
-                           const std::string& url,
-                           const std::string& user_identity,
-                           util::Optional<std::string> new_name=none);
-
+    // INTERNAL USE ONLY
     SyncFileActionMetadata(Schema schema, SharedRealm realm, RowExpr row);
 private:
-    Schema m_schema;
     SharedRealm m_realm;
+    Schema m_schema;
     Row m_row;
 };
 
@@ -156,6 +161,7 @@ private:
 using SyncUserMetadataResults = SyncMetadataResults<SyncUserMetadata>;
 using SyncFileActionMetadataResults = SyncMetadataResults<SyncFileActionMetadata>;
 
+// A facade for the application's metadata Realm.
 class SyncMetadataManager {
 friend class SyncUserMetadata;
 friend class SyncFileActionMetadata;
@@ -175,8 +181,21 @@ public:
     // Returns true iff there was an existing metadata action and it was deleted.
     bool delete_metadata_action(const std::string&) const;
 
-    Realm::Config get_configuration() const;
+    // Retrieve or create user metadata.
+    // Note: if `make_is_absent` is true and the user has been marked for deletion, it will be unmarked.
+    util::Optional<SyncUserMetadata> get_or_make_user_metadata(const std::string& identity, const std::string& url,
+                                                               bool make_if_absent=true) const;
 
+    // Retrieve file action metadata.
+    util::Optional<SyncFileActionMetadata> get_file_action_metadata(const std::string& path) const;
+
+    // Create file action metadata.
+    SyncFileActionMetadata make_file_action_metadata(const std::string& original_name,
+                                                     const std::string& url,
+                                                     const std::string& local_uuid,
+                                                     SyncFileActionMetadata::Action action,
+                                                     util::Optional<std::string> new_name=none) const;
+    
     /// Construct the metadata manager.
     ///
     /// If the platform supports it, setting `should_encrypt` to `true` and not specifying an encryption key will make
@@ -188,12 +207,9 @@ public:
 
 private:
     SyncUserMetadataResults get_users(bool marked) const;
-
     Realm::Config m_metadata_config;
-
     SyncUserMetadata::Schema m_user_schema;
     SyncFileActionMetadata::Schema m_file_action_schema;
-    mutable std::mutex m_metadata_lock;
 };
 
 }

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -43,7 +43,7 @@ void SyncManager::configure_file_system(const std::string& base_file_path,
     struct UserCreationData {
         std::string identity;
         std::string user_token;
-        util::Optional<std::string> server_url;
+        std::string server_url;
         bool is_admin;
     };
 
@@ -106,7 +106,7 @@ void SyncManager::configure_file_system(const std::string& base_file_path,
             auto user_data = users.get(i);
             auto user_token = user_data.user_token();
             auto identity = user_data.identity();
-            auto server_url = user_data.server_url();
+            auto server_url = user_data.auth_server_url();
             bool is_admin = user_data.is_admin();
             if (user_token) {
                 UserCreationData data = {
@@ -127,7 +127,7 @@ void SyncManager::configure_file_system(const std::string& base_file_path,
             // FIXME: delete user data in a different way? (This deletes a logged-out user's data as soon as the app
             // launches again, which might not be how some apps want to treat their data.)
             try {
-                m_file_manager->remove_user_directory(user.identity());
+                m_file_manager->remove_user_directory(user.local_uuid());
                 dead_users.emplace_back(std::move(user));
             } catch (util::File::AccessError const&) {
                 continue;
@@ -140,9 +140,11 @@ void SyncManager::configure_file_system(const std::string& base_file_path,
     {
         std::lock_guard<std::mutex> lock(m_user_mutex);
         for (auto& user_data : users_to_add) {
-            auto user = std::make_shared<SyncUser>(user_data.user_token, user_data.identity, user_data.server_url);
+            auto& identity = user_data.identity;
+            auto& server_url = user_data.server_url;
+            auto user = std::make_shared<SyncUser>(user_data.user_token, identity, server_url);
             user->set_is_admin(user_data.is_admin);
-            m_users.insert({ user_data.identity, std::move(user) });
+            m_users.insert({ {identity, server_url}, std::move(user) });
         }
     }
 }
@@ -152,13 +154,11 @@ bool SyncManager::immediately_run_file_actions(const std::string& realm_path)
     if (!m_metadata_manager) {
         return false;
     }
-    auto metadata = SyncFileActionMetadata::metadata_for_path(realm_path, *m_metadata_manager);
-    if (!metadata) {
-        return false;
-    }
-    if (run_file_action(*metadata)) {
-        metadata->remove();
-        return true;
+    if (auto metadata = m_metadata_manager->get_file_action_metadata(realm_path)) {
+        if (run_file_action(*metadata)) {
+            metadata->remove();
+            return true;
+        }
     }
     return false;
 }
@@ -198,6 +198,7 @@ void SyncManager::reset_for_testing()
         // Destroy all the users.
         std::lock_guard<std::mutex> lock(m_user_mutex);
         m_users.clear();
+        m_admin_token_users.clear();
     }
     {
         std::lock_guard<std::mutex> lock(m_mutex);
@@ -286,25 +287,21 @@ bool SyncManager::perform_metadata_update(std::function<void(const SyncMetadataM
 }
 
 std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& identity,
-                                                std::string refresh_token,
-                                                util::Optional<std::string> auth_server_url,
-                                                SyncUser::TokenType token_type)
+                                                const std::string& auth_server_url,
+                                                std::string refresh_token)
 {
     std::lock_guard<std::mutex> lock(m_user_mutex);
-    auto it = m_users.find(identity);
+    auto it = m_users.find({identity, auth_server_url});
     if (it == m_users.end()) {
         // No existing user.
-        auto new_user = std::make_shared<SyncUser>(std::move(refresh_token), identity, auth_server_url, token_type);
-        m_users.insert({ identity, new_user });
+        auto new_user = std::make_shared<SyncUser>(std::move(refresh_token),
+                                                   identity,
+                                                   auth_server_url,
+                                                   SyncUser::TokenType::Normal);
+        m_users.insert({ {identity, auth_server_url}, new_user });
         return new_user;
     } else {
         auto user = it->second;
-        if (auth_server_url && *auth_server_url != user->server_url()) {
-            throw std::invalid_argument("Cannot retrieve an existing user specifying a different auth server.");
-        }
-        if (user->token_type() != token_type) {
-            throw std::invalid_argument("Cannot retrieve a user specifying a different token type.");
-        }
         if (user->state() == SyncUser::State::Error) {
             return nullptr;
         }
@@ -313,27 +310,36 @@ std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& identity,
     }
 }
 
-std::shared_ptr<SyncUser> SyncManager::get_existing_logged_in_user(const std::string& identity) const
+std::shared_ptr<SyncUser> SyncManager::get_admin_token_user(const std::string& identifier, std::string refresh_token)
 {
     std::lock_guard<std::mutex> lock(m_user_mutex);
-    auto it = m_users.find(identity);
-    if (it == m_users.end()) {
-        return nullptr;
+    auto it = m_admin_token_users.find(identifier);
+    if (it == m_admin_token_users.end()) {
+        // No existing user.
+        auto new_user = std::make_shared<SyncUser>(std::move(refresh_token),
+                                                   identifier,
+                                                   none,
+                                                   SyncUser::TokenType::Admin);
+        m_admin_token_users.insert({ identifier, new_user });
+        return new_user;
+    } else {
+        return it->second;
     }
-    auto ptr = it->second;
-    return (ptr->state() == SyncUser::State::Active ? ptr : nullptr);
 }
 
 std::vector<std::shared_ptr<SyncUser>> SyncManager::all_logged_in_users() const
 {
     std::lock_guard<std::mutex> lock(m_user_mutex);
     std::vector<std::shared_ptr<SyncUser>> users;
-    users.reserve(m_users.size());
+    users.reserve(m_users.size() + m_admin_token_users.size());
     for (auto& it : m_users) {
         auto user = it.second;
         if (user->state() == SyncUser::State::Active) {
             users.emplace_back(std::move(user));
         }
+    }
+    for (auto& it : m_admin_token_users) {
+        users.emplace_back(std::move(it.second));
     }
     return users;
 }
@@ -344,20 +350,27 @@ std::shared_ptr<SyncUser> SyncManager::get_current_user() const
     
     auto is_active_user = [](auto& el) { return el.second->state() == SyncUser::State::Active; };
     auto it = std::find_if(m_users.begin(), m_users.end(), is_active_user);
-    if (it == m_users.end()) {
+    if (it == m_users.end())
         return nullptr;
-    }
-    if (std::find_if(std::next(it), m_users.end(), is_active_user) != m_users.end()) {
+
+    if (std::find_if(std::next(it), m_users.end(), is_active_user) != m_users.end())
         throw std::logic_error("Current user is not valid if more that one valid, logged-in user exists.");
-    }
+
     return it->second;
 }
 
-std::string SyncManager::path_for_realm(const std::string& user_identity, const std::string& raw_realm_url) const
+std::string SyncManager::path_for_realm(const SyncUser& user, const std::string& raw_realm_url) const
 {
+    using StringPair = std::tuple<std::string, std::string>;
     std::lock_guard<std::mutex> lock(m_file_system_mutex);
     REALM_ASSERT(m_file_manager);
-    return m_file_manager->path(user_identity, raw_realm_url);
+    const auto user_identity = user.identity();
+    const auto user_local_identity = user.local_identity();
+    std::string local_identity = user_local_identity.value_or(user_identity);
+    util::Optional<StringPair> user_info = (user_local_identity
+                                            ? util::Optional<StringPair>(StringPair(user_identity, user.server_url()))
+                                            : none);
+    return m_file_manager->path(local_identity, raw_realm_url, std::move(user_info));
 }
 
 std::string SyncManager::recovery_directory_path() const
@@ -381,18 +394,15 @@ std::shared_ptr<SyncSession> SyncManager::get_existing_session_locked(const std:
 {
     REALM_ASSERT(!m_session_mutex.try_lock());
     auto it = m_sessions.find(path);
-    if (it == m_sessions.end()) {
-        return nullptr;
-    }
-    return it->second;
+    return (it == m_sessions.end() ? nullptr : it->second);
 }
 
 std::shared_ptr<SyncSession> SyncManager::get_existing_session(const std::string& path) const
 {
     std::lock_guard<std::mutex> lock(m_session_mutex);
-    if (auto session = get_existing_session_locked(path)) {
+    if (auto session = get_existing_session_locked(path))
         return session->external_reference();
-    }
+
     return nullptr;
 }
 

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -313,10 +313,10 @@ std::shared_ptr<SyncUser> SyncManager::get_user(const SyncUserIdentifier& identi
 
 std::shared_ptr<SyncUser> SyncManager::get_admin_token_user_from_identity(const std::string& identity,
                                                                           util::Optional<std::string> server_url,
-                                                                          util::Optional<std::string> token)
+                                                                          const std::string& token)
 {
     if (server_url)
-        return get_admin_token_user(*server_url, std::move(token), identity);
+        return get_admin_token_user(*server_url, token, identity);
 
     std::lock_guard<std::mutex> lock(m_user_mutex);
     // Look up the user based off the identity.
@@ -324,10 +324,7 @@ std::shared_ptr<SyncUser> SyncManager::get_admin_token_user_from_identity(const 
     auto it = m_admin_token_users.find(identity);
     if (it == m_admin_token_users.end()) {
         // No existing user.
-        if (!token)
-            throw std::invalid_argument("User did not exist, but token was not provided.");
-
-        auto new_user = std::make_shared<SyncUser>(std::move(*token),
+        auto new_user = std::make_shared<SyncUser>(token,
                                                    c_admin_identity,
                                                    std::move(server_url),
                                                    identity,
@@ -340,7 +337,7 @@ std::shared_ptr<SyncUser> SyncManager::get_admin_token_user_from_identity(const 
 }
 
 std::shared_ptr<SyncUser> SyncManager::get_admin_token_user(const std::string& server_url,
-                                                            util::Optional<std::string> token,
+                                                            const std::string& token,
                                                             util::Optional<std::string> old_identity)
 {
     std::shared_ptr<SyncUser> user;
@@ -350,10 +347,7 @@ std::shared_ptr<SyncUser> SyncManager::get_admin_token_user(const std::string& s
         auto it = m_admin_token_users.find(server_url);
         if (it == m_admin_token_users.end()) {
             // No existing user.
-            if (!token)
-                throw std::invalid_argument("User did not exist, but token was not provided.");
-
-            auto new_user = std::make_shared<SyncUser>(std::move(*token),
+            auto new_user = std::make_shared<SyncUser>(token,
                                                        c_admin_identity,
                                                        server_url,
                                                        c_admin_identity + server_url,

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -106,10 +106,11 @@ public:
     // If a logged-out user exists, it will marked as logged back in.
     std::shared_ptr<SyncUser> get_user(const SyncUserIdentifier& identifier, std::string refresh_token);
 
-    // Get an admin token user for the given identifier. 
-    std::shared_ptr<SyncUser> get_admin_token_user(const std::string& identifier,
-                                                   std::string refresh_token,
-                                                   util::Optional<std::string> server_url=none);
+    // Get or create an admin token user for the given URL.
+    // If a user does not already exist and the token is not provided, an exception will be thrown.
+    // If the user already exists and a token is provided, the token value will be ignored.
+    std::shared_ptr<SyncUser> get_admin_token_user(const std::string& server_url,
+                                                   util::Optional<std::string> token=none);
 
     // Get an existing user for a given identifier, if one exists and is logged in.
     std::shared_ptr<SyncUser> get_existing_logged_in_user(const SyncUserIdentifier&) const;

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -111,15 +111,14 @@ public:
     // use of identities for admin users completely.
     std::shared_ptr<SyncUser> get_admin_token_user_from_identity(const std::string& identity,
                                                                  util::Optional<std::string> server_url,
-                                                                 util::Optional<std::string> token);
+                                                                 const std::string& token);
 
     // Get or create an admin token user for the given URL.
-    // If a user does not already exist and the token is not provided, an exception will be thrown.
-    // If the user already exists and a token is provided, the token value will be ignored.
+    // If the user already exists, the token value will be ignored.
     // If an old identity is provided and a directory for the user already exists, the directory
     // will be renamed.
     std::shared_ptr<SyncUser> get_admin_token_user(const std::string& server_url,
-                                                   util::Optional<std::string> token=none,
+                                                   const std::string& token,
                                                    util::Optional<std::string> old_identity=none);
 
     // Get an existing user for a given identifier, if one exists and is logged in.

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -109,6 +109,9 @@ public:
     // Get or create an admin token user based on the given identity.
     // Please note: a future version will remove this method and deprecate the
     // use of identities for admin users completely.
+    // Warning: it is an error to create or get an admin token user with a given identity and
+    // specifying a URL, and later get that same user by specifying only the identity and no
+    // URL, or vice versa.
     std::shared_ptr<SyncUser> get_admin_token_user_from_identity(const std::string& identity,
                                                                  util::Optional<std::string> server_url,
                                                                  const std::string& token);

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -104,12 +104,10 @@ public:
 
     // Get a sync user for a given identity, or create one if none exists yet, and set its token.
     // If a logged-out user exists, it will marked as logged back in.
-    std::shared_ptr<SyncUser> get_user(const std::string& identity,
-                                       const std::string& auth_server_url,
-                                       std::string refresh_token);
+    std::shared_ptr<SyncUser> get_user(const SyncUserIdentifier& identifier, std::string refresh_token);
 
     // Get an admin token user for the given identifier. 
-    std::shared_ptr<SyncUser> get_admin_token_user(const std::string&, std::string);
+    std::shared_ptr<SyncUser> get_admin_token_user(const std::string& identifier, std::string refresh_token);
 
     // Get all the users that are logged in and not errored out.
     std::vector<std::shared_ptr<SyncUser>> all_logged_in_users() const;
@@ -156,28 +154,8 @@ private:
     // Protects m_users
     mutable std::mutex m_user_mutex;
 
-    // A custom key for the user map system. It's basically a hashable tuple.
-    struct UserMapKey {
-        std::string user_id;
-        std::string auth_server_url;
-
-        bool operator==(const UserMapKey& other) const
-        {
-            return user_id == other.user_id && auth_server_url == other.auth_server_url;
-        }
-
-        struct Hasher {
-            std::size_t operator()(const UserMapKey& k) const
-            {
-                using std::string;
-                using std::hash;
-                return ((hash<string>()(k.user_id) ^ (hash<string>()(k.auth_server_url) << 1)) >> 1);
-            }
-        };
-    };
-
     // A map of user ID/auth server URL pairs to (shared pointers to) SyncUser objects.
-    std::unordered_map<UserMapKey, std::shared_ptr<SyncUser>, UserMapKey::Hasher> m_users;
+    std::unordered_map<SyncUserIdentifier, std::shared_ptr<SyncUser>> m_users;
     // A map of local identifiers to admin token users.
     std::unordered_map<std::string, std::shared_ptr<SyncUser>> m_admin_token_users;
 

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -107,7 +107,9 @@ public:
     std::shared_ptr<SyncUser> get_user(const SyncUserIdentifier& identifier, std::string refresh_token);
 
     // Get an admin token user for the given identifier. 
-    std::shared_ptr<SyncUser> get_admin_token_user(const std::string& identifier, std::string refresh_token);
+    std::shared_ptr<SyncUser> get_admin_token_user(const std::string& identifier,
+                                                   std::string refresh_token,
+                                                   util::Optional<std::string> server_url=none);
 
     // Get an existing user for a given identifier, if one exists and is logged in.
     std::shared_ptr<SyncUser> get_existing_logged_in_user(const SyncUserIdentifier&) const;

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -106,11 +106,21 @@ public:
     // If a logged-out user exists, it will marked as logged back in.
     std::shared_ptr<SyncUser> get_user(const SyncUserIdentifier& identifier, std::string refresh_token);
 
+    // Get or create an admin token user based on the given identity.
+    // Please note: a future version will remove this method and deprecate the
+    // use of identities for admin users completely.
+    std::shared_ptr<SyncUser> get_admin_token_user_from_identity(const std::string& identity,
+                                                                 util::Optional<std::string> server_url,
+                                                                 util::Optional<std::string> token);
+
     // Get or create an admin token user for the given URL.
     // If a user does not already exist and the token is not provided, an exception will be thrown.
     // If the user already exists and a token is provided, the token value will be ignored.
+    // If an old identity is provided and a directory for the user already exists, the directory
+    // will be renamed.
     std::shared_ptr<SyncUser> get_admin_token_user(const std::string& server_url,
-                                                   util::Optional<std::string> token=none);
+                                                   util::Optional<std::string> token=none,
+                                                   util::Optional<std::string> old_identity=none);
 
     // Get an existing user for a given identifier, if one exists and is logged in.
     std::shared_ptr<SyncUser> get_existing_logged_in_user(const SyncUserIdentifier&) const;
@@ -133,6 +143,8 @@ public:
 
 private:
     using ReconnectMode = sync::Client::ReconnectMode;
+    
+    static constexpr const char c_admin_identity[] = "__auth";
 
     // Stop tracking the session for the given path if it is inactive.
     // No-op if the session is either still active or in the active sessions list

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -109,6 +109,9 @@ public:
     // Get an admin token user for the given identifier. 
     std::shared_ptr<SyncUser> get_admin_token_user(const std::string& identifier, std::string refresh_token);
 
+    // Get an existing user for a given identifier, if one exists and is logged in.
+    std::shared_ptr<SyncUser> get_existing_logged_in_user(const SyncUserIdentifier&) const;
+
     // Get all the users that are logged in and not errored out.
     std::vector<std::shared_ptr<SyncUser>> all_logged_in_users() const;
     // Gets the currently logged in user. If there are more than 1 users logged in, an exception is thrown.

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -432,12 +432,11 @@ void SyncSession::update_error_and_mark_file_for_deletion(SyncError& error, Shou
                                                    action,
                                                    original_path=std::move(original_path),
                                                    recovery_path=std::move(recovery_path)](const auto& manager) {
-        SyncFileActionMetadata(manager,
-                               action,
-                               original_path,
-                               m_config.realm_url,
-                               m_config.user->identity(),
-                               util::Optional<std::string>(std::move(recovery_path)));
+        manager.make_file_action_metadata(original_path,
+                                          m_config.realm_url,
+                                          m_config.user->identity(),
+                                          action,
+                                          util::Optional<std::string>(std::move(recovery_path)));
     });
 }
 

--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -56,9 +56,7 @@ SyncUser::SyncUser(std::string refresh_token,
             m_local_identity = m_identity;
     } else {
         // Admin token users. The local identity serves as the directory path.
-        if (!local_identity)
-            throw std::invalid_argument("Admin token users must specify a local identity.");
-
+        REALM_ASSERT(local_identity);
         m_local_identity = std::move(*local_identity);
     }
 }

--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -252,3 +252,10 @@ void SyncUser::register_permission_session(const std::string& path)
 }
 
 }
+
+namespace std {
+size_t hash<realm::SyncUserIdentifier>::operator()(const realm::SyncUserIdentifier& k) const
+{
+    return ((hash<string>()(k.user_id) ^ (hash<string>()(k.auth_server_url) << 1)) >> 1);
+}
+}

--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -27,8 +27,11 @@ namespace realm {
 SyncUserContextFactory SyncUser::s_binding_context_factory;
 std::mutex SyncUser::s_binding_context_factory_mutex;
 
-SyncUser::SyncUser(std::string refresh_token, std::string identity,
-                   util::Optional<std::string> server_url, TokenType token_type)
+SyncUser::SyncUser(std::string refresh_token,
+                   std::string identity,
+                   util::Optional<std::string> server_url,
+                   util::Optional<std::string> local_identity,
+                   TokenType token_type)
 : m_state(State::Active)
 , m_server_url(server_url.value_or(""))
 , m_token_type(token_type)
@@ -43,12 +46,20 @@ SyncUser::SyncUser(std::string refresh_token, std::string identity,
     }
     if (token_type == TokenType::Normal) {
         REALM_ASSERT(m_server_url.length() > 0);
-        SyncManager::shared().perform_metadata_update([=](const auto& manager) {
+        bool updated = SyncManager::shared().perform_metadata_update([=](const auto& manager) {
             auto metadata = manager.get_or_make_user_metadata(m_identity, m_server_url);
             metadata->set_user_token(m_refresh_token);
             m_is_admin = metadata->is_admin();
             m_local_identity = metadata->local_uuid();
         });
+        if (!updated)
+            m_local_identity = m_identity;
+    } else {
+        // Admin token users. The local identity serves as the directory path.
+        if (!local_identity)
+            throw std::invalid_argument("Admin token users must specify a local identity.");
+
+        m_local_identity = std::move(*local_identity);
     }
 }
 

--- a/src/sync/sync_user.hpp
+++ b/src/sync/sync_user.hpp
@@ -42,6 +42,17 @@ public:
 
 using SyncUserContextFactory = std::function<std::shared_ptr<SyncUserContext>()>;
 
+// A struct that uniquely identifies a user. Consists of ROS identity and auth server URL.
+struct SyncUserIdentifier {
+    std::string user_id;
+    std::string auth_server_url;
+
+    bool operator==(const SyncUserIdentifier& other) const
+    {
+        return user_id == other.user_id && auth_server_url == other.auth_server_url;
+    }
+};
+
 // A `SyncUser` represents a single user account. Each user manages the sessions that
 // are associated with it.
 class SyncUser {
@@ -175,6 +186,12 @@ private:
     std::unordered_map<std::string, std::weak_ptr<SyncSession>> m_waiting_sessions;
 };
 
+}
+
+namespace std {
+template<> struct hash<realm::SyncUserIdentifier> {
+    size_t operator()(realm::SyncUserIdentifier const&) const;
+};
 }
 
 #endif // REALM_OS_SYNC_USER_HPP

--- a/src/sync/sync_user.hpp
+++ b/src/sync/sync_user.hpp
@@ -102,10 +102,14 @@ public:
         return m_identity;
     }
 
-    // FIXME: remove this APIs once the new token system is implemented.
     const std::string& server_url() const noexcept
     {
         return m_server_url;
+    }
+
+    util::Optional<std::string> local_identity() const noexcept
+    {
+        return m_local_identity;
     }
 
     std::string refresh_token() const;
@@ -137,12 +141,14 @@ private:
 
     util::AtomicSharedPtr<SyncUserContext> m_binding_context;
 
+    // A locally assigned UUID intended to provide a level of indirection for various features.
+    util::Optional<std::string> m_local_identity;
+
     std::weak_ptr<SyncSession> m_management_session;
     std::weak_ptr<SyncSession> m_permission_session;
 
-    // The auth server URL. Bindings should set this appropriately when they retrieve
-    // instances of `SyncUser`s.
-    // FIXME: once the new token system is implemented, this can be removed completely.
+    // The auth server URL associated with this user. Set upon creation. The empty string for
+    // auth token users.
     std::string m_server_url;
 
     // Mark the user as invalid, since a fatal user-related error was encountered.

--- a/src/sync/sync_user.hpp
+++ b/src/sync/sync_user.hpp
@@ -73,6 +73,7 @@ public:
     SyncUser(std::string refresh_token,
              std::string identity,
              util::Optional<std::string> server_url,
+             util::Optional<std::string> local_identity=none,
              TokenType token_type=TokenType::Normal);
 
     // Return a list of all sessions belonging to this user.
@@ -118,7 +119,7 @@ public:
         return m_server_url;
     }
 
-    util::Optional<std::string> local_identity() const noexcept
+    const std::string& local_identity() const noexcept
     {
         return m_local_identity;
     }
@@ -153,7 +154,7 @@ private:
     util::AtomicSharedPtr<SyncUserContext> m_binding_context;
 
     // A locally assigned UUID intended to provide a level of indirection for various features.
-    util::Optional<std::string> m_local_identity;
+    std::string m_local_identity;
 
     std::weak_ptr<SyncSession> m_management_session;
     std::weak_ptr<SyncSession> m_permission_session;

--- a/tests/sync/file.cpp
+++ b/tests/sync/file.cpp
@@ -35,6 +35,8 @@ static void prepare_sync_manager_test(void) {
     util::make_dir(manager_path);
 }
 
+// TODO: test writing the backup file
+
 TEST_CASE("sync_file: percent-encoding APIs", "[sync]") {
     SECTION("does not encode a string that has no restricted characters") {
         const std::string expected = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_-";

--- a/tests/sync/file.cpp
+++ b/tests/sync/file.cpp
@@ -21,6 +21,8 @@
 #include "shared_realm.hpp"
 #include <realm/util/file.hpp>
 
+#include <fstream>
+
 using namespace realm;
 using namespace realm::util;
 using File = realm::util::File;
@@ -140,36 +142,63 @@ TEST_CASE("sync_file: URL manipulation APIs", "[sync]") {
 }
 
 TEST_CASE("sync_file: SyncFileManager APIs", "[sync]") {
-    const std::string identity = "123456789";
+    const std::string local_identity = "123456789";
     const std::string manager_path = base_path + "syncmanager/";
     prepare_sync_manager_test();
     auto manager = SyncFileManager(manager_path);
 
     SECTION("user directory APIs") {
-        const std::string expected = manager_path + "realm-object-server/123456789/";
+        const std::string expected = manager_path + "realm-object-server/" + local_identity + "/";
 
         SECTION("getting a user directory") {
             SECTION("that didn't exist before succeeds") {
-                auto actual = manager.user_directory(identity);
+                auto actual = manager.user_directory(local_identity);
                 REQUIRE(actual == expected);
                 REQUIRE_DIR_EXISTS(expected);
             }
             SECTION("that already existed succeeds") {
-                auto actual = manager.user_directory(identity);
+                auto actual = manager.user_directory(local_identity);
                 REQUIRE(actual == expected);
                 REQUIRE_DIR_EXISTS(expected);
             }
         }
 
+        SECTION("getting a user directory with additional metadata") {
+            const std::string identity = "the-identity";
+            const std::string auth_url = "https://realm.example.org";
+            std::tuple<std::string, std::string> info_tuple(identity, auth_url);
+            auto actual = manager.user_directory(local_identity, info_tuple);
+            REQUIRE(actual == expected);
+            REQUIRE_DIR_EXISTS(expected);
+            // Check the backup file
+            auto user_info_path = actual + "/__user_info";
+            std::ifstream user_info;
+            user_info.open(user_info_path.c_str());
+            REQUIRE(user_info.is_open());
+            int ctr = 0;
+            for (std::string current_line; std::getline(user_info, current_line);) {
+                if (ctr == 0) {
+                    // First line is the user's ROS identity
+                    CHECK(current_line == identity);
+                } else if (ctr == 1) {
+                    // Second line is the user's auth server URL
+                    CHECK(current_line == auth_url);
+                }
+                ctr++;
+            }
+            user_info.close();
+            CHECK(ctr == 2);
+        }
+
         SECTION("deleting a user directory") {
-            manager.user_directory(identity);
+            manager.user_directory(local_identity);
             REQUIRE_DIR_EXISTS(expected);
             SECTION("that wasn't yet deleted succeeds") {
-                manager.remove_user_directory(identity);
+                manager.remove_user_directory(local_identity);
                 REQUIRE_DIR_DOES_NOT_EXIST(expected);
             }
             SECTION("that was already deleted succeeds") {
-                manager.remove_user_directory(identity);
+                manager.remove_user_directory(local_identity);
                 REQUIRE(opendir(expected.c_str()) == NULL);
                 REQUIRE_DIR_DOES_NOT_EXIST(expected);
             }
@@ -181,12 +210,12 @@ TEST_CASE("sync_file: SyncFileManager APIs", "[sync]") {
 
         SECTION("getting a Realm path") {
             const std::string expected = manager_path + "realm-object-server/123456789/realms%3A%2F%2Fr.example.com%2F%7E%2Fmy%2Frealm%2Fpath";
-            auto actual = manager.path(identity, relative_path);
+            auto actual = manager.path(local_identity, relative_path);
             REQUIRE(expected == actual);
         }
 
         SECTION("deleting a Realm for a valid user") {
-            manager.path(identity, relative_path);
+            manager.path(local_identity, relative_path);
             // Create the required files
             auto realm_base_path = manager_path + "realm-object-server/123456789/realms%3A%2F%2Fr.example.com%2F%7E%2Fmy%2Frealm%2Fpath";
             REQUIRE(create_dummy_realm(realm_base_path));
@@ -194,7 +223,7 @@ TEST_CASE("sync_file: SyncFileManager APIs", "[sync]") {
             REQUIRE(File::exists(realm_base_path + ".lock"));
             REQUIRE_DIR_EXISTS(realm_base_path + ".management");
             // Delete the Realm
-            manager.remove_realm(identity, relative_path);
+            manager.remove_realm(local_identity, relative_path);
             // Ensure the files don't exist anymore
             REQUIRE(!File::exists(realm_base_path));
             REQUIRE(!File::exists(realm_base_path + ".lock"));

--- a/tests/sync/file.cpp
+++ b/tests/sync/file.cpp
@@ -37,8 +37,6 @@ static void prepare_sync_manager_test(void) {
     util::make_dir(manager_path);
 }
 
-// TODO: test writing the backup file
-
 TEST_CASE("sync_file: percent-encoding APIs", "[sync]") {
     SECTION("does not encode a string that has no restricted characters") {
         const std::string expected = "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_-";
@@ -166,7 +164,7 @@ TEST_CASE("sync_file: SyncFileManager APIs", "[sync]") {
         SECTION("getting a user directory with additional metadata") {
             const std::string identity = "the-identity";
             const std::string auth_url = "https://realm.example.org";
-            std::tuple<std::string, std::string> info_tuple(identity, auth_url);
+            SyncUserIdentifier info_tuple{identity, auth_url};
             auto actual = manager.user_directory(local_identity, info_tuple);
             REQUIRE(actual == expected);
             REQUIRE_DIR_EXISTS(expected);

--- a/tests/sync/metadata.cpp
+++ b/tests/sync/metadata.cpp
@@ -55,6 +55,7 @@ Property make_primary_key_property(const char* name)
 TEST_CASE("sync_metadata: migration", "[sync]") {
     reset_test_directory(base_path);
     const auto identity = "migrationtestuser";
+    const std::string auth_server_url = "https:://realm.example.org";
 
     const Schema v0_schema{
         {"UserMetadata", {
@@ -72,7 +73,25 @@ TEST_CASE("sync_metadata: migration", "[sync]") {
         }},
     };
 
-    SECTION("properly upgrades from v0 to v1") {
+    const Schema v1_schema{
+        {"UserMetadata", {
+            make_primary_key_property("identity"),
+            {"marked_for_removal", PropertyType::Bool},
+            make_nullable_string_property("auth_server_url"),
+            make_nullable_string_property("user_token"),
+            {"user_is_admin", PropertyType::Bool},
+        }},
+        {"FileActionMetadata", {
+            make_primary_key_property("original_name"),
+            {"action", PropertyType::Int},
+            make_nullable_string_property("new_name"),
+            {"url", PropertyType::String},
+            {"identity", PropertyType::String},
+        }},
+    };
+    // TODO: actually make v0 and v1 objects so we can check the migration
+
+    SECTION("properly upgrades from v0 to v2") {
         // Open v0 metadata (create a Realm directly)
         {
             Realm::Config config;
@@ -83,15 +102,38 @@ TEST_CASE("sync_metadata: migration", "[sync]") {
             auto realm = Realm::get_shared_realm(std::move(config));
             REQUIRE(realm);
         }
-        // Open v1 metadata
+        // Open v2 metadata
         {
             SyncMetadataManager manager(metadata_path, false, none);
-            auto user_metadata = SyncUserMetadata(manager, identity);
-            REQUIRE(user_metadata.is_valid());
-            CHECK(user_metadata.identity() == identity);
-            CHECK(!user_metadata.is_admin());
-            user_metadata.set_is_admin(true);
-            CHECK(user_metadata.is_admin());
+            auto user_metadata = manager.get_or_make_user_metadata(identity, auth_server_url);
+            REQUIRE(user_metadata->is_valid());
+            CHECK(user_metadata->identity() == identity);
+            CHECK(user_metadata->local_uuid() != "");
+            CHECK(!user_metadata->is_admin());
+            user_metadata->set_is_admin(true);
+            CHECK(user_metadata->is_admin());
+            CHECK(user_metadata->auth_server_url() == auth_server_url);
+        }
+    }
+
+    SECTION("properly upgrades from v1 to v2") {
+        // Open v1 metadata (create a Realm directly)
+        {
+            Realm::Config config;
+            config.path = metadata_path;
+            config.schema = v1_schema;
+            config.schema_version = 1;
+            auto realm = Realm::get_shared_realm(std::move(config));
+            REQUIRE(realm);
+        }
+        // Open v2 metadata
+        {
+            SyncMetadataManager manager(metadata_path, false, none);
+            auto user_metadata = manager.get_or_make_user_metadata(identity, auth_server_url);
+            REQUIRE(user_metadata->is_valid());
+            CHECK(user_metadata->identity() == identity);
+            CHECK(user_metadata->local_uuid() != "");
+            CHECK(user_metadata->auth_server_url() == auth_server_url);
         }
     }
 }
@@ -99,105 +141,101 @@ TEST_CASE("sync_metadata: migration", "[sync]") {
 TEST_CASE("sync_metadata: user metadata", "[sync]") {
     reset_test_directory(base_path);
     SyncMetadataManager manager(metadata_path, false);
+    const std::string auth_server_url = "https://realm.example.org";
 
     SECTION("can be properly constructed") {
         const auto identity = "testcase1a";
-        auto user_metadata = SyncUserMetadata(manager, identity);
-        REQUIRE(user_metadata.identity() == identity);
-        REQUIRE(user_metadata.server_url() == none);
-        REQUIRE(user_metadata.user_token() == none);
-        REQUIRE(!user_metadata.is_admin());
+        auto user_metadata = manager.get_or_make_user_metadata(identity, auth_server_url);
+        REQUIRE(user_metadata->identity() == identity);
+        REQUIRE(user_metadata->auth_server_url() == auth_server_url);
+        REQUIRE(user_metadata->user_token() == none);
+        REQUIRE(!user_metadata->is_admin());
     }
 
-    SECTION("properly reflects setting state") {
+    SECTION("properly reflects updating state") {
         const auto identity = "testcase1b";
-        const std::string sample_url = "https://realm.example.org";
         const std::string sample_token = "this_is_a_user_token";
-        auto user_metadata = SyncUserMetadata(manager, identity);
-        user_metadata.set_state(sample_url, sample_token);
-        REQUIRE(user_metadata.identity() == identity);
-        REQUIRE(user_metadata.server_url() == sample_url);
-        REQUIRE(user_metadata.user_token() == sample_token);
-        user_metadata.set_is_admin(true);
-        REQUIRE(user_metadata.is_admin());
+        auto user_metadata = manager.get_or_make_user_metadata(identity, auth_server_url);
+        user_metadata->set_user_token(sample_token);
+        REQUIRE(user_metadata->identity() == identity);
+        REQUIRE(user_metadata->auth_server_url() == auth_server_url);
+        REQUIRE(user_metadata->user_token() == sample_token);
+        user_metadata->set_is_admin(true);
+        REQUIRE(user_metadata->is_admin());
     }
 
     SECTION("can be properly re-retrieved from the same manager") {
         const auto identity = "testcase1c";
-        const std::string sample_url = "https://realm.example.org";
         const std::string sample_token = "this_is_a_user_token";
-        auto first = SyncUserMetadata(manager, identity);
-        first.set_state(sample_url, sample_token);
+        auto first = manager.get_or_make_user_metadata(identity, auth_server_url);
+        first->set_user_token(sample_token);
         // Get a second instance of the user metadata for the same identity.
-        auto second = SyncUserMetadata(manager, identity, false);
-        REQUIRE(second.identity() == identity);
-        REQUIRE(second.server_url() == sample_url);
-        REQUIRE(second.user_token() == sample_token);
+        auto second = manager.get_or_make_user_metadata(identity, auth_server_url, false);
+        REQUIRE(second->identity() == identity);
+        REQUIRE(second->auth_server_url() == auth_server_url);
+        REQUIRE(second->user_token() == sample_token);
     }
 
     SECTION("properly reflects changes across different instances") {
         const auto identity = "testcase1d";
-        const std::string sample_url_1 = "https://realm.example.org";
         const std::string sample_token_1 = "this_is_a_user_token";
-        auto first = SyncUserMetadata(manager, identity);
-        auto second = SyncUserMetadata(manager, identity);
-        CHECK(!first.is_admin());
-        first.set_state(sample_url_1, sample_token_1);
-        REQUIRE(first.identity() == identity);
-        REQUIRE(first.server_url() == sample_url_1);
-        REQUIRE(first.user_token() == sample_token_1);
-        CHECK(!first.is_admin());
-        REQUIRE(second.identity() == identity);
-        REQUIRE(second.server_url() == sample_url_1);
-        REQUIRE(second.user_token() == sample_token_1);
-        CHECK(!second.is_admin());
+        auto first = manager.get_or_make_user_metadata(identity, auth_server_url);
+        auto second = manager.get_or_make_user_metadata(identity, auth_server_url);
+        CHECK(!first->is_admin());
+        first->set_user_token(sample_token_1);
+        REQUIRE(first->identity() == identity);
+        REQUIRE(first->auth_server_url() == auth_server_url);
+        REQUIRE(first->user_token() == sample_token_1);
+        CHECK(!first->is_admin());
+        REQUIRE(second->identity() == identity);
+        REQUIRE(second->auth_server_url() == auth_server_url);
+        REQUIRE(second->user_token() == sample_token_1);
+        CHECK(!second->is_admin());
         // Set the state again.
-        const std::string sample_url_2 = "https://foobar.example.org";
         const std::string sample_token_2 = "this_is_another_user_token";
-        second.set_state(sample_url_2, sample_token_2);
-        REQUIRE(first.identity() == identity);
-        REQUIRE(first.server_url() == sample_url_2);
-        REQUIRE(first.user_token() == sample_token_2);
-        REQUIRE(second.identity() == identity);
-        REQUIRE(second.server_url() == sample_url_2);
-        REQUIRE(second.user_token() == sample_token_2);
+        second->set_user_token(sample_token_2);
+        REQUIRE(first->identity() == identity);
+        REQUIRE(first->auth_server_url() == auth_server_url);
+        REQUIRE(first->user_token() == sample_token_2);
+        REQUIRE(second->identity() == identity);
+        REQUIRE(second->auth_server_url() == auth_server_url);
+        REQUIRE(second->user_token() == sample_token_2);
     }
 
     SECTION("can be removed") {
         const auto identity = "testcase1e";
-        auto user_metadata = SyncUserMetadata(manager, identity);
-        REQUIRE(user_metadata.is_valid());
-        user_metadata.remove();
-        REQUIRE(!user_metadata.is_valid());
+        auto user_metadata = manager.get_or_make_user_metadata(identity, auth_server_url);
+        REQUIRE(user_metadata->is_valid());
+        user_metadata->remove();
+        REQUIRE(!user_metadata->is_valid());
     }
 
     SECTION("respects make_if_absent flag set to false in constructor") {
-        const std::string sample_url = "https://realm.example.org";
         const std::string sample_token = "this_is_a_user_token";
 
         SECTION("with no prior metadata for the identifier") {
             const auto identity = "testcase1g1";
-            auto user_metadata = SyncUserMetadata(manager, identity, false);
-            REQUIRE(!user_metadata.is_valid());
+            auto user_metadata = manager.get_or_make_user_metadata(identity, auth_server_url, false);
+            REQUIRE(!user_metadata);
         }
         SECTION("with valid prior metadata for the identifier") {
             const auto identity = "testcase1g2";
-            auto first = SyncUserMetadata(manager, identity, true);
-            first.set_state(sample_url, sample_token);
-            auto second = SyncUserMetadata(manager, identity, false);
-            REQUIRE(second.is_valid());
-            REQUIRE(second.identity() == identity);
-            REQUIRE(second.server_url() == sample_url);
-            REQUIRE(second.user_token() == sample_token);
-            REQUIRE(!second.is_admin());
+            auto first = manager.get_or_make_user_metadata(identity, auth_server_url);
+            first->set_user_token(sample_token);
+            auto second = manager.get_or_make_user_metadata(identity, auth_server_url, false);
+            REQUIRE(second->is_valid());
+            REQUIRE(second->identity() == identity);
+            REQUIRE(second->auth_server_url() == auth_server_url);
+            REQUIRE(second->user_token() == sample_token);
+            REQUIRE(!second->is_admin());
         }
         SECTION("with invalid prior metadata for the identifier") {
             const auto identity = "testcase1g3";
-            auto first = SyncUserMetadata(manager, identity);
-            first.set_state(sample_url, sample_token);
-            first.mark_for_removal();
-            auto second = SyncUserMetadata(manager, identity, false);
-            REQUIRE(!second.is_valid());
+            auto first = manager.get_or_make_user_metadata(identity, auth_server_url);
+            first->set_user_token(sample_token);
+            first->mark_for_removal();
+            auto second = manager.get_or_make_user_metadata(identity, auth_server_url, false);
+            REQUIRE(!second);
         }
     }
 }
@@ -205,31 +243,35 @@ TEST_CASE("sync_metadata: user metadata", "[sync]") {
 TEST_CASE("sync_metadata: user metadata APIs", "[sync]") {
     reset_test_directory(base_path);
     SyncMetadataManager manager(metadata_path, false);
+    const std::string auth_server_url = "https://realm.example.org";
 
     SECTION("properly list all marked and unmarked users") {
         const auto identity1 = "testcase2a1";
-        const auto identity2 = "testcase2a2";
+        const auto identity2 = "testcase2a1";   // same as identity 1
         const auto identity3 = "testcase2a3";
-        auto first = SyncUserMetadata(manager, identity1);
-        auto second = SyncUserMetadata(manager, identity2);
-        auto third = SyncUserMetadata(manager, identity3);
+        const std::string auth_server_url_1 = "https://foobar.example.org";
+        const std::string auth_server_url_2 = "https://realm.example.org";
+        const std::string auth_server_url_3 = "https://realm.example.org";
+        auto first = manager.get_or_make_user_metadata(identity1, auth_server_url_1);
+        auto second = manager.get_or_make_user_metadata(identity2, auth_server_url_2);
+        auto third = manager.get_or_make_user_metadata(identity3, auth_server_url_3);
         auto unmarked_users = manager.all_unmarked_users();
         REQUIRE(unmarked_users.size() == 3);
-        REQUIRE(results_contains_user(unmarked_users, identity1));
-        REQUIRE(results_contains_user(unmarked_users, identity2));
-        REQUIRE(results_contains_user(unmarked_users, identity3));
+        REQUIRE(results_contains_user(unmarked_users, identity1, auth_server_url_1));
+        REQUIRE(results_contains_user(unmarked_users, identity2, auth_server_url_2));
+        REQUIRE(results_contains_user(unmarked_users, identity3, auth_server_url_3));
         auto marked_users = manager.all_users_marked_for_removal();
         REQUIRE(marked_users.size() == 0);
         // Now, mark a few users for removal.
-        first.mark_for_removal();
-        third.mark_for_removal();
+        first->mark_for_removal();
+        third->mark_for_removal();
         unmarked_users = manager.all_unmarked_users();
         REQUIRE(unmarked_users.size() == 1);
-        REQUIRE(results_contains_user(unmarked_users, identity2));
+        REQUIRE(results_contains_user(unmarked_users, identity2, auth_server_url_2));
         marked_users = manager.all_users_marked_for_removal();
         REQUIRE(marked_users.size() == 2);
-        REQUIRE(results_contains_user(marked_users, identity1));
-        REQUIRE(results_contains_user(marked_users, identity3));
+        REQUIRE(results_contains_user(marked_users, identity1, auth_server_url_1));
+        REQUIRE(results_contains_user(marked_users, identity3, auth_server_url_3));
     }
 }
 
@@ -237,41 +279,41 @@ TEST_CASE("sync_metadata: file action metadata", "[sync]") {
     reset_test_directory(base_path);
     SyncMetadataManager manager(metadata_path, false);
 
-    const std::string identity_1 = "asdfg";
-    const std::string identity_2 = "qwerty";
+    const std::string local_uuid_1 = "asdfg";
+    const std::string local_uuid_2 = "qwerty";
     const std::string url_1 = "realm://realm.example.com/1";
     const std::string url_2 = "realm://realm.example.com/2";
 
     SECTION("can be properly constructed") {
         const auto original_name = tmp_dir() + "foobar/test1";
-        auto user_metadata = SyncFileActionMetadata(manager, SyncAction::BackUpThenDeleteRealm, original_name, url_1, identity_1);
-        REQUIRE(user_metadata.original_name() == original_name);
-        REQUIRE(user_metadata.new_name() == none);
-        REQUIRE(user_metadata.action() == SyncAction::BackUpThenDeleteRealm);
-        REQUIRE(user_metadata.url() == url_1);
-        REQUIRE(user_metadata.user_identity() == identity_1);
+        auto metadata = manager.make_file_action_metadata(original_name, url_1, local_uuid_1, SyncAction::BackUpThenDeleteRealm);
+        REQUIRE(metadata.original_name() == original_name);
+        REQUIRE(metadata.new_name() == none);
+        REQUIRE(metadata.action() == SyncAction::BackUpThenDeleteRealm);
+        REQUIRE(metadata.url() == url_1);
+        REQUIRE(metadata.user_local_uuid() == local_uuid_1);
     }
 
     SECTION("properly reflects updating state, across multiple instances") {
         const auto original_name = tmp_dir() + "foobar/test2a";
         const std::string new_name_1 = tmp_dir() + "foobar/test2b";
         const std::string new_name_2 = tmp_dir() + "foobar/test2c";
-        auto user_metadata_1 = SyncFileActionMetadata(manager, SyncAction::BackUpThenDeleteRealm, original_name, url_1, identity_1, new_name_1);
-        REQUIRE(user_metadata_1.original_name() == original_name);
-        REQUIRE(user_metadata_1.new_name() == new_name_1);
-        REQUIRE(user_metadata_1.action() == SyncAction::BackUpThenDeleteRealm);
-        REQUIRE(user_metadata_1.url() == url_1);
-        REQUIRE(user_metadata_1.user_identity() == identity_1);
+        auto metadata_1 = manager.make_file_action_metadata(original_name, url_1, local_uuid_1, SyncAction::BackUpThenDeleteRealm, new_name_1);
+        REQUIRE(metadata_1.original_name() == original_name);
+        REQUIRE(metadata_1.new_name() == new_name_1);
+        REQUIRE(metadata_1.action() == SyncAction::BackUpThenDeleteRealm);
+        REQUIRE(metadata_1.url() == url_1);
+        REQUIRE(metadata_1.user_local_uuid() == local_uuid_1);
 
-        auto user_metadata_2 = SyncFileActionMetadata(manager, SyncAction::DeleteRealm, original_name, url_2, identity_2, new_name_2);
-        REQUIRE(user_metadata_1.original_name() == original_name);
-        REQUIRE(user_metadata_1.new_name() == new_name_2);
-        REQUIRE(user_metadata_1.action() == SyncAction::DeleteRealm);
-        REQUIRE(user_metadata_2.original_name() == original_name);
-        REQUIRE(user_metadata_2.new_name() == new_name_2);
-        REQUIRE(user_metadata_2.action() == SyncAction::DeleteRealm);
-        REQUIRE(user_metadata_1.url() == url_2);
-        REQUIRE(user_metadata_1.user_identity() == identity_2);
+        auto metadata_2 = manager.make_file_action_metadata(original_name, url_2, local_uuid_2, SyncAction::DeleteRealm, new_name_2);
+        REQUIRE(metadata_1.original_name() == original_name);
+        REQUIRE(metadata_1.new_name() == new_name_2);
+        REQUIRE(metadata_1.action() == SyncAction::DeleteRealm);
+        REQUIRE(metadata_2.original_name() == original_name);
+        REQUIRE(metadata_2.new_name() == new_name_2);
+        REQUIRE(metadata_2.action() == SyncAction::DeleteRealm);
+        REQUIRE(metadata_1.url() == url_2);
+        REQUIRE(metadata_1.user_local_uuid() == local_uuid_2);
     }
 }
 
@@ -282,9 +324,9 @@ TEST_CASE("sync_metadata: file action metadata APIs", "[sync]") {
         const auto filename1 = tmp_dir() + "foobar/file1";
         const auto filename2 = tmp_dir() + "foobar/file2";
         const auto filename3 = tmp_dir() + "foobar/file3";
-        auto first = SyncFileActionMetadata(manager, SyncAction::BackUpThenDeleteRealm, filename1, "asdf", "realm://realm.example.com/1");
-        auto second = SyncFileActionMetadata(manager, SyncAction::BackUpThenDeleteRealm, filename2, "asdf", "realm://realm.example.com/2");
-        auto third = SyncFileActionMetadata(manager, SyncAction::BackUpThenDeleteRealm, filename3, "asdf", "realm://realm.example.com/3");
+        auto first = manager.make_file_action_metadata(filename1, "asdf", "realm://realm.example.com/1", SyncAction::BackUpThenDeleteRealm);
+        auto second = manager.make_file_action_metadata(filename2, "asdf", "realm://realm.example.com/2", SyncAction::BackUpThenDeleteRealm);
+        auto third = manager.make_file_action_metadata(filename3, "asdf", "realm://realm.example.com/3", SyncAction::BackUpThenDeleteRealm);
         auto actions = manager.all_pending_actions();
         REQUIRE(actions.size() == 3);
         REQUIRE(results_contains_original_name(actions, filename1));
@@ -300,45 +342,46 @@ TEST_CASE("sync_metadata: file action metadata APIs", "[sync]") {
 TEST_CASE("sync_metadata: results", "[sync]") {
     reset_test_directory(base_path);
     SyncMetadataManager manager(metadata_path, false);
+    const auto identity1 = "testcase3a1";
+    const auto identity2 = "testcase3a1";   // same as identity 1
+    const auto identity3 = "testcase3a3";
+    const std::string auth_server_url_1 = "https://realm.example.org";
+    const std::string auth_server_url_2 = "https://foobar.example.org";
+    const std::string auth_server_url_3 = "https://realm.example.org";
+
 
     SECTION("properly update as underlying items are added") {
-        const auto identity1 = "testcase3a1";
-        const auto identity2 = "testcase3a2";
-        const auto identity3 = "testcase3a3";
         auto results = manager.all_unmarked_users();
         REQUIRE(results.size() == 0);
         // Add users, one at a time.
-        auto first = SyncUserMetadata(manager, identity1);
+        auto first = manager.get_or_make_user_metadata(identity1, auth_server_url_1);
         REQUIRE(results.size() == 1);
-        REQUIRE(results_contains_user(results, identity1));
-        auto second = SyncUserMetadata(manager, identity2);
+        REQUIRE(results_contains_user(results, identity1, auth_server_url_1));
+        auto second = manager.get_or_make_user_metadata(identity2, auth_server_url_2);
         REQUIRE(results.size() == 2);
-        REQUIRE(results_contains_user(results, identity2));
-        auto third = SyncUserMetadata(manager, identity3);
+        REQUIRE(results_contains_user(results, identity2, auth_server_url_2));
+        auto third = manager.get_or_make_user_metadata(identity3, auth_server_url_3);
         REQUIRE(results.size() == 3);
-        REQUIRE(results_contains_user(results, identity3));
+        REQUIRE(results_contains_user(results, identity3, auth_server_url_3));
     }
 
     SECTION("properly update as underlying items are removed") {
-        const auto identity1 = "testcase3b1";
-        const auto identity2 = "testcase3b2";
-        const auto identity3 = "testcase3b3";
         auto results = manager.all_unmarked_users();
-        auto first = SyncUserMetadata(manager, identity1);
-        auto second = SyncUserMetadata(manager, identity2);
-        auto third = SyncUserMetadata(manager, identity3);
+        auto first = manager.get_or_make_user_metadata(identity1, auth_server_url_1);
+        auto second = manager.get_or_make_user_metadata(identity2, auth_server_url_2);
+        auto third = manager.get_or_make_user_metadata(identity3, auth_server_url_3);
         REQUIRE(results.size() == 3);
-        REQUIRE(results_contains_user(results, identity1));
-        REQUIRE(results_contains_user(results, identity2));
-        REQUIRE(results_contains_user(results, identity3));
+        REQUIRE(results_contains_user(results, identity1, auth_server_url_1));
+        REQUIRE(results_contains_user(results, identity2, auth_server_url_2));
+        REQUIRE(results_contains_user(results, identity3, auth_server_url_3));
         // Remove users, one at a time.
-        third.remove();
+        third->remove();
         REQUIRE(results.size() == 2);
-        REQUIRE(!results_contains_user(results, identity3));
-        first.remove();
+        REQUIRE(!results_contains_user(results, identity3, auth_server_url_3));
+        first->remove();
         REQUIRE(results.size() == 1);
-        REQUIRE(!results_contains_user(results, identity1));
-        second.remove();
+        REQUIRE(!results_contains_user(results, identity1, auth_server_url_1));
+        second->remove();
         REQUIRE(results.size() == 0);
     }
 }
@@ -348,22 +391,22 @@ TEST_CASE("sync_metadata: persistence across metadata manager instances", "[sync
 
     SECTION("works for the basic case") {
         const auto identity = "testcase4a";
-        const std::string sample_url = "https://realm.example.org";
+        const std::string auth_server_url = "https://realm.example.org";
         const std::string sample_token = "this_is_a_user_token";
         SyncMetadataManager first_manager(metadata_path, false);
-        auto first = SyncUserMetadata(first_manager, identity);
-        first.set_state(sample_url, sample_token);
-        first.set_is_admin(true);
-        REQUIRE(first.identity() == identity);
-        REQUIRE(first.server_url() == sample_url);
-        REQUIRE(first.user_token() == sample_token);
-        REQUIRE(first.is_admin());
+        auto first = first_manager.get_or_make_user_metadata(identity, auth_server_url);
+        first->set_user_token(sample_token);
+        first->set_is_admin(true);
+        REQUIRE(first->identity() == identity);
+        REQUIRE(first->auth_server_url() == auth_server_url);
+        REQUIRE(first->user_token() == sample_token);
+        REQUIRE(first->is_admin());
         SyncMetadataManager second_manager(metadata_path, false);
-        auto second = SyncUserMetadata(second_manager, identity, false);
-        REQUIRE(second.identity() == identity);
-        REQUIRE(second.server_url() == sample_url);
-        REQUIRE(second.user_token() == sample_token);
-        REQUIRE(second.is_admin());
+        auto second = second_manager.get_or_make_user_metadata(identity, auth_server_url, false);
+        REQUIRE(second->identity() == identity);
+        REQUIRE(second->auth_server_url() == auth_server_url);
+        REQUIRE(second->user_token() == sample_token);
+        REQUIRE(second->is_admin());
     }
 }
 
@@ -384,15 +427,20 @@ TEST_CASE("sync_metadata: encryption", "[sync]") {
     SECTION("works when enabled") {
         std::vector<char> key = make_test_encryption_key(10);
         const auto identity = "testcase5a";
+        const auto auth_url = "https://realm.example.org";
         SyncMetadataManager manager(metadata_path, true, key);
-        auto user_metadata = SyncUserMetadata(manager, identity);
-        REQUIRE(user_metadata.identity() == identity);
-        REQUIRE(user_metadata.server_url() == none);
-        REQUIRE(user_metadata.user_token() == none);
+        auto user_metadata = manager.get_or_make_user_metadata(identity, auth_url);
+        REQUIRE(bool(user_metadata));
+        CHECK(user_metadata->identity() == identity);
+        CHECK(user_metadata->auth_server_url() == auth_url);
+        CHECK(user_metadata->user_token() == none);
+        CHECK(user_metadata->is_valid());
         // Reopen the metadata file with the same key.
         SyncMetadataManager manager_2(metadata_path, true, key);
-        auto user_metadata_2 = SyncUserMetadata(manager_2, identity, false);
-        REQUIRE(user_metadata_2.identity() == identity);
-        REQUIRE(user_metadata_2.is_valid());
+        auto user_metadata_2 = manager_2.get_or_make_user_metadata(identity, auth_url, false);
+        REQUIRE(bool(user_metadata_2));
+        CHECK(user_metadata_2->identity() == identity);
+        CHECK(user_metadata_2->auth_server_url() == auth_url);
+        CHECK(user_metadata_2->is_valid());
     }
 }

--- a/tests/sync/session/progress_notifications.cpp
+++ b/tests/sync/session/progress_notifications.cpp
@@ -44,14 +44,16 @@ TEST_CASE("progress notification", "[sync]") {
     if (!EventLoop::has_implementation())
         return;
 
+    const std::string dummy_auth_url = "https://realm.example.org";
+
     auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
     // Disable file-related functionality and metadata functionality for testing purposes.
     SyncManager::shared().configure_file_system(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
-    auto user = SyncManager::shared().get_user("user", "https://realm.example.org", "not_a_real_token");
+    auto user = SyncManager::shared().get_user({ "user", dummy_auth_url }, "not_a_real_token");
 
     SECTION("runs at least once (initially when registered)") {
-        auto user = SyncManager::shared().get_user("user-test-sync-1", "https://realm.example.org", "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ "user-test-sync-1", dummy_auth_url }, "not_a_real_token");
         auto session = sync_session(server, user, "/test-sync-progress-1",
                                     [](auto&, auto&) { return s_test_token; },
                                     [](auto, auto) { },
@@ -88,7 +90,7 @@ TEST_CASE("progress notification", "[sync]") {
     }
 
     SECTION("properly runs for streaming notifiers") {
-        auto user = SyncManager::shared().get_user("user-test-sync-2", "https://realm.example.org", "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ "user-test-sync-2", dummy_auth_url }, "not_a_real_token");
         auto session = sync_session(server, user, "/test-sync-progress-2",
                                     [](auto&, auto&) { return s_test_token; },
                                     [](auto, auto) { },
@@ -256,7 +258,7 @@ TEST_CASE("progress notification", "[sync]") {
     }
 
     SECTION("properly runs for non-streaming notifiers") {
-        auto user = SyncManager::shared().get_user("user-test-sync-3", "https://realm.example.org", "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ "user-test-sync-3", dummy_auth_url }, "not_a_real_token");
         auto session = sync_session(server, user, "/test-sync-progress-3",
                                     [](auto&, auto&) { return s_test_token; },
                                     [](auto, auto) { },

--- a/tests/sync/session/progress_notifications.cpp
+++ b/tests/sync/session/progress_notifications.cpp
@@ -48,10 +48,10 @@ TEST_CASE("progress notification", "[sync]") {
     SyncServer server;
     // Disable file-related functionality and metadata functionality for testing purposes.
     SyncManager::shared().configure_file_system(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
-    auto user = SyncManager::shared().get_user("user", "not_a_real_token");
+    auto user = SyncManager::shared().get_user("user", "https://realm.example.org", "not_a_real_token");
 
     SECTION("runs at least once (initially when registered)") {
-        auto user = SyncManager::shared().get_user("user-test-sync-1", "not_a_real_token");
+        auto user = SyncManager::shared().get_user("user-test-sync-1", "https://realm.example.org", "not_a_real_token");
         auto session = sync_session(server, user, "/test-sync-progress-1",
                                     [](auto&, auto&) { return s_test_token; },
                                     [](auto, auto) { },
@@ -88,7 +88,7 @@ TEST_CASE("progress notification", "[sync]") {
     }
 
     SECTION("properly runs for streaming notifiers") {
-        auto user = SyncManager::shared().get_user("user-test-sync-2", "not_a_real_token");
+        auto user = SyncManager::shared().get_user("user-test-sync-2", "https://realm.example.org", "not_a_real_token");
         auto session = sync_session(server, user, "/test-sync-progress-2",
                                     [](auto&, auto&) { return s_test_token; },
                                     [](auto, auto) { },
@@ -256,7 +256,7 @@ TEST_CASE("progress notification", "[sync]") {
     }
 
     SECTION("properly runs for non-streaming notifiers") {
-        auto user = SyncManager::shared().get_user("user-test-sync-3", "not_a_real_token");
+        auto user = SyncManager::shared().get_user("user-test-sync-3", "https://realm.example.org", "not_a_real_token");
         auto session = sync_session(server, user, "/test-sync-progress-3",
                                     [](auto&, auto&) { return s_test_token; },
                                     [](auto, auto) { },

--- a/tests/sync/session/session.cpp
+++ b/tests/sync/session/session.cpp
@@ -44,13 +44,14 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
 
     auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
+    const std::string dummy_auth_url = "https://realm.example.org";
     SyncManager::shared().configure_file_system(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
     const std::string realm_base_url = server.base_url();
 
     SECTION("a SyncUser can properly retrieve its owned sessions") {
         std::string path_1;
         std::string path_2;
-        auto user = SyncManager::shared().get_user("user1a", "not_a_real_token");
+        auto user = SyncManager::shared().get_user("user1a", dummy_auth_url, "not_a_real_token");
         auto session1 = sync_session(server, user, "/test1a-1",
                                      [](auto&, auto&) { return s_test_token; },
                                      [](auto, auto) { },
@@ -74,7 +75,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
     }
 
     SECTION("a SyncUser properly unbinds its sessions upon logging out") {
-        auto user = SyncManager::shared().get_user("user1b", "not_a_real_token");
+        auto user = SyncManager::shared().get_user("user1b", dummy_auth_url, "not_a_real_token");
         auto session1 = sync_session(server, user, "/test1b-1",
                                      [](auto&, auto&) { return s_test_token; },
                                      [](auto, auto) { });
@@ -92,7 +93,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
 
     SECTION("a SyncUser defers binding new sessions until it is logged in") {
         const std::string user_id = "user1c";
-        auto user = SyncManager::shared().get_user(user_id, "not_a_real_token");
+        auto user = SyncManager::shared().get_user(user_id, dummy_auth_url, "not_a_real_token");
         user->log_out();
         REQUIRE(user->state() == SyncUser::State::LoggedOut);
         auto session1 = sync_session(server, user, "/test1c-1",
@@ -107,14 +108,14 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
         REQUIRE(sessions_are_inactive(*session2));
         REQUIRE(user->all_sessions().size() == 0);
         // Log the user back in via the sync manager.
-        user = SyncManager::shared().get_user(user_id, "not_a_real_token_either");
+        user = SyncManager::shared().get_user(user_id, dummy_auth_url, "not_a_real_token_either");
         EventLoop::main().run_until([&] { return sessions_are_active(*session1, *session2); });
         REQUIRE(user->all_sessions().size() == 2);
     }
 
     SECTION("a SyncUser properly rebinds existing sessions upon logging back in") {
         const std::string user_id = "user1d";
-        auto user = SyncManager::shared().get_user(user_id, "not_a_real_token");
+        auto user = SyncManager::shared().get_user(user_id, dummy_auth_url, "not_a_real_token");
         auto session1 = sync_session(server, user, "/test1d-1",
                                      [](auto&, auto&) { return s_test_token; },
                                      [](auto, auto) { });
@@ -133,7 +134,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
         REQUIRE(sessions_are_inactive(*session2));
         REQUIRE(user->all_sessions().size() == 0);
         // Log the user back in via the sync manager.
-        user = SyncManager::shared().get_user(user_id, "not_a_real_token_either");
+        user = SyncManager::shared().get_user(user_id, dummy_auth_url, "not_a_real_token_either");
         EventLoop::main().run_until([&] { return sessions_are_active(*session1, *session2); });
         REQUIRE(user->all_sessions().size() == 2);
     }
@@ -143,7 +144,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
         std::weak_ptr<SyncSession> weak_session;
         std::string on_disk_path;
         SyncConfig config;
-        auto user = SyncManager::shared().get_user("user1e", "not_a_real_token");
+        auto user = SyncManager::shared().get_user("user1e", dummy_auth_url, "not_a_real_token");
         {
             // Create the session within a nested scope, so we can control its lifetime.
             auto session = sync_session(server, user, path,
@@ -169,7 +170,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
     }
 
     SECTION("a user can create multiple sessions for the same URL") {
-        auto user = SyncManager::shared().get_user("user", "not_a_real_token");
+        auto user = SyncManager::shared().get_user("user", dummy_auth_url, "not_a_real_token");
         auto create_session = [&]() {
             // Note that this should put the sessions at different paths.
             return sync_session(server, user, "/test",
@@ -188,9 +189,10 @@ TEST_CASE("sync: log-in", "[sync]") {
 
     auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
+    const std::string dummy_auth_url = "https://realm.example.org";
     // Disable file-related functionality and metadata functionality for testing purposes.
     SyncManager::shared().configure_file_system(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
-    auto user = SyncManager::shared().get_user("user", "not_a_real_token");
+    auto user = SyncManager::shared().get_user("user", dummy_auth_url, "not_a_real_token");
 
     SECTION("Can log in") {
         std::atomic<int> error_count(0);
@@ -227,9 +229,10 @@ TEST_CASE("sync: token refreshing", "[sync]") {
 
     auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
+    const std::string dummy_auth_url = "https://realm.example.org";
     // Disable file-related functionality and metadata functionality for testing purposes.
     SyncManager::shared().configure_file_system(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
-    auto user = SyncManager::shared().get_user("user-token-refreshing", "not_a_real_token");
+    auto user = SyncManager::shared().get_user("user-token-refreshing", dummy_auth_url, "not_a_real_token");
 
     SECTION("Can preemptively refresh token while session is active.") {
         auto session = sync_session(server, user, "/test-token-refreshing",
@@ -273,7 +276,7 @@ TEST_CASE("SyncSession: close() API", "[sync]") {
     auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
 
-    auto user = SyncManager::shared().get_user("close-api-tests-user", "not_a_real_token");
+    auto user = SyncManager::shared().get_user("close-api-tests-user", "https://realm.example.org", "not_a_real_token");
 
     SECTION("Behaves properly when called on session in the 'waiting for token' state for Immediate") {
         std::atomic<bool> bind_function_called(false);
@@ -331,7 +334,7 @@ TEST_CASE("sync: error handling", "[sync]") {
     std::function<void(std::shared_ptr<SyncSession>, SyncError)> error_handler = [](auto, auto) { };
     const std::string user_id = "user1d";
     std::string on_disk_path;
-    auto user = SyncManager::shared().get_user(user_id, "not_a_real_token");
+    auto user = SyncManager::shared().get_user(user_id, "https://realm.example.org", "not_a_real_token");
     auto session = sync_session(server, user, "/test1e",
                                  [](auto&, auto&) { return s_test_token; },
                                  [&](auto session, SyncError error) { 
@@ -427,7 +430,7 @@ TEST_CASE("sync: stop policy behavior", "[sync]") {
     };
 
     SECTION("properly transitions from active directly to inactive, and nothing bad happens", "[Immediately]") {
-        auto user = SyncManager::shared().get_user("user-dying-state-1", "not_a_real_token");
+        auto user = SyncManager::shared().get_user("user-dying-state-1", "https://realm.example.org", "not_a_real_token");
         Realm::Config config;
         auto session = sync_session(server, user, "/test-dying-state-1",
                                     [](auto&, auto&) { return s_test_token; },
@@ -443,7 +446,7 @@ TEST_CASE("sync: stop policy behavior", "[sync]") {
     }
 
     SECTION("properly transitions from active to dying to inactive if nothing bad happens", "[AfterChangesUploaded]") {
-        auto user = SyncManager::shared().get_user("user-dying-state-2", "not_a_real_token");
+        auto user = SyncManager::shared().get_user("user-dying-state-2", "https://realm.example.org", "not_a_real_token");
         Realm::Config config;
         auto session = sync_session(server, user, "/test-dying-state-2",
                                     [](auto&, auto&) { return s_test_token; },
@@ -464,7 +467,7 @@ TEST_CASE("sync: stop policy behavior", "[sync]") {
 
     SECTION("properly transitions from active to dying to inactive if a fatal error happens", "[AfterChangesUploaded]") {
         std::atomic<bool> error_handler_invoked(false);
-        auto user = SyncManager::shared().get_user("user-dying-state-3", "not_a_real_token");
+        auto user = SyncManager::shared().get_user("user-dying-state-3", "https://realm.example.org", "not_a_real_token");
         Realm::Config config;
         auto session = sync_session(server, user, "/test-dying-state-3",
                                     [](auto&, auto&) { return s_test_token; },
@@ -488,7 +491,7 @@ TEST_CASE("sync: stop policy behavior", "[sync]") {
 
     SECTION("ignores and swallows non-fatal errors if in the dying state.", "[AfterChangesUploaded]") {
         std::atomic<bool> error_handler_invoked(false);
-        auto user = SyncManager::shared().get_user("user-dying-state-4", "not_a_real_token");
+        auto user = SyncManager::shared().get_user("user-dying-state-4", "https://realm.example.org", "not_a_real_token");
         Realm::Config config;
         auto session = sync_session(server, user, "/test-dying-state-4",
                                     [](auto&, auto&) { return s_test_token; },

--- a/tests/sync/session/session.cpp
+++ b/tests/sync/session/session.cpp
@@ -51,7 +51,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
     SECTION("a SyncUser can properly retrieve its owned sessions") {
         std::string path_1;
         std::string path_2;
-        auto user = SyncManager::shared().get_user("user1a", dummy_auth_url, "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ "user1a", dummy_auth_url }, "not_a_real_token");
         auto session1 = sync_session(server, user, "/test1a-1",
                                      [](auto&, auto&) { return s_test_token; },
                                      [](auto, auto) { },
@@ -75,7 +75,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
     }
 
     SECTION("a SyncUser properly unbinds its sessions upon logging out") {
-        auto user = SyncManager::shared().get_user("user1b", dummy_auth_url, "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ "user1b", dummy_auth_url }, "not_a_real_token");
         auto session1 = sync_session(server, user, "/test1b-1",
                                      [](auto&, auto&) { return s_test_token; },
                                      [](auto, auto) { });
@@ -93,7 +93,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
 
     SECTION("a SyncUser defers binding new sessions until it is logged in") {
         const std::string user_id = "user1c";
-        auto user = SyncManager::shared().get_user(user_id, dummy_auth_url, "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ user_id, dummy_auth_url }, "not_a_real_token");
         user->log_out();
         REQUIRE(user->state() == SyncUser::State::LoggedOut);
         auto session1 = sync_session(server, user, "/test1c-1",
@@ -108,14 +108,14 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
         REQUIRE(sessions_are_inactive(*session2));
         REQUIRE(user->all_sessions().size() == 0);
         // Log the user back in via the sync manager.
-        user = SyncManager::shared().get_user(user_id, dummy_auth_url, "not_a_real_token_either");
+        user = SyncManager::shared().get_user({ user_id, dummy_auth_url }, "not_a_real_token_either");
         EventLoop::main().run_until([&] { return sessions_are_active(*session1, *session2); });
         REQUIRE(user->all_sessions().size() == 2);
     }
 
     SECTION("a SyncUser properly rebinds existing sessions upon logging back in") {
         const std::string user_id = "user1d";
-        auto user = SyncManager::shared().get_user(user_id, dummy_auth_url, "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ user_id, dummy_auth_url }, "not_a_real_token");
         auto session1 = sync_session(server, user, "/test1d-1",
                                      [](auto&, auto&) { return s_test_token; },
                                      [](auto, auto) { });
@@ -134,7 +134,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
         REQUIRE(sessions_are_inactive(*session2));
         REQUIRE(user->all_sessions().size() == 0);
         // Log the user back in via the sync manager.
-        user = SyncManager::shared().get_user(user_id, dummy_auth_url, "not_a_real_token_either");
+        user = SyncManager::shared().get_user({ user_id, dummy_auth_url }, "not_a_real_token_either");
         EventLoop::main().run_until([&] { return sessions_are_active(*session1, *session2); });
         REQUIRE(user->all_sessions().size() == 2);
     }
@@ -144,7 +144,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
         std::weak_ptr<SyncSession> weak_session;
         std::string on_disk_path;
         SyncConfig config;
-        auto user = SyncManager::shared().get_user("user1e", dummy_auth_url, "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ "user1e", dummy_auth_url }, "not_a_real_token");
         {
             // Create the session within a nested scope, so we can control its lifetime.
             auto session = sync_session(server, user, path,
@@ -170,7 +170,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
     }
 
     SECTION("a user can create multiple sessions for the same URL") {
-        auto user = SyncManager::shared().get_user("user", dummy_auth_url, "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ "user", dummy_auth_url }, "not_a_real_token");
         auto create_session = [&]() {
             // Note that this should put the sessions at different paths.
             return sync_session(server, user, "/test",
@@ -192,7 +192,7 @@ TEST_CASE("sync: log-in", "[sync]") {
     const std::string dummy_auth_url = "https://realm.example.org";
     // Disable file-related functionality and metadata functionality for testing purposes.
     SyncManager::shared().configure_file_system(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
-    auto user = SyncManager::shared().get_user("user", dummy_auth_url, "not_a_real_token");
+    auto user = SyncManager::shared().get_user({ "user", dummy_auth_url }, "not_a_real_token");
 
     SECTION("Can log in") {
         std::atomic<int> error_count(0);
@@ -232,7 +232,7 @@ TEST_CASE("sync: token refreshing", "[sync]") {
     const std::string dummy_auth_url = "https://realm.example.org";
     // Disable file-related functionality and metadata functionality for testing purposes.
     SyncManager::shared().configure_file_system(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
-    auto user = SyncManager::shared().get_user("user-token-refreshing", dummy_auth_url, "not_a_real_token");
+    auto user = SyncManager::shared().get_user({ "user-token-refreshing", dummy_auth_url }, "not_a_real_token");
 
     SECTION("Can preemptively refresh token while session is active.") {
         auto session = sync_session(server, user, "/test-token-refreshing",
@@ -276,7 +276,7 @@ TEST_CASE("SyncSession: close() API", "[sync]") {
     auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
 
-    auto user = SyncManager::shared().get_user("close-api-tests-user", "https://realm.example.org", "not_a_real_token");
+    auto user = SyncManager::shared().get_user({ "close-api-tests-user", "https://realm.example.org" }, "not_a_real_token");
 
     SECTION("Behaves properly when called on session in the 'waiting for token' state for Immediate") {
         std::atomic<bool> bind_function_called(false);
@@ -334,7 +334,7 @@ TEST_CASE("sync: error handling", "[sync]") {
     std::function<void(std::shared_ptr<SyncSession>, SyncError)> error_handler = [](auto, auto) { };
     const std::string user_id = "user1d";
     std::string on_disk_path;
-    auto user = SyncManager::shared().get_user(user_id, "https://realm.example.org", "not_a_real_token");
+    auto user = SyncManager::shared().get_user({ user_id, "https://realm.example.org" }, "not_a_real_token");
     auto session = sync_session(server, user, "/test1e",
                                  [](auto&, auto&) { return s_test_token; },
                                  [&](auto session, SyncError error) { 
@@ -402,6 +402,7 @@ TEST_CASE("sync: error handling", "[sync]") {
 
 TEST_CASE("sync: stop policy behavior", "[sync]") {
     using ProtocolError = realm::sync::ProtocolError;
+    const std::string dummy_auth_url = "https://realm.example.org";
     if (!EventLoop::has_implementation())
         return;
 
@@ -430,7 +431,7 @@ TEST_CASE("sync: stop policy behavior", "[sync]") {
     };
 
     SECTION("properly transitions from active directly to inactive, and nothing bad happens", "[Immediately]") {
-        auto user = SyncManager::shared().get_user("user-dying-state-1", "https://realm.example.org", "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ "user-dying-state-1", dummy_auth_url }, "not_a_real_token");
         Realm::Config config;
         auto session = sync_session(server, user, "/test-dying-state-1",
                                     [](auto&, auto&) { return s_test_token; },
@@ -446,7 +447,7 @@ TEST_CASE("sync: stop policy behavior", "[sync]") {
     }
 
     SECTION("properly transitions from active to dying to inactive if nothing bad happens", "[AfterChangesUploaded]") {
-        auto user = SyncManager::shared().get_user("user-dying-state-2", "https://realm.example.org", "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ "user-dying-state-2", dummy_auth_url }, "not_a_real_token");
         Realm::Config config;
         auto session = sync_session(server, user, "/test-dying-state-2",
                                     [](auto&, auto&) { return s_test_token; },
@@ -467,7 +468,7 @@ TEST_CASE("sync: stop policy behavior", "[sync]") {
 
     SECTION("properly transitions from active to dying to inactive if a fatal error happens", "[AfterChangesUploaded]") {
         std::atomic<bool> error_handler_invoked(false);
-        auto user = SyncManager::shared().get_user("user-dying-state-3", "https://realm.example.org", "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ "user-dying-state-3", dummy_auth_url }, "not_a_real_token");
         Realm::Config config;
         auto session = sync_session(server, user, "/test-dying-state-3",
                                     [](auto&, auto&) { return s_test_token; },
@@ -491,7 +492,7 @@ TEST_CASE("sync: stop policy behavior", "[sync]") {
 
     SECTION("ignores and swallows non-fatal errors if in the dying state.", "[AfterChangesUploaded]") {
         std::atomic<bool> error_handler_invoked(false);
-        auto user = SyncManager::shared().get_user("user-dying-state-4", "https://realm.example.org", "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ "user-dying-state-4", dummy_auth_url }, "not_a_real_token");
         Realm::Config config;
         auto session = sync_session(server, user, "/test-dying-state-4",
                                     [](auto&, auto&) { return s_test_token; },

--- a/tests/sync/session/wait_for_completion.cpp
+++ b/tests/sync/session/wait_for_completion.cpp
@@ -31,6 +31,8 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
     if (!EventLoop::has_implementation())
         return;
 
+    const std::string dummy_auth_url = "https://realm.example.org";
+
     auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
     // Disable file-related functionality and metadata functionality for testing purposes.
@@ -39,7 +41,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
     std::atomic<bool> handler_called(false);
 
     SECTION("works properly when called after the session is bound") {
-        auto user = SyncManager::shared().get_user("user-async-wait-download-1", "https://realm.example.org", "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ "user-async-wait-download-1", dummy_auth_url }, "not_a_real_token");
         auto session = sync_session(server, user, "/async-wait-download-1",
                                     [](const std::string&, const std::string&) { return s_test_token; },
                                     [](auto, auto) { });
@@ -52,7 +54,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
     }
 
     SECTION("works properly when called on a session waiting for its access token") {
-        auto user = SyncManager::shared().get_user("user-async-wait-download-2", "https://realm.example.org", "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ "user-async-wait-download-2", dummy_auth_url }, "not_a_real_token");
         std::atomic<bool> login_handler_called(false);
         auto server_path = "/async-wait-download-2";
         std::shared_ptr<SyncSession> session = sync_session_with_bind_handler(server, user, server_path,
@@ -78,7 +80,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
 
     SECTION("works properly when called on a logged-out session") {
         const auto user_id = "user-async-wait-download-3";
-        auto user = SyncManager::shared().get_user(user_id, "https://realm.example.org", "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ user_id, dummy_auth_url }, "not_a_real_token");
         auto session = sync_session(server, user, "/user-async-wait-download-3",
                                     [](auto&, auto&) { return s_test_token; },
                                     [](auto, auto) { });
@@ -93,7 +95,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
         spin_runloop();
         REQUIRE(handler_called == false);
         // Log the user back in
-        user = SyncManager::shared().get_user(user_id, "https://realm.example.org", "not_a_real_token_either");
+        user = SyncManager::shared().get_user({ user_id, dummy_auth_url }, "not_a_real_token_either");
         EventLoop::main().run_until([&] { return sessions_are_active(*session); });
         // Now, wait for the completion handler to be called.
         EventLoop::main().run_until([&] { return handler_called == true; });
@@ -101,7 +103,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
 
     SECTION("aborts properly when queued and the session errors out") {
         using ProtocolError = realm::sync::ProtocolError;
-        auto user = SyncManager::shared().get_user("user-async-wait-download-4", "https://realm.example.org", "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ "user-async-wait-download-4", dummy_auth_url }, "not_a_real_token");
         std::atomic<bool> login_handler_called(false);
         std::atomic<int> error_count(0);
         auto server_path = "/async-wait-download-4";
@@ -126,7 +128,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
     }
 
     SECTION("properly rejects any callbacks when session is errored") {
-        auto user = SyncManager::shared().get_user("user-async-wait-download-5", "https://realm.example.org", "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ "user-async-wait-download-5", dummy_auth_url }, "not_a_real_token");
         std::atomic<int> error_count(0);
         auto session = sync_session(server, user, "/test",
                                     [](const std::string&, const std::string&) { return "this is not a valid access token"; },
@@ -141,6 +143,8 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
     if (!EventLoop::has_implementation())
         return;
 
+    const std::string dummy_auth_url = "https://realm.example.org";
+
     auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
     // Disable file-related functionality and metadata functionality for testing purposes.
@@ -149,7 +153,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
     std::atomic<bool> handler_called(false);
 
     SECTION("works properly when called after the session is bound") {
-        auto user = SyncManager::shared().get_user("user-async-wait-upload-1", "https://realm.example.org", "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ "user-async-wait-upload-1", dummy_auth_url }, "not_a_real_token");
         auto session = sync_session(server, user, "/async-wait-upload-1",
                                     [](const std::string&, const std::string&) { return s_test_token; },
                                     [](auto, auto) { });
@@ -162,7 +166,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
     }
 
     SECTION("works properly when called on a session waiting for its access token") {
-        auto user = SyncManager::shared().get_user("user-async-wait-upload-2", "https://realm.example.org", "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ "user-async-wait-upload-2", dummy_auth_url }, "not_a_real_token");
         std::atomic<bool> login_handler_called(false);
         auto server_path = "/async-wait-upload-2";
         std::shared_ptr<SyncSession> session = sync_session_with_bind_handler(server, user, server_path,
@@ -188,7 +192,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
 
     SECTION("works properly when called on a logged-out session") {
         const auto user_id = "user-async-wait-upload-3";
-        auto user = SyncManager::shared().get_user(user_id, "https://realm.example.org", "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ user_id, dummy_auth_url }, "not_a_real_token");
         auto session = sync_session(server, user, "/user-async-wait-upload-3",
                                     [](auto&, auto&) { return s_test_token; },
                                     [](auto, auto) { });
@@ -203,7 +207,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
         spin_runloop();
         REQUIRE(handler_called == false);
         // Log the user back in
-        user = SyncManager::shared().get_user(user_id, "https://realm.example.org", "not_a_real_token_either");
+        user = SyncManager::shared().get_user({ user_id, dummy_auth_url }, "not_a_real_token_either");
         EventLoop::main().run_until([&] { return sessions_are_active(*session); });
         // Now, wait for the completion handler to be called.
         EventLoop::main().run_until([&] { return handler_called == true; });
@@ -211,7 +215,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
 
     SECTION("aborts properly when queued and the session errors out") {
         using ProtocolError = realm::sync::ProtocolError;
-        auto user = SyncManager::shared().get_user("user-async-wait-upload-4", "https://realm.example.org", "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ "user-async-wait-upload-4", dummy_auth_url }, "not_a_real_token");
         std::atomic<bool> login_handler_called(false);
         std::atomic<int> error_count(0);
         auto server_path = "/async-wait-upload-4";
@@ -236,7 +240,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
     }
 
     SECTION("properly rejects any callbacks when session is errored") {
-        auto user = SyncManager::shared().get_user("user-async-wait-upload-5", "https://realm.example.org", "not_a_real_token");
+        auto user = SyncManager::shared().get_user({ "user-async-wait-upload-5", dummy_auth_url }, "not_a_real_token");
         std::atomic<int> error_count(0);
         auto session = sync_session(server, user, "/test",
                                     [](const std::string&, const std::string&) { return "this is not a valid access token"; },

--- a/tests/sync/session/wait_for_completion.cpp
+++ b/tests/sync/session/wait_for_completion.cpp
@@ -39,7 +39,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
     std::atomic<bool> handler_called(false);
 
     SECTION("works properly when called after the session is bound") {
-        auto user = SyncManager::shared().get_user("user-async-wait-download-1", "not_a_real_token");
+        auto user = SyncManager::shared().get_user("user-async-wait-download-1", "https://realm.example.org", "not_a_real_token");
         auto session = sync_session(server, user, "/async-wait-download-1",
                                     [](const std::string&, const std::string&) { return s_test_token; },
                                     [](auto, auto) { });
@@ -52,7 +52,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
     }
 
     SECTION("works properly when called on a session waiting for its access token") {
-        auto user = SyncManager::shared().get_user("user-async-wait-download-2", "not_a_real_token");
+        auto user = SyncManager::shared().get_user("user-async-wait-download-2", "https://realm.example.org", "not_a_real_token");
         std::atomic<bool> login_handler_called(false);
         auto server_path = "/async-wait-download-2";
         std::shared_ptr<SyncSession> session = sync_session_with_bind_handler(server, user, server_path,
@@ -78,7 +78,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
 
     SECTION("works properly when called on a logged-out session") {
         const auto user_id = "user-async-wait-download-3";
-        auto user = SyncManager::shared().get_user(user_id, "not_a_real_token");
+        auto user = SyncManager::shared().get_user(user_id, "https://realm.example.org", "not_a_real_token");
         auto session = sync_session(server, user, "/user-async-wait-download-3",
                                     [](auto&, auto&) { return s_test_token; },
                                     [](auto, auto) { });
@@ -93,7 +93,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
         spin_runloop();
         REQUIRE(handler_called == false);
         // Log the user back in
-        user = SyncManager::shared().get_user(user_id, "not_a_real_token_either");
+        user = SyncManager::shared().get_user(user_id, "https://realm.example.org", "not_a_real_token_either");
         EventLoop::main().run_until([&] { return sessions_are_active(*session); });
         // Now, wait for the completion handler to be called.
         EventLoop::main().run_until([&] { return handler_called == true; });
@@ -101,7 +101,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
 
     SECTION("aborts properly when queued and the session errors out") {
         using ProtocolError = realm::sync::ProtocolError;
-        auto user = SyncManager::shared().get_user("user-async-wait-download-4", "not_a_real_token");
+        auto user = SyncManager::shared().get_user("user-async-wait-download-4", "https://realm.example.org", "not_a_real_token");
         std::atomic<bool> login_handler_called(false);
         std::atomic<int> error_count(0);
         auto server_path = "/async-wait-download-4";
@@ -126,7 +126,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
     }
 
     SECTION("properly rejects any callbacks when session is errored") {
-        auto user = SyncManager::shared().get_user("user-async-wait-download-5", "not_a_real_token");
+        auto user = SyncManager::shared().get_user("user-async-wait-download-5", "https://realm.example.org", "not_a_real_token");
         std::atomic<int> error_count(0);
         auto session = sync_session(server, user, "/test",
                                     [](const std::string&, const std::string&) { return "this is not a valid access token"; },
@@ -149,7 +149,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
     std::atomic<bool> handler_called(false);
 
     SECTION("works properly when called after the session is bound") {
-        auto user = SyncManager::shared().get_user("user-async-wait-upload-1", "not_a_real_token");
+        auto user = SyncManager::shared().get_user("user-async-wait-upload-1", "https://realm.example.org", "not_a_real_token");
         auto session = sync_session(server, user, "/async-wait-upload-1",
                                     [](const std::string&, const std::string&) { return s_test_token; },
                                     [](auto, auto) { });
@@ -162,7 +162,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
     }
 
     SECTION("works properly when called on a session waiting for its access token") {
-        auto user = SyncManager::shared().get_user("user-async-wait-upload-2", "not_a_real_token");
+        auto user = SyncManager::shared().get_user("user-async-wait-upload-2", "https://realm.example.org", "not_a_real_token");
         std::atomic<bool> login_handler_called(false);
         auto server_path = "/async-wait-upload-2";
         std::shared_ptr<SyncSession> session = sync_session_with_bind_handler(server, user, server_path,
@@ -188,7 +188,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
 
     SECTION("works properly when called on a logged-out session") {
         const auto user_id = "user-async-wait-upload-3";
-        auto user = SyncManager::shared().get_user(user_id, "not_a_real_token");
+        auto user = SyncManager::shared().get_user(user_id, "https://realm.example.org", "not_a_real_token");
         auto session = sync_session(server, user, "/user-async-wait-upload-3",
                                     [](auto&, auto&) { return s_test_token; },
                                     [](auto, auto) { });
@@ -203,7 +203,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
         spin_runloop();
         REQUIRE(handler_called == false);
         // Log the user back in
-        user = SyncManager::shared().get_user(user_id, "not_a_real_token_either");
+        user = SyncManager::shared().get_user(user_id, "https://realm.example.org", "not_a_real_token_either");
         EventLoop::main().run_until([&] { return sessions_are_active(*session); });
         // Now, wait for the completion handler to be called.
         EventLoop::main().run_until([&] { return handler_called == true; });
@@ -211,7 +211,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
 
     SECTION("aborts properly when queued and the session errors out") {
         using ProtocolError = realm::sync::ProtocolError;
-        auto user = SyncManager::shared().get_user("user-async-wait-upload-4", "not_a_real_token");
+        auto user = SyncManager::shared().get_user("user-async-wait-upload-4", "https://realm.example.org", "not_a_real_token");
         std::atomic<bool> login_handler_called(false);
         std::atomic<int> error_count(0);
         auto server_path = "/async-wait-upload-4";
@@ -236,7 +236,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
     }
 
     SECTION("properly rejects any callbacks when session is errored") {
-        auto user = SyncManager::shared().get_user("user-async-wait-upload-5", "not_a_real_token");
+        auto user = SyncManager::shared().get_user("user-async-wait-upload-5", "https://realm.example.org", "not_a_real_token");
         std::atomic<int> error_count(0);
         auto session = sync_session(server, user, "/test",
                                     [](const std::string&, const std::string&) { return "this is not a valid access token"; },

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -176,13 +176,12 @@ TEST_CASE("sync_manager: user state management", "[sync]") {
         CHECK(validate_user_in_vector(users, identity_3, url_3, token_3a));
     }
 
-    SECTION("should contain admin-token users if such users are created.") {
+    SECTION("should not contain admin-token users if such users are created.") {
         SyncManager::shared().get_user({ identity_2, url_2 }, token_2);
         SyncManager::shared().get_admin_token_user(identity_3, token_3);
         auto users = SyncManager::shared().all_logged_in_users();
-        REQUIRE(users.size() == 2);
+        REQUIRE(users.size() == 1);
         CHECK(validate_user_in_vector(users, identity_2, url_2, token_2));
-        CHECK(validate_user_in_vector(users, identity_3, none, token_3));
     }
 
     SECTION("should return current user that was created during run time") {

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -72,15 +72,21 @@ TEST_CASE("sync_manager: basic properties and APIs", "[sync]") {
 TEST_CASE("sync_manager: `path_for_realm` API", "[sync]") {
     auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     reset_test_directory(base_path);
-    SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoMetadata);
-
-    SECTION("should work properly") {
+    
+    SECTION("should work properly without metadata") {
+        SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoMetadata);
+        // Get a sync user
         const std::string identity = "foobarbaz";
+        auto user = SyncManager::shared().get_user(identity, "https://realm.example.org", "dummy_token");
         const std::string raw_url = "realms://foo.bar.example.com/realm/something/~/123456/xyz";
         const auto expected = base_path + "realm-object-server/foobarbaz/realms%3A%2F%2Ffoo.bar.example.com%2Frealm%2Fsomething%2F%7E%2F123456%2Fxyz";
-        REQUIRE(SyncManager::shared().path_for_realm(identity, raw_url) == expected);
+        REQUIRE(SyncManager::shared().path_for_realm(*user, raw_url) == expected);
         // This API should also generate the directory if it doesn't already exist.
         REQUIRE_DIR_EXISTS(base_path + "realm-object-server/foobarbaz/");
+    }
+
+    SECTION("should work properly with metadata") {
+        // TODO
     }
 }
 
@@ -100,19 +106,43 @@ TEST_CASE("sync_manager: user state management", "[sync]") {
     const std::string identity_3 = "user-baz";
 
     SECTION("should get all users that are created during run time") {
-        SyncManager::shared().get_user(identity_1, token_1, url_1);
-        SyncManager::shared().get_user(identity_2, token_2, url_2);
+        SyncManager::shared().get_user(identity_1, url_1, token_1);
+        SyncManager::shared().get_user(identity_2, url_2, token_2);
         auto users = SyncManager::shared().all_logged_in_users();
         REQUIRE(users.size() == 2);
         CHECK(validate_user_in_vector(users, identity_1, url_1, token_1));
         CHECK(validate_user_in_vector(users, identity_2, url_2, token_2));
     }
 
+    SECTION("should be able to distinguish users based solely on URL") {
+        SyncManager::shared().get_user(identity_1, url_1, token_1);
+        SyncManager::shared().get_user(identity_1, url_2, token_1);
+        SyncManager::shared().get_user(identity_1, url_3, token_1);
+        SyncManager::shared().get_user(identity_1, url_1, token_1); // existing
+        auto users = SyncManager::shared().all_logged_in_users();
+        REQUIRE(users.size() == 3);
+        CHECK(validate_user_in_vector(users, identity_1, url_1, token_1));
+        CHECK(validate_user_in_vector(users, identity_1, url_2, token_1));
+        CHECK(validate_user_in_vector(users, identity_1, url_2, token_1));
+    }
+
+    SECTION("should be able to distinguish users based solely on user ID") {
+        SyncManager::shared().get_user(identity_1, url_1, token_1);
+        SyncManager::shared().get_user(identity_2, url_1, token_1);
+        SyncManager::shared().get_user(identity_3, url_1, token_1);
+        SyncManager::shared().get_user(identity_1, url_1, token_1); // existing
+        auto users = SyncManager::shared().all_logged_in_users();
+        REQUIRE(users.size() == 3);
+        CHECK(validate_user_in_vector(users, identity_1, url_1, token_1));
+        CHECK(validate_user_in_vector(users, identity_2, url_1, token_1));
+        CHECK(validate_user_in_vector(users, identity_3, url_1, token_1));
+    }
+
     SECTION("should properly update state in response to users logging in and out") {
         auto token_3a = "qwerty";
-        auto u1 = SyncManager::shared().get_user(identity_1, token_1, url_1);
-        auto u2 = SyncManager::shared().get_user(identity_2, token_2, url_2);
-        auto u3 = SyncManager::shared().get_user(identity_3, token_3, url_3);
+        auto u1 = SyncManager::shared().get_user(identity_1, url_1, token_1);
+        auto u2 = SyncManager::shared().get_user(identity_2, url_2, token_2);
+        auto u3 = SyncManager::shared().get_user(identity_3, url_3, token_3);
         auto users = SyncManager::shared().all_logged_in_users();
         REQUIRE(users.size() == 3);
         CHECK(validate_user_in_vector(users, identity_1, url_1, token_1));
@@ -125,7 +155,7 @@ TEST_CASE("sync_manager: user state management", "[sync]") {
         REQUIRE(users.size() == 1);
         CHECK(validate_user_in_vector(users, identity_2, url_2, token_2));
         // Log user 3 back in
-        u3 = SyncManager::shared().get_user(identity_3, token_3a, url_3);
+        u3 = SyncManager::shared().get_user(identity_3, url_3, token_3a);
         users = SyncManager::shared().all_logged_in_users();
         REQUIRE(users.size() == 2);
         CHECK(validate_user_in_vector(users, identity_2, url_2, token_2));
@@ -138,9 +168,8 @@ TEST_CASE("sync_manager: user state management", "[sync]") {
     }
 
     SECTION("should contain admin-token users if such users are created.") {
-        // FIXME: once we refactor how admin-token users they should no longer be persisted.
-        SyncManager::shared().get_user(identity_2, token_2, url_2);
-        SyncManager::shared().get_user(identity_3, token_3, none, SyncUser::TokenType::Admin);
+        SyncManager::shared().get_user(identity_2, url_2, token_2);
+        SyncManager::shared().get_admin_token_user(identity_3, token_3);
         auto users = SyncManager::shared().all_logged_in_users();
         REQUIRE(users.size() == 2);
         CHECK(validate_user_in_vector(users, identity_2, url_2, token_2));
@@ -151,11 +180,11 @@ TEST_CASE("sync_manager: user state management", "[sync]") {
         auto u_null = SyncManager::shared().get_current_user();
         REQUIRE(u_null == nullptr);
 
-        auto u1 = SyncManager::shared().get_user(identity_1, token_1, url_1);
+        auto u1 = SyncManager::shared().get_user(identity_1, url_1, token_1);
         auto u_current = SyncManager::shared().get_current_user();
         REQUIRE(u_current == u1);
 
-        auto u2 = SyncManager::shared().get_user(identity_2, token_2, url_2);
+        auto u2 = SyncManager::shared().get_user(identity_2, url_2, token_2);
         REQUIRE_THROWS_AS(SyncManager::shared().get_current_user(), std::logic_error);
     }
 }
@@ -167,9 +196,9 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
     // Open the metadata separately, so we can investigate it ourselves.
     SyncMetadataManager manager(file_manager.metadata_path(), false);
 
-    const std::string url_1 = "https://example.realm.com/1/";
-    const std::string url_2 = "https://example.realm.com/2/";
-    const std::string url_3 = "https://example.realm.com/3/";
+    const std::string url_1 = "https://example.realm.org/1/";
+    const std::string url_2 = "https://example.realm.org/2/";
+    const std::string url_3 = "https://example.realm.org/3/";
     const std::string token_1 = "foo_token";
     const std::string token_2 = "bar_token";
     const std::string token_3 = "baz_token";
@@ -179,14 +208,14 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
         const std::string identity_2 = "bar-1";
         const std::string identity_3 = "baz-1";
         // First, create a few users and add them to the metadata.
-        auto u1 = SyncUserMetadata(manager, identity_1);
-        u1.set_state(url_1, token_1);
-        auto u2 = SyncUserMetadata(manager, identity_2);
-        u2.set_state(url_2, token_2);
-        auto u3 = SyncUserMetadata(manager, identity_3);
-        u3.set_state(url_3, token_3);
+        auto u1 = manager.get_or_make_user_metadata(identity_1, url_1);
+        u1->set_user_token(token_1);
+        auto u2 = manager.get_or_make_user_metadata(identity_2, url_2);
+        u2->set_user_token(token_2);
+        auto u3 = manager.get_or_make_user_metadata(identity_3, url_3);
+        u3->set_user_token(token_3);
         // The fourth user is an "invalid" user: no token, so shouldn't show up.
-        auto u_invalid = SyncUserMetadata(manager, "invalid_user");
+        auto u_invalid = manager.get_or_make_user_metadata("invalid_user", url_1);
         REQUIRE(manager.all_unmarked_users().size() == 4);
 
         SECTION("they should be added to the active users list when metadata is enabled") {
@@ -205,33 +234,36 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
     }
 
     SECTION("when users are marked") {
+        const std::string auth_url = "https://example.realm.org";
         const std::string identity_1 = "foo-2";
         const std::string identity_2 = "bar-2";
         const std::string identity_3 = "baz-2";
+        
+        // Create the user metadata.
+        auto u1 = manager.get_or_make_user_metadata(identity_1, auth_url);
+        u1->mark_for_removal();
+        auto u2 = manager.get_or_make_user_metadata(identity_2, auth_url);
+        u2->mark_for_removal();
+        // Don't mark this user for deletion.
+        auto u3 = manager.get_or_make_user_metadata(identity_3, auth_url);
+        u3->set_user_token(token_3);
+
         // Pre-populate the user directories.
-        const auto user_dir_1 = file_manager.user_directory(identity_1);
-        const auto user_dir_2 = file_manager.user_directory(identity_2);
-        const auto user_dir_3 = file_manager.user_directory(identity_3);
+        const auto user_dir_1 = file_manager.user_directory(u1->local_uuid());
+        const auto user_dir_2 = file_manager.user_directory(u2->local_uuid());
+        const auto user_dir_3 = file_manager.user_directory(u3->local_uuid());
         create_dummy_realm(user_dir_1 + "123456789");
         create_dummy_realm(user_dir_1 + "foo");
         create_dummy_realm(user_dir_2 + "123456789");
         create_dummy_realm(user_dir_3 + "foo");
         create_dummy_realm(user_dir_3 + "bar");
         create_dummy_realm(user_dir_3 + "baz");
-        // Create the user metadata.
-        auto u1 = SyncUserMetadata(manager, identity_1);
-        u1.mark_for_removal();
-        auto u2 = SyncUserMetadata(manager, identity_2);
-        u2.mark_for_removal();
-        // Don't mark this user for deletion.
-        auto u3 = SyncUserMetadata(manager, identity_3);
-        u3.set_state(url_3, token_3);
 
         SECTION("they should be cleaned up if metadata is enabled") {
             SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoEncryption);
             auto users = SyncManager::shared().all_logged_in_users();
             REQUIRE(users.size() == 1);
-            REQUIRE(validate_user_in_vector(users, identity_3, url_3, token_3));
+            REQUIRE(validate_user_in_vector(users, identity_3, auth_url, token_3));
             REQUIRE_DIR_DOES_NOT_EXIST(user_dir_1);
             REQUIRE_DIR_DOES_NOT_EXIST(user_dir_2);
             REQUIRE_DIR_EXISTS(user_dir_3);
@@ -255,22 +287,22 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
     SyncMetadataManager manager(file_manager.metadata_path(), false);
 
     const std::string realm_url = "https://example.realm.com/~/1";
-    const std::string identity_1 = "foo-1";
-    const std::string identity_2 = "bar-1";
-    const std::string identity_3 = "baz-1";
-    const std::string identity_4 = "baz-2";
+    const std::string local_uuid_1 = "foo-1";
+    const std::string local_uuid_2 = "bar-1";
+    const std::string local_uuid_3 = "baz-1";
+    const std::string local_uuid_4 = "baz-2";
 
     // Realm paths
-    const std::string realm_path_1 = file_manager.path(identity_1, realm_url);
-    const std::string realm_path_2 = file_manager.path(identity_2, realm_url);
-    const std::string realm_path_3 = file_manager.path(identity_3, realm_url);
-    const std::string realm_path_4 = file_manager.path(identity_4, realm_url);
+    const std::string realm_path_1 = file_manager.path(local_uuid_1, realm_url);
+    const std::string realm_path_2 = file_manager.path(local_uuid_2, realm_url);
+    const std::string realm_path_3 = file_manager.path(local_uuid_3, realm_url);
+    const std::string realm_path_4 = file_manager.path(local_uuid_4, realm_url);
 
     SECTION("Action::DeleteRealm") {
         // Create some file actions
-        auto a1 = SyncFileActionMetadata(manager, Action::DeleteRealm, realm_path_1, realm_url, "user1");
-        auto a2 = SyncFileActionMetadata(manager, Action::DeleteRealm, realm_path_2, realm_url, "user2");
-        auto a3 = SyncFileActionMetadata(manager, Action::DeleteRealm, realm_path_3, realm_url, "user3");
+        auto a1 = manager.make_file_action_metadata(realm_path_1, realm_url, "user1", Action::DeleteRealm);
+        auto a2 = manager.make_file_action_metadata(realm_path_2, realm_url, "user2", Action::DeleteRealm);
+        auto a3 = manager.make_file_action_metadata(realm_path_3, realm_url, "user3", Action::DeleteRealm);
 
         SECTION("should properly delete the Realm") {
             // Create some Realms
@@ -319,9 +351,9 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
         const std::string recovery_1 = util::file_path_by_appending_component(recovery_dir, "recovery-1");
         const std::string recovery_2 = util::file_path_by_appending_component(recovery_dir, "recovery-2");
         const std::string recovery_3 = util::file_path_by_appending_component(recovery_dir, "recovery-3");
-        auto a1 = SyncFileActionMetadata(manager, Action::BackUpThenDeleteRealm, realm_path_1, realm_url, "user1", recovery_1);
-        auto a2 = SyncFileActionMetadata(manager, Action::BackUpThenDeleteRealm, realm_path_2, realm_url, "user2", recovery_2);
-        auto a3 = SyncFileActionMetadata(manager, Action::BackUpThenDeleteRealm, realm_path_3, realm_url, "user3", recovery_3);
+        auto a1 = manager.make_file_action_metadata(realm_path_1, realm_url, "user1", Action::BackUpThenDeleteRealm, recovery_1);
+        auto a2 = manager.make_file_action_metadata(realm_path_2, realm_url, "user2", Action::BackUpThenDeleteRealm, recovery_2);
+        auto a3 = manager.make_file_action_metadata(realm_path_3, realm_url, "user3", Action::BackUpThenDeleteRealm, recovery_3);
 
         SECTION("should properly copy the Realm file and delete the Realm") {
             // Create some Realms
@@ -351,7 +383,7 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
             REQUIRE_REALM_EXISTS(realm_base_path);
             REQUIRE(!File::exists(recovery_path));
             // Manually create a file action metadata entry to simulate a client reset.
-            auto a = SyncFileActionMetadata(manager, Action::BackUpThenDeleteRealm, realm_base_path, realm_url, identity, recovery_path);
+            auto a = manager.make_file_action_metadata(realm_base_path, realm_url, identity, Action::BackUpThenDeleteRealm, recovery_path);
             auto pending_actions = manager.all_pending_actions();
             REQUIRE(pending_actions.size() == 4);
 
@@ -389,7 +421,7 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
             // Add a file action after the system is configured.
             REQUIRE_REALM_EXISTS(realm_path_4);
             REQUIRE(File::exists(file_manager.recovery_directory_path()));
-            auto a4 = SyncFileActionMetadata(manager, Action::BackUpThenDeleteRealm, realm_path_4, realm_url, "user4", recovery_1);
+            auto a4 = manager.make_file_action_metadata(realm_path_4, realm_url, "user4", Action::BackUpThenDeleteRealm, recovery_1);
             CHECK(pending_actions.size() == 1);
             // Force the recovery. (In a real application, the user would have closed the files by now.)
             REQUIRE(SyncManager::shared().immediately_run_file_actions(realm_path_4));

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -91,11 +91,10 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync]") {
         const std::string identity = "foobarbaz";
         auto user = SyncManager::shared().get_user({ identity, auth_server_url }, "dummy_token");
         auto local_identity = user->local_identity();
-        REQUIRE(local_identity);
-        const auto expected = base_path + "realm-object-server/" + *local_identity + "/realms%3A%2F%2Frealm.example.org%2Fa%2Fb%2F%7E%2F123456%2Fxyz";
+        const auto expected = base_path + "realm-object-server/" + local_identity + "/realms%3A%2F%2Frealm.example.org%2Fa%2Fb%2F%7E%2F123456%2Fxyz";
         REQUIRE(SyncManager::shared().path_for_realm(*user, raw_url) == expected);
         // This API should also generate the directory if it doesn't already exist.
-        REQUIRE_DIR_EXISTS(base_path + "realm-object-server/" + *local_identity + "/");
+        REQUIRE_DIR_EXISTS(base_path + "realm-object-server/" + local_identity + "/");
     }
 }
 

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -176,12 +176,13 @@ TEST_CASE("sync_manager: user state management", "[sync]") {
         CHECK(validate_user_in_vector(users, identity_3, url_3, token_3a));
     }
 
-    SECTION("should not contain admin-token users if such users are created.") {
+    SECTION("should contain admin-token users if such users are created.") {
         SyncManager::shared().get_user({ identity_2, url_2 }, token_2);
-        SyncManager::shared().get_admin_token_user(identity_3, token_3);
+        SyncManager::shared().get_admin_token_user(url_3, token_3);
         auto users = SyncManager::shared().all_logged_in_users();
-        REQUIRE(users.size() == 1);
+        REQUIRE(users.size() == 2);
         CHECK(validate_user_in_vector(users, identity_2, url_2, token_2));
+        CHECK(validate_user_in_vector(users, "__auth", url_3, token_3));
     }
 
     SECTION("should return current user that was created during run time") {

--- a/tests/sync/sync_test_utils.cpp
+++ b/tests/sync/sync_test_utils.cpp
@@ -37,9 +37,10 @@ void reset_test_directory(const std::string& base_path) {
     util::make_dir(base_path);
 }
 
-bool results_contains_user(SyncUserMetadataResults& results, const std::string& identity) {
+bool results_contains_user(SyncUserMetadataResults& results, const std::string& identity, const std::string& auth_server) {
     for (size_t i = 0; i < results.size(); i++) {
-        if (results.get(i).identity() == identity) {
+        auto this_result = results.get(i);
+        if (this_result.identity() == identity && this_result.auth_server_url() == auth_server) {
             return true;
         }
     }

--- a/tests/sync/sync_test_utils.hpp
+++ b/tests/sync/sync_test_utils.hpp
@@ -29,7 +29,7 @@ namespace realm {
 /// Open a Realm at a given path, creating its files.
 bool create_dummy_realm(std::string path);
 void reset_test_directory(const std::string& base_path);
-bool results_contains_user(SyncUserMetadataResults& results, const std::string& identity);
+bool results_contains_user(SyncUserMetadataResults& results, const std::string& identity, const std::string& auth_server);
 bool results_contains_original_name(SyncFileActionMetadataResults& results, const std::string& original_name);
 std::string tmp_dir();
 std::vector<char> make_test_encryption_key(const char start = 0);

--- a/tests/sync/user.cpp
+++ b/tests/sync/user.cpp
@@ -102,14 +102,10 @@ TEST_CASE("sync_user: SyncManager `get_admin_token_user()` APIs", "[sync]") {
         REQUIRE(user->state() == SyncUser::State::Active);
     }
 
-    SECTION("properly throws if trying to create a new wraps-admin-token user without a token") {
-        REQUIRE_THROWS(SyncManager::shared().get_admin_token_user(server_url));
-    }
-
     SECTION("properly retrieves an existing wraps-admin-token user ") {
         auto user = SyncManager::shared().get_admin_token_user(server_url, token);
         REQUIRE(user);
-        auto user2 = SyncManager::shared().get_admin_token_user(server_url);
+        auto user2 = SyncManager::shared().get_admin_token_user(server_url, token);
         REQUIRE(user2);
         REQUIRE(user2->is_admin());
         REQUIRE(user2->identity() == "__auth");
@@ -122,21 +118,28 @@ TEST_CASE("sync_user: SyncManager `get_admin_token_user()` APIs", "[sync]") {
         SECTION("if no server URL is provided") {
             auto user = SyncManager::shared().get_admin_token_user_from_identity(identity, none, token);
             REQUIRE(user);
+            REQUIRE(user->identity() == "__auth");
             // Retrieve the same user.
-            auto user2 = SyncManager::shared().get_admin_token_user_from_identity(identity, none, none);
+            auto user2 = SyncManager::shared().get_admin_token_user_from_identity(identity, none, token);
             REQUIRE(user2);
+            REQUIRE(user2->identity() == "__auth");
             REQUIRE(user2->refresh_token() == token);
+            REQUIRE(user2->local_identity() == user->local_identity());
         }
 
         SECTION("if server URL is provided") {
             auto user = SyncManager::shared().get_admin_token_user_from_identity(identity, server_url, token);
-            auto user2 = SyncManager::shared().get_admin_token_user_from_identity(identity, server_url, none);
+            auto user2 = SyncManager::shared().get_admin_token_user_from_identity(identity, server_url, token);
             REQUIRE(user2);
+            REQUIRE(user2->identity() == "__auth");
             REQUIRE(user2->refresh_token() == token);
+            REQUIRE(user2->local_identity() == user->local_identity());
             // The user should be indexed based on their server URL.
-            auto user3 = SyncManager::shared().get_admin_token_user(server_url);
+            auto user3 = SyncManager::shared().get_admin_token_user(server_url, token);
             REQUIRE(user3);
+            REQUIRE(user3->identity() == "__auth");
             REQUIRE(user3->refresh_token() == token);
+            REQUIRE(user3->local_identity() == user->local_identity());
         }
     }
 }

--- a/tests/sync/user.cpp
+++ b/tests/sync/user.cpp
@@ -38,7 +38,7 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
     const std::string server_url = "https://realm.example.org";
 
     SECTION("properly creates a new normal user") {
-        auto user = SyncManager::shared().get_user(identity, token, server_url);
+        auto user = SyncManager::shared().get_user(identity, server_url, token);
         REQUIRE(user);
         // The expected state for a newly created user:
         REQUIRE(!user->is_admin());
@@ -49,18 +49,18 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
     }
 
     SECTION("properly creates a new wraps-admin-token user") {
-        auto user = SyncManager::shared().get_user(identity, token, server_url, SyncUser::TokenType::Admin);
+        auto user = SyncManager::shared().get_admin_token_user(identity, token);
         REQUIRE(user);
         // The expected state for a newly created user:
         REQUIRE(user->is_admin());
         REQUIRE(user->identity() == identity);
-        REQUIRE(user->server_url() == server_url);
+        REQUIRE(user->server_url() == "");
         REQUIRE(user->refresh_token() == token);
         REQUIRE(user->state() == SyncUser::State::Active);
     }
 
     SECTION("properly creates a new user marked as an admin") {
-        auto user = SyncManager::shared().get_user(identity, token, server_url);
+        auto user = SyncManager::shared().get_user(identity, server_url, token);
         REQUIRE(user);
         REQUIRE(!user->is_admin());
         user->set_is_admin(true);
@@ -69,12 +69,12 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
 
     SECTION("properly retrieves a previously created user, updating fields as necessary") {
         const std::string second_token = "0987654321-fake-token";
-        auto first = SyncManager::shared().get_user(identity, token, server_url);
+        auto first = SyncManager::shared().get_user(identity, server_url, token);
         REQUIRE(first);
         REQUIRE(first->identity() == identity);
         REQUIRE(first->refresh_token() == token);
         // Get the user again, but with a different token.
-        auto second = SyncManager::shared().get_user(identity, second_token, server_url);
+        auto second = SyncManager::shared().get_user(identity, server_url, second_token);
         REQUIRE(second == first);
         REQUIRE(second->identity() == identity);
         REQUIRE(second->refresh_token() == second_token);
@@ -82,50 +82,16 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
 
     SECTION("properly resurrects a logged-out user") {
         const std::string second_token = "0987654321-fake-token";
-        auto first = SyncManager::shared().get_user(identity, token, server_url);
+        auto first = SyncManager::shared().get_user(identity, server_url, token);
         REQUIRE(first->identity() == identity);
         first->log_out();
         REQUIRE(first->state() == SyncUser::State::LoggedOut);
         // Get the user again, with a new token.
-        auto second = SyncManager::shared().get_user(identity, second_token, server_url);
+        auto second = SyncManager::shared().get_user(identity, server_url, second_token);
         REQUIRE(second == first);
         REQUIRE(second->identity() == identity);
         REQUIRE(second->refresh_token() == second_token);
         REQUIRE(second->state() == SyncUser::State::Active);
-    }
-}
-
-TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API", "[sync]") {
-    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
-    reset_test_directory(base_path);
-    SyncManager::shared().configure_file_system(base_path, SyncManager::MetadataMode::NoEncryption);
-    const std::string identity = "sync_test_identity";
-    const std::string token = "1234567890-fake-token";
-    const std::string server_url = "https://realm.example.org";
-
-    SECTION("properly returns a null pointer when called for a non-existent user") {
-        std::shared_ptr<SyncUser> user = SyncManager::shared().get_existing_logged_in_user(identity);
-        REQUIRE(!user);
-    }
-
-    SECTION("properly returns an existing logged-in user") {
-        auto first = SyncManager::shared().get_user(identity, token, server_url);
-        REQUIRE(first->identity() == identity);
-        REQUIRE(first->state() == SyncUser::State::Active);
-        // Get that user using the 'existing user' API.
-        auto second = SyncManager::shared().get_existing_logged_in_user(identity);
-        REQUIRE(second == first);
-        REQUIRE(second->refresh_token() == token);
-    }
-
-    SECTION("properly returns a null pointer for a logged-out user") {
-        auto first = SyncManager::shared().get_user(identity, token, server_url);
-        first->log_out();
-        REQUIRE(first->identity() == identity);
-        REQUIRE(first->state() == SyncUser::State::LoggedOut);
-        // Get that user using the 'existing user' API.
-        auto second = SyncManager::shared().get_existing_logged_in_user(identity);
-        REQUIRE(!second);
     }
 }
 
@@ -137,7 +103,7 @@ TEST_CASE("sync_user: logout", "[sync]") {
     const std::string server_url = "https://realm.example.org";
 
     SECTION("properly changes the state of the user object") {
-        auto user = SyncManager::shared().get_user(identity, token, server_url);
+        auto user = SyncManager::shared().get_user(identity, server_url, token);
         REQUIRE(user->state() == SyncUser::State::Active);
         user->log_out();
         REQUIRE(user->state() == SyncUser::State::LoggedOut);
@@ -156,24 +122,24 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         const std::string identity = "test_identity_1";
         const std::string token = "token-1";
         const std::string server_url = "https://realm.example.org/1/";
-        auto user = SyncManager::shared().get_user(identity, token, server_url);
+        auto user = SyncManager::shared().get_user(identity, server_url, token);
         user->set_is_admin(true);
         // Now try to pull the user out of the shadow manager directly.
-        auto metadata = SyncUserMetadata(manager, identity, false);
-        REQUIRE(metadata.is_valid());
-        REQUIRE(metadata.server_url() == server_url);
-        REQUIRE(metadata.user_token() == token);
-        REQUIRE(metadata.is_admin());
+        auto metadata = manager.get_or_make_user_metadata(identity, server_url, false);
+        REQUIRE(metadata->is_valid());
+        REQUIRE(metadata->auth_server_url() == server_url);
+        REQUIRE(metadata->user_token() == token);
+        REQUIRE(metadata->is_admin());
     }
 
     SECTION("does not persist wraps-admin-token users upon creation") {
         const std::string identity = "test_identity_1a";
         const std::string token = "token-1a";
         const std::string server_url = "https://realm.example.org/1a/";
-        auto user = SyncManager::shared().get_user(identity, token, server_url, SyncUser::TokenType::Admin);
+        auto user = SyncManager::shared().get_admin_token_user(identity, token);
         // Now try to pull the user out of the shadow manager directly.
-        auto metadata = SyncUserMetadata(manager, identity, false);
-        REQUIRE(!metadata.is_valid());
+        auto metadata = manager.get_or_make_user_metadata(identity, server_url, false);
+        REQUIRE(!metadata);
     }
 
     SECTION("properly persists a user's information when the user is updated") {
@@ -181,20 +147,20 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         const std::string token = "token-2a";
         const std::string server_url = "https://realm.example.org/2/";
         // Create the user and validate it.
-        auto first = SyncManager::shared().get_user(identity, token, server_url);
+        auto first = SyncManager::shared().get_user(identity, server_url, token);
         first->set_is_admin(true);
-        auto first_metadata = SyncUserMetadata(manager, identity, false);
-        REQUIRE(first_metadata.is_valid());
-        REQUIRE(first_metadata.user_token() == token);
-        REQUIRE(first_metadata.is_admin());
+        auto first_metadata = manager.get_or_make_user_metadata(identity, server_url, false);
+        REQUIRE(first_metadata->is_valid());
+        REQUIRE(first_metadata->user_token() == token);
+        REQUIRE(first_metadata->is_admin());
         const std::string token_2 = "token-2b";
         // Update the user.
-        auto second = SyncManager::shared().get_user(identity, token_2, server_url);
-        auto second_metadata = SyncUserMetadata(manager, identity, false);
+        auto second = SyncManager::shared().get_user(identity, server_url, token_2);
+        auto second_metadata = manager.get_or_make_user_metadata(identity, server_url, false);
         second->set_is_admin(false);
-        REQUIRE(second_metadata.is_valid());
-        REQUIRE(second_metadata.user_token() == token_2);
-        REQUIRE(!second_metadata.is_admin());
+        REQUIRE(second_metadata->is_valid());
+        REQUIRE(second_metadata->user_token() == token_2);
+        REQUIRE(!second_metadata->is_admin());
     }
 
     SECTION("properly marks a user when the user is logged out") {
@@ -202,14 +168,14 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         const std::string token = "token-3";
         const std::string server_url = "https://realm.example.org/3/";
         // Create the user and validate it.
-        auto user = SyncManager::shared().get_user(identity, token, server_url);
+        auto user = SyncManager::shared().get_user(identity, server_url, token);
         auto marked_users = manager.all_users_marked_for_removal();
         REQUIRE(marked_users.size() == 0);
         // Log out the user.
         user->log_out();
         marked_users = manager.all_users_marked_for_removal();
         REQUIRE(marked_users.size() == 1);
-        REQUIRE(results_contains_user(marked_users, identity));
+        REQUIRE(results_contains_user(marked_users, identity, server_url));
     }
 
     SECTION("properly unmarks a logged-out user when it's requested again") {
@@ -217,14 +183,14 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         const std::string token = "token-4a";
         const std::string server_url = "https://realm.example.org/3/";
         // Create the user and log it out.
-        auto first = SyncManager::shared().get_user(identity, token, server_url);
+        auto first = SyncManager::shared().get_user(identity, server_url, token);
         first->log_out();
         auto marked_users = manager.all_users_marked_for_removal();
         REQUIRE(marked_users.size() == 1);
-        REQUIRE(results_contains_user(marked_users, identity));
+        REQUIRE(results_contains_user(marked_users, identity, server_url));
         // Log the user back in.
         const std::string token_2 = "token-4b";
-        auto second = SyncManager::shared().get_user(identity, token_2, server_url);
+        auto second = SyncManager::shared().get_user(identity, server_url, token_2);
         marked_users = manager.all_users_marked_for_removal();
         REQUIRE(marked_users.size() == 0);
     }

--- a/tests/util/test_file.cpp
+++ b/tests/util/test_file.cpp
@@ -102,7 +102,7 @@ SyncTestFile::SyncTestFile(SyncServer& server, std::string name)
     auto url = server.url_for_realm(name);
 
     sync_config = std::make_shared<SyncConfig>(SyncConfig{
-        SyncManager::shared().get_user("user", url, "not_a_real_token"),
+        SyncManager::shared().get_user({ "user", url }, "not_a_real_token"),
         url,
         SyncSessionStopPolicy::Immediately,
         [=](auto&, auto&, auto session) { session->refresh_access_token(s_test_token, url); },

--- a/tests/util/test_file.cpp
+++ b/tests/util/test_file.cpp
@@ -102,7 +102,7 @@ SyncTestFile::SyncTestFile(SyncServer& server, std::string name)
     auto url = server.url_for_realm(name);
 
     sync_config = std::make_shared<SyncConfig>(SyncConfig{
-        SyncManager::shared().get_user("user", "not_a_real_token"),
+        SyncManager::shared().get_user("user", url, "not_a_real_token"),
         url,
         SyncSessionStopPolicy::Immediately,
         [=](auto&, auto&, auto session) { session->refresh_access_token(s_test_token, url); },


### PR DESCRIPTION
Changes:
- Users are no longer keyed exclusively by user identity, but rather identity and auth URL
- Local copies of synced Realms are now stored in a directory based on a locally assigned UUID, rather than the user identity
- Upgraded tests

TODO:
- [ ] Make sure API is okay
- [x] Write better migration tests
- [x] Write tests to check the text file we write to user directories
- [x] Test sync manager's `path_for_realm()` API with metadata enabled

Fixes #296.