### PR TITLE
Add support for type-templated test cases

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@ include_directories(../external/catch/single_include .)
 set(HEADERS
     util/event_loop.hpp
     util/index_helpers.hpp
+    util/templated_test_case.hpp
     util/test_file.hpp
 )
 

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -1158,7 +1158,7 @@ struct ModeManual {
 };
 struct ModeResetFile {
     static SchemaMode mode() { return SchemaMode::ResetFile; }
-    static bool should_call_init_on_version_bump() { return false; }
+    static bool should_call_init_on_version_bump() { return true; }
 };
 
 TEMPLATE_TEST_CASE("SharedRealm: update_schema with initialization_function",

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -19,9 +19,10 @@
 #include "catch.hpp"
 
 #include "util/event_loop.hpp"
-#include "util/index_helpers.hpp"
-#include "util/test_file.hpp"
 #include "util/format.hpp"
+#include "util/index_helpers.hpp"
+#include "util/templated_test_case.hpp"
+#include "util/test_file.hpp"
 
 #include "impl/realm_coordinator.hpp"
 #include "binding_context.hpp"
@@ -2464,35 +2465,38 @@ TEST_CASE("distinct") {
 #endif // !REALM_HAVE_COMPOSABLE_DISTINCT
 
 
-TEST_CASE("aggregate") {
-#define SECTIONS_RESULT_BUILT_FROM_TABLE_QUERY_TABLE_VIEW() \
-    SECTION("results built from table") { \
-        results = Results(r, *table); \
-    } \
-    SECTION("results built from query") { \
-        results = Results(r, table->where()); \
-    } \
-    SECTION("results built from tableview") { \
-        results = Results(r, table->where().find_all()); \
-    } \
-    SECTION("results built from linkview") { \
-        r->begin_transaction(); \
-        auto link_table = r->read_group().get_table("class_linking_object"); \
-        link_table->add_empty_row(1); \
-        auto link_view = link_table->get_linklist(0, 0); \
-        auto table_view = table->where().find_all(); \
-        for (size_t i = 0; i< table_view.size(); ++i) { \
-            link_view->add(table_view.get_source_ndx(i)); \
-        } \
-        r->commit_transaction(); \
-        results = Results(r, link_view); \
+struct ResultsFromTable {
+    static Results call(std::shared_ptr<Realm> r, Table* table) {
+        return Results(std::move(r), *table);
     }
+};
+struct ResultsFromQuery {
+    static Results call(std::shared_ptr<Realm> r, Table* table) {
+        return Results(std::move(r), table->where());
+    }
+};
+struct ResultsFromTableView {
+    static Results call(std::shared_ptr<Realm> r, Table* table) {
+        return Results(std::move(r), table->where().find_all());
+    }
+};
+struct ResultsFromLinkView {
+    static Results call(std::shared_ptr<Realm> r, Table* table) {
+        r->begin_transaction();
+        auto link_table = r->read_group().get_table("class_linking_object");
+        link_table->add_empty_row(1);
+        auto link_view = link_table->get_linklist(0, 0);
+        for (size_t i = 0; i < table->size(); ++i)
+            link_view->add(i);
+        r->commit_transaction();
+        return Results(r, link_view);
+    }
+};
 
-    const int column_count = 4;
+TEMPLATE_TEST_CASE("results: aggregate", ResultsFromTable, ResultsFromQuery, ResultsFromTableView, ResultsFromLinkView) {
     InMemoryTestFile config;
     config.cache = false;
     config.automatic_change_notifications = false;
-
 
     auto r = Realm::get_shared_realm(config);
     r->update_schema({
@@ -2512,9 +2516,6 @@ TEST_CASE("aggregate") {
     SECTION("one row with null values") {
         r->begin_transaction();
         table->add_empty_row(3);
-        for (int i = 0; i < column_count; ++i) {
-            table->set_null(i, 0);
-        }
 
         table->set_int(0, 1, 0);
         table->set_float(1, 1, 0.f);
@@ -2531,11 +2532,9 @@ TEST_CASE("aggregate") {
         //  2,    2,    2,    (2, 0)
         r->commit_transaction();
 
+        Results results = TestType::call(r, table.get());
+
         SECTION("max") {
-            Results results;
-
-            SECTIONS_RESULT_BUILT_FROM_TABLE_QUERY_TABLE_VIEW()
-
             REQUIRE(results.max(0)->get_int() == 2);
             REQUIRE(results.max(1)->get_float() == 2.f);
             REQUIRE(results.max(2)->get_double() == 2.0);
@@ -2543,10 +2542,6 @@ TEST_CASE("aggregate") {
         }
 
         SECTION("min") {
-            Results results;
-
-            SECTIONS_RESULT_BUILT_FROM_TABLE_QUERY_TABLE_VIEW()
-
             REQUIRE(results.min(0)->get_int() == 0);
             REQUIRE(results.min(1)->get_float() == 0.f);
             REQUIRE(results.min(2)->get_double() == 0.0);
@@ -2554,10 +2549,6 @@ TEST_CASE("aggregate") {
         }
 
         SECTION("average") {
-            Results results;
-
-            SECTIONS_RESULT_BUILT_FROM_TABLE_QUERY_TABLE_VIEW()
-
             REQUIRE(results.average(0)->get_double() == 1.0);
             REQUIRE(results.average(1)->get_double() == 1.0);
             REQUIRE(results.average(2)->get_double() == 1.0);
@@ -2565,10 +2556,6 @@ TEST_CASE("aggregate") {
         }
 
         SECTION("sum") {
-            Results results;
-
-            SECTIONS_RESULT_BUILT_FROM_TABLE_QUERY_TABLE_VIEW()
-
             REQUIRE(results.sum(0)->get_int() == 2);
             REQUIRE(results.sum(1)->get_double() == 2.0);
             REQUIRE(results.sum(2)->get_double() == 2.0);
@@ -2577,25 +2564,17 @@ TEST_CASE("aggregate") {
     }
 
     SECTION("rows with all null values") {
-        const int row_count = 3;
         r->begin_transaction();
-        table->add_empty_row(row_count);
-        for (int i = 0; i < column_count; ++i) {
-            for (int j = 0; j < row_count; ++j) {
-                table->set_null(i, j);
-            }
-        }
+        table->add_empty_row(3);
         // table:
         //  null, null, null,  null,  null
         //  null, null, null,  null,  null
         //  null, null, null,  null,  null
         r->commit_transaction();
 
+        Results results = TestType::call(r, table.get());
+
         SECTION("max") {
-            Results results;
-
-            SECTIONS_RESULT_BUILT_FROM_TABLE_QUERY_TABLE_VIEW()
-
             REQUIRE(!results.max(0));
             REQUIRE(!results.max(1));
             REQUIRE(!results.max(2));
@@ -2603,10 +2582,6 @@ TEST_CASE("aggregate") {
         }
 
         SECTION("min") {
-            Results results;
-
-            SECTIONS_RESULT_BUILT_FROM_TABLE_QUERY_TABLE_VIEW()
-
             REQUIRE(!results.min(0));
             REQUIRE(!results.min(1));
             REQUIRE(!results.min(2));
@@ -2614,10 +2589,6 @@ TEST_CASE("aggregate") {
         }
 
         SECTION("average") {
-            Results results;
-
-            SECTIONS_RESULT_BUILT_FROM_TABLE_QUERY_TABLE_VIEW()
-
             REQUIRE(!results.average(0));
             REQUIRE(!results.average(1));
             REQUIRE(!results.average(2));
@@ -2625,10 +2596,6 @@ TEST_CASE("aggregate") {
         }
 
         SECTION("sum") {
-            Results results;
-
-            SECTIONS_RESULT_BUILT_FROM_TABLE_QUERY_TABLE_VIEW()
-
             REQUIRE(results.sum(0)->get_int() == 0);
             REQUIRE(results.sum(1)->get_double() == 0.0);
             REQUIRE(results.sum(2)->get_double() == 0.0);
@@ -2637,15 +2604,9 @@ TEST_CASE("aggregate") {
     }
 
     SECTION("empty") {
+        Results results = TestType::call(r, table.get());
+
         SECTION("max") {
-            Results results;
-
-            SECTION("empty results") {
-                results = Results();
-            }
-
-            SECTIONS_RESULT_BUILT_FROM_TABLE_QUERY_TABLE_VIEW()
-
             REQUIRE(!results.max(0));
             REQUIRE(!results.max(1));
             REQUIRE(!results.max(2));
@@ -2653,10 +2614,6 @@ TEST_CASE("aggregate") {
         }
 
         SECTION("min") {
-            Results results;
-
-            SECTIONS_RESULT_BUILT_FROM_TABLE_QUERY_TABLE_VIEW()
-
             REQUIRE(!results.min(0));
             REQUIRE(!results.min(1));
             REQUIRE(!results.min(2));
@@ -2664,10 +2621,6 @@ TEST_CASE("aggregate") {
         }
 
         SECTION("average") {
-            Results results;
-
-            SECTIONS_RESULT_BUILT_FROM_TABLE_QUERY_TABLE_VIEW()
-
             REQUIRE(!results.average(0));
             REQUIRE(!results.average(1));
             REQUIRE(!results.average(2));
@@ -2675,10 +2628,6 @@ TEST_CASE("aggregate") {
         }
 
         SECTION("sum") {
-            Results results;
-
-            SECTIONS_RESULT_BUILT_FROM_TABLE_QUERY_TABLE_VIEW()
-
             REQUIRE(results.sum(0)->get_int() == 0);
             REQUIRE(results.sum(1)->get_double() == 0.0);
             REQUIRE(results.sum(2)->get_double() == 0.0);

--- a/tests/util/templated_test_case.hpp
+++ b/tests/util/templated_test_case.hpp
@@ -16,11 +16,15 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+// Work around a msvc preprocessor bug that considers __VA_ARGS__ a single token
+// by forcing another round of macro expansion whereever it's used.
+#define REALM_EXPAND(x) x
+
 // Define a Catch test case templated on up to 20 types
 // The current type is exposed inside the test as `TestType`
 #define TEMPLATE_TEST_CASE(name, ...) \
-    REALM_TEMPLATE_TEST_CASE(name, INTERNAL_CATCH_UNIQUE_NAME(REALM_TEMPLATE_TEST_), \
-                             __VA_ARGS__, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE(name, INTERNAL_CATCH_UNIQUE_NAME(REALM_TEMPLATE_TEST_), \
+                                          __VA_ARGS__, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0))
 
 #define REALM_TEMPLATE_TEST_CASE(name, fn, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, n, ...) \
     template<typename> static void fn(); \
@@ -37,87 +41,88 @@
 
 #define REALM_TEMPLATE_TEST_CASE_2(fn, T, ...) \
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
-    REALM_TEMPLATE_TEST_CASE_1(fn, __VA_ARGS__)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE_1(fn, __VA_ARGS__))
 
 #define REALM_TEMPLATE_TEST_CASE_3(fn, T, ...) \
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
-    REALM_TEMPLATE_TEST_CASE_2(fn, __VA_ARGS__)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE_2(fn, __VA_ARGS__))
 
 #define REALM_TEMPLATE_TEST_CASE_4(fn, T, ...) \
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
-    REALM_TEMPLATE_TEST_CASE_3(fn, __VA_ARGS__)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE_3(fn, __VA_ARGS__))
 
 #define REALM_TEMPLATE_TEST_CASE_5(fn, T, ...) \
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
-    REALM_TEMPLATE_TEST_CASE_4(fn, __VA_ARGS__)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE_4(fn, __VA_ARGS__))
 
 #define REALM_TEMPLATE_TEST_CASE_6(fn, T, ...) \
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
-    REALM_TEMPLATE_TEST_CASE_5(fn, __VA_ARGS__)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE_5(fn, __VA_ARGS__))
 
 #define REALM_TEMPLATE_TEST_CASE_7(fn, T, ...) \
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
-    REALM_TEMPLATE_TEST_CASE_6(fn, __VA_ARGS__)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE_6(fn, __VA_ARGS__))
 
 #define REALM_TEMPLATE_TEST_CASE_8(fn, T, ...) \
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
-    REALM_TEMPLATE_TEST_CASE_7(fn, __VA_ARGS__)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE_7(fn, __VA_ARGS__))
 
 #define REALM_TEMPLATE_TEST_CASE_9(fn, T, ...) \
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
-    REALM_TEMPLATE_TEST_CASE_8(fn, __VA_ARGS__)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE_8(fn, __VA_ARGS__))
 
 #define REALM_TEMPLATE_TEST_CASE_10(fn, T, ...) \
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
-    REALM_TEMPLATE_TEST_CASE_9(fn, __VA_ARGS__)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE_9(fn, __VA_ARGS__))
 
 #define REALM_TEMPLATE_TEST_CASE_11(fn, T, ...) \
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
-    REALM_TEMPLATE_TEST_CASE_10(fn, __VA_ARGS__)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE_10(fn, __VA_ARGS__))
 
 #define REALM_TEMPLATE_TEST_CASE_12(fn, T, ...) \
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
-    REALM_TEMPLATE_TEST_CASE_11(fn, __VA_ARGS__)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE_11(fn, __VA_ARGS__))
 
 #define REALM_TEMPLATE_TEST_CASE_13(fn, T, ...) \
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
-    REALM_TEMPLATE_TEST_CASE_12(fn, __VA_ARGS__)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE_12(fn, __VA_ARGS__))
 
 #define REALM_TEMPLATE_TEST_CASE_14(fn, T, ...) \
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
-    REALM_TEMPLATE_TEST_CASE_13(fn, __VA_ARGS__)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE_13(fn, __VA_ARGS__))
 
 #define REALM_TEMPLATE_TEST_CASE_15(fn, T, ...) \
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
-    REALM_TEMPLATE_TEST_CASE_14(fn, __VA_ARGS__)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE_14(fn, __VA_ARGS__))
 
 #define REALM_TEMPLATE_TEST_CASE_16(fn, T, ...) \
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
-    REALM_TEMPLATE_TEST_CASE_15(fn, __VA_ARGS__)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE_15(fn, __VA_ARGS__))
 
 #define REALM_TEMPLATE_TEST_CASE_17(fn, T, ...) \
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
-    REALM_TEMPLATE_TEST_CASE_16(fn, __VA_ARGS__)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE_16(fn, __VA_ARGS__))
 
 #define REALM_TEMPLATE_TEST_CASE_18(fn, T, ...) \
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
-    REALM_TEMPLATE_TEST_CASE_17(fn, __VA_ARGS__)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE_17(fn, __VA_ARGS__))
 
 #define REALM_TEMPLATE_TEST_CASE_19(fn, T, ...) \
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
-    REALM_TEMPLATE_TEST_CASE_18(fn, __VA_ARGS__)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE_18(fn, __VA_ARGS__))
 
 #define REALM_TEMPLATE_TEST_CASE_20(fn, T, ...) \
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
-    REALM_TEMPLATE_TEST_CASE_19(fn, __VA_ARGS__)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE_19(fn, __VA_ARGS__))
 
 /* // code to generate the above
 count = 20
 
 template = r'''
+#define REALM_EXPAND(x) x
 #define TEMPLATE_TEST_CASE(name, ...) \
-    REALM_TEMPLATE_TEST_CASE(name, INTERNAL_CATCH_UNIQUE_NAME(REALM_TEMPLATE_TEST_), \
-                             __VA_ARGS__, {0})
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE(name, INTERNAL_CATCH_UNIQUE_NAME(REALM_TEMPLATE_TEST_), \
+                                          __VA_ARGS__, {0}))
 
 #define REALM_TEMPLATE_TEST_CASE(name, fn, {1}, n, ...) \
     template<typename> static void fn(); \
@@ -136,10 +141,10 @@ template = r'''
 test_case = r'''
 #define REALM_TEMPLATE_TEST_CASE_{0}(fn, T, ...) \
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
-    REALM_TEMPLATE_TEST_CASE_{1}(fn, __VA_ARGS__)
+    REALM_EXPAND(REALM_TEMPLATE_TEST_CASE_{1}(fn, __VA_ARGS__))
 '''
 
-print template.format(', '.join(map(str, range(count, 0, -1))),
+print template.format(', '.join(map(str, reversed(range(count)))),
                       ', '.join(('T' + str(x) for x in range(count)))),
 
 for i in range(1, count):

--- a/tests/util/templated_test_case.hpp
+++ b/tests/util/templated_test_case.hpp
@@ -1,0 +1,148 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2017 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+// Define a Catch test case templated on up to 20 types
+// The current type is exposed inside the test as `TestType`
+#define TEMPLATE_TEST_CASE(name, ...) \
+    REALM_TEMPLATE_TEST_CASE(name, INTERNAL_CATCH_UNIQUE_NAME(REALM_TEMPLATE_TEST_), \
+                             __VA_ARGS__, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+
+#define REALM_TEMPLATE_TEST_CASE(name, fn, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, n, ...) \
+    template<typename> static void fn(); \
+    TEST_CASE(name) { \
+        REALM_TEMPLATE_TEST_CASE_##n(fn, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19) \
+    } \
+    template<typename TestType> static void fn()
+
+#define REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    INTERNAL_CATCH_SECTION(#T, "") { fn<T>(); }
+
+#define REALM_TEMPLATE_TEST_CASE_1(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+
+#define REALM_TEMPLATE_TEST_CASE_2(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    REALM_TEMPLATE_TEST_CASE_1(fn, __VA_ARGS__)
+
+#define REALM_TEMPLATE_TEST_CASE_3(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    REALM_TEMPLATE_TEST_CASE_2(fn, __VA_ARGS__)
+
+#define REALM_TEMPLATE_TEST_CASE_4(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    REALM_TEMPLATE_TEST_CASE_3(fn, __VA_ARGS__)
+
+#define REALM_TEMPLATE_TEST_CASE_5(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    REALM_TEMPLATE_TEST_CASE_4(fn, __VA_ARGS__)
+
+#define REALM_TEMPLATE_TEST_CASE_6(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    REALM_TEMPLATE_TEST_CASE_5(fn, __VA_ARGS__)
+
+#define REALM_TEMPLATE_TEST_CASE_7(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    REALM_TEMPLATE_TEST_CASE_6(fn, __VA_ARGS__)
+
+#define REALM_TEMPLATE_TEST_CASE_8(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    REALM_TEMPLATE_TEST_CASE_7(fn, __VA_ARGS__)
+
+#define REALM_TEMPLATE_TEST_CASE_9(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    REALM_TEMPLATE_TEST_CASE_8(fn, __VA_ARGS__)
+
+#define REALM_TEMPLATE_TEST_CASE_10(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    REALM_TEMPLATE_TEST_CASE_9(fn, __VA_ARGS__)
+
+#define REALM_TEMPLATE_TEST_CASE_11(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    REALM_TEMPLATE_TEST_CASE_10(fn, __VA_ARGS__)
+
+#define REALM_TEMPLATE_TEST_CASE_12(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    REALM_TEMPLATE_TEST_CASE_11(fn, __VA_ARGS__)
+
+#define REALM_TEMPLATE_TEST_CASE_13(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    REALM_TEMPLATE_TEST_CASE_12(fn, __VA_ARGS__)
+
+#define REALM_TEMPLATE_TEST_CASE_14(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    REALM_TEMPLATE_TEST_CASE_13(fn, __VA_ARGS__)
+
+#define REALM_TEMPLATE_TEST_CASE_15(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    REALM_TEMPLATE_TEST_CASE_14(fn, __VA_ARGS__)
+
+#define REALM_TEMPLATE_TEST_CASE_16(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    REALM_TEMPLATE_TEST_CASE_15(fn, __VA_ARGS__)
+
+#define REALM_TEMPLATE_TEST_CASE_17(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    REALM_TEMPLATE_TEST_CASE_16(fn, __VA_ARGS__)
+
+#define REALM_TEMPLATE_TEST_CASE_18(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    REALM_TEMPLATE_TEST_CASE_17(fn, __VA_ARGS__)
+
+#define REALM_TEMPLATE_TEST_CASE_19(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    REALM_TEMPLATE_TEST_CASE_18(fn, __VA_ARGS__)
+
+#define REALM_TEMPLATE_TEST_CASE_20(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    REALM_TEMPLATE_TEST_CASE_19(fn, __VA_ARGS__)
+
+#if 0 // code to generate the above
+count = 20
+
+template = r'''
+#define TEMPLATE_TEST_CASE(name, ...) \
+    REALM_TEMPLATE_TEST_CASE(name, INTERNAL_CATCH_UNIQUE_NAME(REALM_TEMPLATE_TEST_), \
+                             __VA_ARGS__, {0})
+
+#define REALM_TEMPLATE_TEST_CASE(name, fn, {1}, n, ...) \
+    template<typename> static void fn(); \
+    TEST_CASE(name) {{ \
+        REALM_TEMPLATE_TEST_CASE_##n(fn, {1}) \
+    }} \
+    template<typename TestType> static void fn()
+
+#define REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    INTERNAL_CATCH_SECTION(#T, "") {{ fn<T>(); }}
+
+#define REALM_TEMPLATE_TEST_CASE_1(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+'''
+
+test_case = r'''
+#define REALM_TEMPLATE_TEST_CASE_{0}(fn, T, ...) \
+    REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
+    REALM_TEMPLATE_TEST_CASE_{1}(fn, __VA_ARGS__)
+'''
+
+print template.format(', '.join(map(str, reversed(range(count)))),
+                      ', '.join(('T' + str(x) for x in range(count)))),
+
+for i in range(1, count):
+    print test_case.format(i + 1, i),
+#endif
+

--- a/tests/util/templated_test_case.hpp
+++ b/tests/util/templated_test_case.hpp
@@ -20,7 +20,7 @@
 // The current type is exposed inside the test as `TestType`
 #define TEMPLATE_TEST_CASE(name, ...) \
     REALM_TEMPLATE_TEST_CASE(name, INTERNAL_CATCH_UNIQUE_NAME(REALM_TEMPLATE_TEST_), \
-                             __VA_ARGS__, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0)
+                             __VA_ARGS__, 20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1)
 
 #define REALM_TEMPLATE_TEST_CASE(name, fn, T0, T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, n, ...) \
     template<typename> static void fn(); \

--- a/tests/util/templated_test_case.hpp
+++ b/tests/util/templated_test_case.hpp
@@ -111,7 +111,7 @@
     REALM_TEMPLATE_TEST_CASE_SECTION(fn, T) \
     REALM_TEMPLATE_TEST_CASE_19(fn, __VA_ARGS__)
 
-#if 0 // code to generate the above
+/* // code to generate the above
 count = 20
 
 template = r'''
@@ -139,10 +139,10 @@ test_case = r'''
     REALM_TEMPLATE_TEST_CASE_{1}(fn, __VA_ARGS__)
 '''
 
-print template.format(', '.join(map(str, reversed(range(count)))),
+print template.format(', '.join(map(str, range(count, 0, -1))),
                       ', '.join(('T' + str(x) for x in range(count)))),
 
 for i in range(1, count):
     print test_case.format(i + 1, i),
-#endif
+*/
 


### PR DESCRIPTION
Original motivation for this was for writing tests for primitive lists/results, but it also turned out to be useful for refactoring some tests to both be shorter and involve fewer macros.