### PR TITLE
Optimize in a write transaction

### DIFF
--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -625,11 +625,12 @@ bool Realm::compact()
         throw InvalidTransactionException("Can't compact a Realm within a write transaction");
     }
 
-    Group& group = read_group();
+    verify_open();
+    Group& group = m_shared_group->begin_write();
     for (auto &object_schema : m_schema) {
         ObjectStore::table_for_object_type(group, object_schema.name)->optimize();
     }
-    m_shared_group->end_read();
+    m_shared_group->commit();
     m_group = nullptr;
 
     return m_shared_group->compact();


### PR DESCRIPTION
As discussed, we should be using a write transaction for this code to be effective.