### PR TITLE
Allow `realm::Permission` to be constructed from `realm::Results`

### DIFF
--- a/src/sync/sync_permission.cpp
+++ b/src/sync/sync_permission.cpp
@@ -67,9 +67,8 @@ int64_t ns_since_unix_epoch(const system_clock::time_point& point)
 
 // MARK: - Permission
 
-Permission::Permission(realm::Results& results, size_t index)
+Permission::Permission(Object& permission)
 {
-    Object permission(results.get_realm(), results.get_object_schema(), results.get(index));
     CppContext context;
     path = any_cast<std::string>(permission.get_property_value<util::Any>(context, "path"));
     access = extract_access_level(permission, context);
@@ -78,13 +77,11 @@ Permission::Permission(realm::Results& results, size_t index)
 }
 
 Permission::Permission(std::string path, AccessLevel access, Condition condition, util::Optional<Timestamp> updated_at)
-{
-    this->path = std::move(path);
-    this->access = access;
-    this->condition = std::move(condition);
-    if (updated_at)
-        this->updated_at = std::move(*updated_at);
-}
+: path(std::move(path))
+, access(access)
+, condition(std::move(condition))
+, updated_at(std::move(updated_at.value_or(Timestamp())))
+{ }
 
 std::string Permission::description_for_access_level(AccessLevel level)
 {

--- a/src/sync/sync_permission.cpp
+++ b/src/sync/sync_permission.cpp
@@ -76,11 +76,11 @@ Permission::Permission(Object& permission)
     updated_at = any_cast<Timestamp>(permission.get_property_value<util::Any>(context, "updatedAt"));
 }
 
-Permission::Permission(std::string path, AccessLevel access, Condition condition, util::Optional<Timestamp> updated_at)
+Permission::Permission(std::string path, AccessLevel access, Condition condition, Timestamp updated_at)
 : path(std::move(path))
 , access(access)
 , condition(std::move(condition))
-, updated_at(std::move(updated_at.value_or(Timestamp())))
+, updated_at(std::move(updated_at))
 { }
 
 std::string Permission::description_for_access_level(AccessLevel level)
@@ -154,22 +154,7 @@ private:
 
 void Permissions::get_permissions(std::shared_ptr<SyncUser> user,
                                   PermissionResultsCallback callback,
-                                  const ConfigMaker& config)
-{
-    // callback(std::make_unique<PermissionResults>(results->filter(std::move(query))), nullptr);
-    auto cb = [callback=std::move(callback)](Results results, std::exception_ptr ex) {
-        if (ex) {
-            callback(nullptr, ex);
-        } else {
-            callback(std::make_unique<PermissionResults>(std::move(results)), nullptr);
-        }
-    };
-    get_raw_permissions(std::move(user), std::move(cb), config);
-}
-
-void Permissions::get_raw_permissions(std::shared_ptr<SyncUser> user,
-                                      RawPermissionResultsCallback callback,
-                                      const ConfigMaker& make_config)
+                                  const ConfigMaker& make_config)
 {
     auto realm = Permissions::permission_realm(user, make_config);
     auto table = ObjectStore::table_for_object_type(realm->read_group(), "Permission");

--- a/src/sync/sync_permission.hpp
+++ b/src/sync/sync_permission.hpp
@@ -89,11 +89,11 @@ struct Permission {
 
     Timestamp updated_at;
 
-    /// Create a Permission value from a raw Object.
+    /// Create a Permission value from an `Object`.
     Permission(Object&);
 
     /// Create a Permission value from raw values.
-    Permission(std::string path, AccessLevel, Condition, util::Optional<Timestamp> updated_at=none);
+    Permission(std::string path, AccessLevel, Condition, Timestamp updated_at=Timestamp());
 };
 
 class PermissionResults {
@@ -155,19 +155,11 @@ public:
     // SyncConfig and associated callbacks, as well as the path and other parameters.
     using ConfigMaker = std::function<Realm::Config(std::shared_ptr<SyncUser>, std::string url)>;
 
-    // Callback used to asynchronously vend a `PermissionResults` object.
-    // DEPRECATED. Will be replaced by RawPermissionResultsCallback in the future.
-    using PermissionResultsCallback = std::function<void(std::unique_ptr<PermissionResults>, std::exception_ptr)>;
-
     // Callback used to asynchronously vend permissions results.
-    using RawPermissionResultsCallback = std::function<void(Results, std::exception_ptr)>;
+    using PermissionResultsCallback = std::function<void(Results, std::exception_ptr)>;
 
-    // Asynchronously retrieve the permissions for the provided user.
-    // DEPRECATED. Will be replaced by get_raw_permissions() in the future.
+    // Asynchronously retrieve a `Results` containing the permissions for the provided user.
     static void get_permissions(std::shared_ptr<SyncUser>, PermissionResultsCallback, const ConfigMaker&);
-
-    // Asynchronously retrieve the raw permissions for the provided user.
-    static void get_raw_permissions(std::shared_ptr<SyncUser>, RawPermissionResultsCallback, const ConfigMaker&);
 
     // Callback used to monitor success or errors when changing permissions
     // `exception_ptr` is null_ptr on success

--- a/src/sync/sync_permission.hpp
+++ b/src/sync/sync_permission.hpp
@@ -88,6 +88,12 @@ struct Permission {
     Condition condition;
 
     Timestamp updated_at;
+
+    /// Create a Permission value from a results at a given index.
+    Permission(realm::Results&, size_t);
+
+    /// Create a Permission value from raw values.
+    Permission(std::string path, AccessLevel, Condition, util::Optional<Timestamp> updated_at=none);
 };
 
 class PermissionResults {
@@ -150,10 +156,18 @@ public:
     using ConfigMaker = std::function<Realm::Config(std::shared_ptr<SyncUser>, std::string url)>;
 
     // Callback used to asynchronously vend a `PermissionResults` object.
+    // DEPRECATED. Will be replaced by RawPermissionResultsCallback in the future.
     using PermissionResultsCallback = std::function<void(std::unique_ptr<PermissionResults>, std::exception_ptr)>;
 
+    // Callback used to asynchronously vend permissions results.
+    using RawPermissionResultsCallback = std::function<void(Results, std::exception_ptr)>;
+
     // Asynchronously retrieve the permissions for the provided user.
+    // DEPRECATED. Will be replaced by get_raw_permissions() in the future.
     static void get_permissions(std::shared_ptr<SyncUser>, PermissionResultsCallback, const ConfigMaker&);
+
+    // Asynchronously retrieve the raw permissions for the provided user.
+    static void get_raw_permissions(std::shared_ptr<SyncUser>, RawPermissionResultsCallback, const ConfigMaker&);
 
     // Callback used to monitor success or errors when changing permissions
     // `exception_ptr` is null_ptr on success

--- a/src/sync/sync_permission.hpp
+++ b/src/sync/sync_permission.hpp
@@ -89,8 +89,8 @@ struct Permission {
 
     Timestamp updated_at;
 
-    /// Create a Permission value from a results at a given index.
-    Permission(realm::Results&, size_t);
+    /// Create a Permission value from a raw Object.
+    Permission(Object&);
 
     /// Create a Permission value from raw values.
     Permission(std::string path, AccessLevel, Condition, util::Optional<Timestamp> updated_at=none);


### PR DESCRIPTION
Allow `realm::Permission` to be used without involving `realm::PermissionResults` at all.

Prerequisite work for https://github.com/realm/realm-cocoa/pull/5168.