### PR TITLE
Add schema change callback

### DIFF
--- a/src/binding_context.hpp
+++ b/src/binding_context.hpp
@@ -68,6 +68,7 @@ namespace realm {
 //     std::list<std::function<void ()>> m_registered_notifications;
 // };
 class Realm;
+class Schema;
 class BindingContext {
 public:
     virtual ~BindingContext() = default;
@@ -113,6 +114,12 @@ public:
     virtual void did_change(std::vector<ObserverState> const& observers,
                             std::vector<void*> const& invalidated,
                             bool version_changed=true);
+
+    // Called immediately after the corresponding Realm's schema is changed through
+    // update_schema()/set_schema_subset() or the schema is changed by another Realm
+    // instance. The parameter is a schema reference which is the same as the return
+    // value of Realm::schema().
+    virtual void schema_did_change(Schema const&) {}
 
     // Change information for a single field of a row
     struct ColumnInfo {

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -239,8 +239,8 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
 
     if (schema) {
         lock.unlock();
-        realm->update_schema(std::move(*schema), config.schema_version, std::move(migration_function),
-                             std::move(initialization_function));
+        realm->update_schema_notify(std::move(*schema), config.schema_version, std::move(migration_function),
+                                    std::move(initialization_function), false, false);
     }
 
     return realm;

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -239,8 +239,8 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
 
     if (schema) {
         lock.unlock();
-        realm->update_schema_notify(std::move(*schema), config.schema_version, std::move(migration_function),
-                                    std::move(initialization_function), false, false);
+        realm->update_schema(std::move(*schema), config.schema_version, std::move(migration_function),
+                             std::move(initialization_function));
     }
 
     return realm;

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -213,17 +213,7 @@ public:
     // encryption key will raise an exception.
     static SharedRealm get_shared_realm(Config config);
 
-    // This is called by RealmCoordinator to update a Realm to a given schema, using
-    // the Realm's pre-set schema mode.
-    // By setting notify to false, schema changed function won't be called to ensure
-    // the notification will only be sent after Realm::get_shared_realm() returns.
-    void update_schema_notify(Schema schema, uint64_t version,
-                       MigrationFunction migration_function,
-                       DataInitializationFunction initialization_function,
-                       bool in_transaction, bool notify);
-
     // Updates a Realm to a given schema, using the Realm's pre-set schema mode.
-    // Schema changed function will be called if it exists in the config.
     void update_schema(Schema schema, uint64_t version=0,
                        MigrationFunction migration_function=nullptr,
                        DataInitializationFunction initialization_function=nullptr,

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -145,12 +145,6 @@ public:
     // because it's not crash safe! It may corrupt your database if something fails
     using ShouldCompactOnLaunchFunction = std::function<bool (uint64_t total_bytes, uint64_t used_bytes)>;
 
-    // A callback function which is called when this Realm's schema is changed through
-    // update_schema()/set_schema_subset() or the schema is changed by another Realm instance.
-    // This will only be called after Realm::get_shared_realm() returns.
-    // The parameter schema is a reference which is the same to the return value of Realm::scheme().
-    using SchemaChangedFunction = std::function<void (Schema& schema)>;
-
     struct Config {
         // Path and binary data are mutually exclusive
         std::string path;
@@ -168,8 +162,6 @@ public:
         util::Optional<Schema> schema;
         uint64_t schema_version = -1;
         MigrationFunction migration_function;
-        // Called when the schema changes are delivered to this Realm instance.
-        SchemaChangedFunction schema_changed_function;
 
         DataInitializationFunction initialization_function;
 
@@ -378,7 +370,7 @@ private:
 
     void begin_read(VersionID);
 
-    void set_schema(Schema const& reference, Schema schema, bool notify);
+    void set_schema(Schema const& reference, Schema schema);
     bool reset_file(Schema& schema, std::vector<SchemaChange>& changes_required);
     bool schema_change_needs_write_transaction(Schema& schema, std::vector<SchemaChange>& changes, uint64_t version);
     Schema get_full_schema();


### PR DESCRIPTION
There are some difficulties for java binding to hold a pointer to
Realm::schema() and access group though column indices in the Schema
instance, mostly because of performance concerns.
This commit enable a possibility for bindings to know when the Realm
instance's schema gets changed.
    
- Add schema_changed_function to Realm config.
- schema_changed_function will be called when the schema changes
  delivered to the Realm instance to notify binding to refresh the
  schema information.
