### PR TITLE
Handle non-end insertions in ResultsNotifier

### DIFF
--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -1335,6 +1335,22 @@ TEST_CASE("notifications: results") {
             r->notify();
             REQUIRE(notification_calls == 1);
         }
+
+        SECTION("inserting a non-matching row at the beginning does not produce a notification") {
+            write([&] {
+                table->insert_empty_row(1);
+            });
+            REQUIRE(notification_calls == 1);
+        }
+
+        SECTION("inserting a matching row at the beginning marks just it as inserted") {
+            write([&] {
+                table->insert_empty_row(0);
+                table->set_int(0, 0, 5);
+            });
+            REQUIRE(notification_calls == 2);
+            REQUIRE_INDICES(change.insertions, 0);
+        }
     }
 
     SECTION("before/after change callback") {


### PR DESCRIPTION
The code assumed that all new rows would be added at the end of the table and so we wouldn't need to handle the case where existing rows are shifted by insertions, but this is no longer the case with sync.