### PR TITLE
Add some missing schema change handling

### DIFF
--- a/src/impl/collection_notifier.cpp
+++ b/src/impl/collection_notifier.cpp
@@ -31,6 +31,9 @@ std::function<bool (size_t)>
 CollectionNotifier::get_modification_checker(TransactionChangeInfo const& info,
                                              Table const& root_table)
 {
+    if (info.schema_changed)
+        set_table(root_table);
+
     // First check if any of the tables accessible from the root table were
     // actually modified. This can be false if there were only insertions, or
     // deletions which were not linked to by any row in the linking table

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -53,6 +53,7 @@ struct TransactionChangeInfo {
     std::vector<std::vector<size_t>> column_indices;
     std::vector<size_t> table_indices;
     bool track_all;
+    bool schema_changed;
 };
 
 class DeepChangeChecker {

--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -582,6 +582,8 @@ public:
 
     bool insert_column(size_t ndx, DataType, StringData, bool)
     {
+        m_info.schema_changed = true;
+
         if (m_active_descriptor)
             m_active_descriptor->insert_column(ndx);
         if (m_active_descriptor != m_active_table || !m_is_top_level_table)
@@ -609,6 +611,8 @@ public:
 
     bool insert_group_level_table(size_t ndx, size_t, StringData)
     {
+        m_info.schema_changed = true;
+
         for (auto& list : m_info.lists) {
             if (list.table_ndx >= ndx)
                 ++list.table_ndx;
@@ -623,6 +627,8 @@ public:
 
     bool move_column(size_t from, size_t to)
     {
+        m_info.schema_changed = true;
+
         if (m_active_descriptor)
             m_active_descriptor->move_column(from, to);
         if (m_active_descriptor != m_active_table || !m_is_top_level_table)
@@ -640,6 +646,8 @@ public:
 
     bool move_group_level_table(size_t from, size_t to)
     {
+        m_info.schema_changed = true;
+
         for (auto& list : m_info.lists)
             adjust_for_move(list.table_ndx, from, to);
 


### PR DESCRIPTION
CollectionNotifier's cached information about link columns has to be invalidated following a transaction which changes the schema.

Fixes https://github.com/realm/realm-core/issues/2520.