### PR TITLE
Add ReadOnlyAlternative SchemaMode

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -119,7 +119,11 @@ void RealmCoordinator::set_config(const Realm::Config& config)
         throw std::logic_error("Realms opened in Additive-only schema mode do not use a migration function");
     if (config.schema_mode == SchemaMode::ReadOnly && config.migration_function)
         throw std::logic_error("Realms opened in read-only mode do not use a migration function");
+    if (config.schema_mode == SchemaMode::ReadOnlyAlternative && config.migration_function)
+        throw std::logic_error("Realms opened in read-only mode do not use a migration function");
     if (config.schema_mode == SchemaMode::ReadOnly && config.initialization_function)
+        throw std::logic_error("Realms opened in read-only mode do not use an initialization function");
+    if (config.schema_mode == SchemaMode::ReadOnlyAlternative && config.initialization_function)
         throw std::logic_error("Realms opened in read-only mode do not use an initialization function");
     if (config.schema && config.schema_version == ObjectStore::NotVersioned)
         throw std::logic_error("A schema version must be specified when the schema is specified");

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -119,11 +119,11 @@ void RealmCoordinator::set_config(const Realm::Config& config)
         throw std::logic_error("Realms opened in Additive-only schema mode do not use a migration function");
     if (config.schema_mode == SchemaMode::Immutable && config.migration_function)
         throw std::logic_error("Realms opened in immutable mode do not use a migration function");
-    if (config.schema_mode == SchemaMode::ReadOnly && config.migration_function)
+    if (config.schema_mode == SchemaMode::ReadOnlyAlternative && config.migration_function)
         throw std::logic_error("Realms opened in read-only mode do not use a migration function");
     if (config.schema_mode == SchemaMode::Immutable && config.initialization_function)
         throw std::logic_error("Realms opened in immutable mode do not use an initialization function");
-    if (config.schema_mode == SchemaMode::ReadOnly && config.initialization_function)
+    if (config.schema_mode == SchemaMode::ReadOnlyAlternative && config.initialization_function)
         throw std::logic_error("Realms opened in read-only mode do not use an initialization function");
     if (config.schema && config.schema_version == ObjectStore::NotVersioned)
         throw std::logic_error("A schema version must be specified when the schema is specified");

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -113,21 +113,21 @@ void RealmCoordinator::set_config(const Realm::Config& config)
 {
     if (config.encryption_key.data() && config.encryption_key.size() != 64)
         throw InvalidEncryptionKeyException();
-    if (config.schema_mode == SchemaMode::ReadOnly && config.sync_config)
-        throw std::logic_error("Synchronized Realms cannot be opened in read-only mode");
+    if (config.schema_mode == SchemaMode::Immutable && config.sync_config)
+        throw std::logic_error("Synchronized Realms cannot be opened in immutable mode");
     if (config.schema_mode == SchemaMode::Additive && config.migration_function)
         throw std::logic_error("Realms opened in Additive-only schema mode do not use a migration function");
+    if (config.schema_mode == SchemaMode::Immutable && config.migration_function)
+        throw std::logic_error("Realms opened in immutable mode do not use a migration function");
     if (config.schema_mode == SchemaMode::ReadOnly && config.migration_function)
         throw std::logic_error("Realms opened in read-only mode do not use a migration function");
-    if (config.schema_mode == SchemaMode::ReadOnlyAlternative && config.migration_function)
-        throw std::logic_error("Realms opened in read-only mode do not use a migration function");
+    if (config.schema_mode == SchemaMode::Immutable && config.initialization_function)
+        throw std::logic_error("Realms opened in immutable mode do not use an initialization function");
     if (config.schema_mode == SchemaMode::ReadOnly && config.initialization_function)
-        throw std::logic_error("Realms opened in read-only mode do not use an initialization function");
-    if (config.schema_mode == SchemaMode::ReadOnlyAlternative && config.initialization_function)
         throw std::logic_error("Realms opened in read-only mode do not use an initialization function");
     if (config.schema && config.schema_version == ObjectStore::NotVersioned)
         throw std::logic_error("A schema version must be specified when the schema is specified");
-    if (!config.realm_data.is_null() && (!config.read_only() || !config.in_memory))
+    if (!config.realm_data.is_null() && (!config.immutable() || !config.in_memory))
         throw std::logic_error("In-memory realms initialized from memory buffers can only be opened in read-only mode");
     if (!config.realm_data.is_null() && !config.path.empty())
         throw std::logic_error("Specifying both memory buffer and path is invalid");
@@ -142,7 +142,7 @@ void RealmCoordinator::set_config(const Realm::Config& config)
         m_config = config;
     }
     else {
-        if (m_config.read_only() != config.read_only()) {
+        if (m_config.immutable() != config.immutable()) {
             throw MismatchedConfigException("Realm at path '%1' already opened with different read permissions.", config.path);
         }
         if (m_config.in_memory != config.in_memory) {
@@ -230,7 +230,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
 
     if (!realm) {
         realm = Realm::make_shared_realm(std::move(config), shared_from_this());
-        if (!config.read_only() && !m_notifier && config.automatic_change_notifications) {
+        if (!config.immutable() && !m_notifier && config.automatic_change_notifications) {
             try {
                 m_notifier = std::make_unique<ExternalCommitHelper>(*this);
             }
@@ -393,7 +393,7 @@ void RealmCoordinator::wake_up_notifier_worker()
 
 void RealmCoordinator::commit_write(Realm& realm)
 {
-    REALM_ASSERT(!m_config.read_only());
+    REALM_ASSERT(!m_config.immutable());
     REALM_ASSERT(realm.is_in_transaction());
 
     {

--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -517,7 +517,7 @@ void ObjectStore::verify_compatible_for_immutable(std::vector<SchemaChange> cons
     verify_no_errors<InvalidSchemaChangeException>(verifier, changes);
 }
 
-void ObjectStore::verify_compatible_for_read_only(std::vector<SchemaChange> const& changes)
+void ObjectStore::verify_compatible_for_read_only_alternative(std::vector<SchemaChange> const& changes)
 {
     using namespace schema_change;
     struct Verifier : SchemaDifferenceExplainer {

--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -502,7 +502,7 @@ void ObjectStore::verify_valid_external_changes(std::vector<SchemaChange> const&
     verify_no_errors<InvalidSchemaChangeException>(verifier, changes);
 }
 
-void ObjectStore::verify_compatible_for_read_only(std::vector<SchemaChange> const& changes)
+void ObjectStore::verify_compatible_for_immutable(std::vector<SchemaChange> const& changes)
 {
     using namespace schema_change;
     struct Verifier : SchemaDifferenceExplainer {
@@ -517,7 +517,7 @@ void ObjectStore::verify_compatible_for_read_only(std::vector<SchemaChange> cons
     verify_no_errors<InvalidSchemaChangeException>(verifier, changes);
 }
 
-void ObjectStore::verify_compatible_for_read_only_alternative(std::vector<SchemaChange> const& changes)
+void ObjectStore::verify_compatible_for_read_only(std::vector<SchemaChange> const& changes)
 {
     using namespace schema_change;
     struct Verifier : SchemaDifferenceExplainer {

--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -517,6 +517,19 @@ void ObjectStore::verify_compatible_for_read_only(std::vector<SchemaChange> cons
     verify_no_errors<InvalidSchemaChangeException>(verifier, changes);
 }
 
+void ObjectStore::verify_compatible_for_read_only_alternative(std::vector<SchemaChange> const& changes)
+{
+    using namespace schema_change;
+    struct Verifier : SchemaDifferenceExplainer {
+        using SchemaDifferenceExplainer::operator();
+
+        void operator()(RemoveProperty) { }
+        void operator()(AddIndex) { }
+        void operator()(RemoveIndex) { }
+    } verifier;
+    verify_no_errors<SchemaMismatchException>(verifier, changes);
+}
+
 static void apply_non_migration_changes(Group& group, std::vector<SchemaChange> const& changes)
 {
     using namespace schema_change;

--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -502,7 +502,7 @@ void ObjectStore::verify_valid_external_changes(std::vector<SchemaChange> const&
     verify_no_errors<InvalidSchemaChangeException>(verifier, changes);
 }
 
-void ObjectStore::verify_compatible_for_immutable(std::vector<SchemaChange> const& changes)
+void ObjectStore::verify_compatible_for_immutable_and_readonly(std::vector<SchemaChange> const& changes)
 {
     using namespace schema_change;
     struct Verifier : SchemaDifferenceExplainer {
@@ -515,19 +515,6 @@ void ObjectStore::verify_compatible_for_immutable(std::vector<SchemaChange> cons
         void operator()(RemoveIndex) { }
     } verifier;
     verify_no_errors<InvalidSchemaChangeException>(verifier, changes);
-}
-
-void ObjectStore::verify_compatible_for_read_only_alternative(std::vector<SchemaChange> const& changes)
-{
-    using namespace schema_change;
-    struct Verifier : SchemaDifferenceExplainer {
-        using SchemaDifferenceExplainer::operator();
-
-        void operator()(RemoveProperty) { }
-        void operator()(AddIndex) { }
-        void operator()(RemoveIndex) { }
-    } verifier;
-    verify_no_errors<SchemaMismatchException>(verifier, changes);
 }
 
 static void apply_non_migration_changes(Group& group, std::vector<SchemaChange> const& changes)

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -71,11 +71,7 @@ public:
     // property we were relying on)
     static void verify_valid_external_changes(std::vector<SchemaChange> const& changes);
 
-    static void verify_compatible_for_immutable(std::vector<SchemaChange> const& changes);
-
-    // check if only additive difference exists in the existing schema compared with the given schema.
-    // FIXME: Rename this to verify_compatible_for_read_only
-    static void verify_compatible_for_read_only_alternative(std::vector<SchemaChange> const& changes);
+    static void verify_compatible_for_immutable_and_readonly(std::vector<SchemaChange> const& changes);
 
     // check if changes is empty, and throw an exception if not
     static void verify_no_changes_required(std::vector<SchemaChange> const& changes);

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -71,10 +71,10 @@ public:
     // property we were relying on)
     static void verify_valid_external_changes(std::vector<SchemaChange> const& changes);
 
-    static void verify_compatible_for_read_only(std::vector<SchemaChange> const& changes);
+    static void verify_compatible_for_immutable(std::vector<SchemaChange> const& changes);
 
     // check if only additive difference exists in the existing schema compared with the given schema.
-    static void verify_compatible_for_read_only_alternative(std::vector<SchemaChange> const& changes);
+    static void verify_compatible_for_read_only(std::vector<SchemaChange> const& changes);
 
     // check if changes is empty, and throw an exception if not
     static void verify_no_changes_required(std::vector<SchemaChange> const& changes);

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -74,7 +74,8 @@ public:
     static void verify_compatible_for_immutable(std::vector<SchemaChange> const& changes);
 
     // check if only additive difference exists in the existing schema compared with the given schema.
-    static void verify_compatible_for_read_only(std::vector<SchemaChange> const& changes);
+    // FIXME: Rename this to verify_compatible_for_read_only
+    static void verify_compatible_for_read_only_alternative(std::vector<SchemaChange> const& changes);
 
     // check if changes is empty, and throw an exception if not
     static void verify_no_changes_required(std::vector<SchemaChange> const& changes);

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -73,6 +73,9 @@ public:
 
     static void verify_compatible_for_read_only(std::vector<SchemaChange> const& changes);
 
+    // check if only additive difference exists in the existing schema compared with the given schema.
+    static void verify_compatible_for_read_only_alternative(std::vector<SchemaChange> const& changes);
+
     // check if changes is empty, and throw an exception if not
     static void verify_no_changes_required(std::vector<SchemaChange> const& changes);
 

--- a/src/results.cpp
+++ b/src/results.cpp
@@ -633,8 +633,8 @@ void Results::prepare_async()
     if (m_notifier) {
         return;
     }
-    if (m_realm->config().read_only()) {
-        throw InvalidTransactionException("Cannot create asynchronous query for read-only Realms");
+    if (m_realm->config().immutable()) {
+        throw InvalidTransactionException("Cannot create asynchronous query for immutable Realms");
     }
     if (m_realm->is_in_transaction()) {
         throw InvalidTransactionException("Cannot create asynchronous query while in a write transaction");

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -531,7 +531,7 @@ static void check_read_write(Realm *realm)
 
 static void check_write(Realm* realm)
 {
-    if (realm->config().immutable() || realm->config().read_only()) {
+    if (realm->config().immutable() || realm->config().read_only_alternative()) {
         throw InvalidTransactionException("Can't perform transactions on read-only Realms.");
     }
 }
@@ -651,7 +651,7 @@ bool Realm::compact()
 {
     verify_thread();
 
-    if (m_config.immutable() || m_config.read_only()) {
+    if (m_config.immutable() || m_config.read_only_alternative()) {
         throw InvalidTransactionException("Can't compact a read-only Realm");
     }
     if (is_in_transaction()) {

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -302,7 +302,7 @@ bool Realm::schema_change_needs_write_transaction(Schema& schema,
             ObjectStore::verify_compatible_for_immutable(changes);
             return false;
 
-        case SchemaMode::ReadOnly:
+        case SchemaMode::ReadOnlyAlternative:
             ObjectStore::verify_compatible_for_read_only(changes);
             return false;
 
@@ -373,7 +373,7 @@ void Realm::set_schema_subset(Schema schema)
             ObjectStore::verify_compatible_for_immutable(changes);
             break;
 
-        case SchemaMode::ReadOnly:
+        case SchemaMode::ReadOnlyAlternative:
             ObjectStore::verify_compatible_for_read_only(changes);
             break;
 

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -78,7 +78,7 @@ Realm::Realm(Config config, std::shared_ptr<_impl::RealmCoordinator> coordinator
     m_coordinator = std::move(coordinator);
 }
 
-REALM_NOINLINE static void translate_file_exception(StringData path, bool read_only=false)
+REALM_NOINLINE static void translate_file_exception(StringData path, bool immutable=false)
 {
     try {
         throw;
@@ -86,7 +86,7 @@ REALM_NOINLINE static void translate_file_exception(StringData path, bool read_o
     catch (util::File::PermissionDenied const& ex) {
         throw RealmFileException(RealmFileException::Kind::PermissionDenied, ex.get_path(),
                                  util::format("Unable to open a realm at path '%1'. Please use a path where your app has %2 permissions.",
-                                              ex.get_path(), read_only ? "read" : "read-write"),
+                                              ex.get_path(), immutable ? "read" : "read-write"),
                                  ex.what());
     }
     catch (util::File::Exists const& ex) {
@@ -303,7 +303,7 @@ bool Realm::schema_change_needs_write_transaction(Schema& schema,
             return false;
 
         case SchemaMode::ReadOnlyAlternative:
-            ObjectStore::verify_compatible_for_read_only(changes);
+            ObjectStore::verify_compatible_for_read_only_alternative(changes);
             return false;
 
         case SchemaMode::ResetFile:
@@ -374,7 +374,7 @@ void Realm::set_schema_subset(Schema schema)
             break;
 
         case SchemaMode::ReadOnlyAlternative:
-            ObjectStore::verify_compatible_for_read_only(changes);
+            ObjectStore::verify_compatible_for_read_only_alternative(changes);
             break;
 
         case SchemaMode::Additive:

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -299,11 +299,9 @@ bool Realm::schema_change_needs_write_transaction(Schema& schema,
         case SchemaMode::Immutable:
             if (version != m_schema_version)
                 throw InvalidSchemaVersionException(m_schema_version, version);
-            ObjectStore::verify_compatible_for_immutable(changes);
-            return false;
-
+            REALM_FALLTHROUGH;
         case SchemaMode::ReadOnlyAlternative:
-            ObjectStore::verify_compatible_for_read_only_alternative(changes);
+            ObjectStore::verify_compatible_for_immutable_and_readonly(changes);
             return false;
 
         case SchemaMode::ResetFile:
@@ -370,11 +368,8 @@ void Realm::set_schema_subset(Schema schema)
             break;
 
         case SchemaMode::Immutable:
-            ObjectStore::verify_compatible_for_immutable(changes);
-            break;
-
         case SchemaMode::ReadOnlyAlternative:
-            ObjectStore::verify_compatible_for_read_only_alternative(changes);
+            ObjectStore::verify_compatible_for_immutable_and_readonly(changes);
             break;
 
         case SchemaMode::Additive:

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -84,6 +84,17 @@ enum class SchemaMode : uint8_t {
     // are allowed to be missing from the file.
     ReadOnly,
 
+    // Open the Realm in read-only mode, transactions are not allowed to
+    // be performed on the Realm instance. The schema of the existing Realm
+    // file won't be changed through this Realm instance. Extra tables and
+    // extra properties are allowed in the existing Realm schema. The
+    // difference of indexes is allowed as well. Other schema differences
+    // than those will cause an exception. This is different from ReadOnly
+    // mode, sync Realm can be opened with ReadOnlyAlternative mode. Changes
+    // can be made to the Realm file through another writable Realm instance.
+    // Thus, notifications are also allowed in this mode.
+    ReadOnlyAlternative,
+
     // If the schema version matches and the only schema changes are new
     // tables and indexes being added or removed, apply the changes to
     // the existing file.
@@ -177,6 +188,7 @@ public:
         ShouldCompactOnLaunchFunction should_compact_on_launch_function;
 
         bool read_only() const { return schema_mode == SchemaMode::ReadOnly; }
+        bool read_only_alternative() const { return schema_mode == SchemaMode::ReadOnlyAlternative; }
 
         // The following are intended for internal/testing purposes and
         // should not be publicly exposed in binding APIs

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -78,22 +78,22 @@ enum class SchemaMode : uint8_t {
     // identical.
     Automatic,
 
-    // Open the file in read-only mode. Schema version must match the
+    // Open the file in immutable mode. Schema version must match the
     // version in the file, and all tables present in the file must
     // exactly match the specified schema, except for indexes. Tables
     // are allowed to be missing from the file.
-    ReadOnly,
+    Immutable,
 
     // Open the Realm in read-only mode, transactions are not allowed to
     // be performed on the Realm instance. The schema of the existing Realm
     // file won't be changed through this Realm instance. Extra tables and
     // extra properties are allowed in the existing Realm schema. The
     // difference of indexes is allowed as well. Other schema differences
-    // than those will cause an exception. This is different from ReadOnly
-    // mode, sync Realm can be opened with ReadOnlyAlternative mode. Changes
+    // than those will cause an exception. This is different from Immutable
+    // mode, sync Realm can be opened with ReadOnly mode. Changes
     // can be made to the Realm file through another writable Realm instance.
     // Thus, notifications are also allowed in this mode.
-    ReadOnlyAlternative,
+    ReadOnly,
 
     // If the schema version matches and the only schema changes are new
     // tables and indexes being added or removed, apply the changes to
@@ -187,8 +187,8 @@ public:
         // because it's not crash safe! It may corrupt your database if something fails
         ShouldCompactOnLaunchFunction should_compact_on_launch_function;
 
+        bool immutable() const { return schema_mode == SchemaMode::Immutable; }
         bool read_only() const { return schema_mode == SchemaMode::ReadOnly; }
-        bool read_only_alternative() const { return schema_mode == SchemaMode::ReadOnlyAlternative; }
 
         // The following are intended for internal/testing purposes and
         // should not be publicly exposed in binding APIs

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -82,6 +82,7 @@ enum class SchemaMode : uint8_t {
     // version in the file, and all tables present in the file must
     // exactly match the specified schema, except for indexes. Tables
     // are allowed to be missing from the file.
+    // WARNING: This is the original ReadOnly mode.
     Immutable,
 
     // Open the Realm in read-only mode, transactions are not allowed to
@@ -93,7 +94,10 @@ enum class SchemaMode : uint8_t {
     // mode, sync Realm can be opened with ReadOnly mode. Changes
     // can be made to the Realm file through another writable Realm instance.
     // Thus, notifications are also allowed in this mode.
-    ReadOnly,
+    // FIXME: Rename this to ReadOnly
+    // WARNING: This is not the original ReadOnly mode. The original ReadOnly
+    // has been renamed to Immutable.
+    ReadOnlyAlternative,
 
     // If the schema version matches and the only schema changes are new
     // tables and indexes being added or removed, apply the changes to
@@ -188,7 +192,7 @@ public:
         ShouldCompactOnLaunchFunction should_compact_on_launch_function;
 
         bool immutable() const { return schema_mode == SchemaMode::Immutable; }
-        bool read_only() const { return schema_mode == SchemaMode::ReadOnly; }
+        bool read_only() const { return schema_mode == SchemaMode::ReadOnlyAlternative; }
 
         // The following are intended for internal/testing purposes and
         // should not be publicly exposed in binding APIs

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -191,8 +191,10 @@ public:
         // because it's not crash safe! It may corrupt your database if something fails
         ShouldCompactOnLaunchFunction should_compact_on_launch_function;
 
+        // WARNING: The original read_only() has been renamed to immutable().
         bool immutable() const { return schema_mode == SchemaMode::Immutable; }
-        bool read_only() const { return schema_mode == SchemaMode::ReadOnlyAlternative; }
+        // FIXME: Rename this to read_only().
+        bool read_only_alternative() const { return schema_mode == SchemaMode::ReadOnlyAlternative; }
 
         // The following are intended for internal/testing purposes and
         // should not be publicly exposed in binding APIs

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -1138,7 +1138,7 @@ TEST_CASE("migration: Automatic") {
     }
 }
 
-TEST_CASE("migration: ReadOnly") {
+TEST_CASE("migration: Immutable") {
     TestFile config;
 
     auto realm_with_schema = [&](Schema schema) {
@@ -1146,7 +1146,7 @@ TEST_CASE("migration: ReadOnly") {
             auto realm = Realm::get_shared_realm(config);
             realm->update_schema(std::move(schema));
         }
-        config.schema_mode = SchemaMode::ReadOnly;
+        config.schema_mode = SchemaMode::Immutable;
         return Realm::get_shared_realm(config);
     };
 
@@ -1261,7 +1261,7 @@ TEST_CASE("migration: ReadOnly") {
     }
 }
 
-TEST_CASE("migration: ReadOnlyAlternative") {
+TEST_CASE("migration: ReadOnly") {
     TestFile config;
 
     auto realm_with_schema = [&](Schema schema) {
@@ -1269,7 +1269,7 @@ TEST_CASE("migration: ReadOnlyAlternative") {
             auto realm = Realm::get_shared_realm(config);
             realm->update_schema(std::move(schema));
         }
-        config.schema_mode = SchemaMode::ReadOnlyAlternative;
+        config.schema_mode = SchemaMode::ReadOnly;
         return Realm::get_shared_realm(config);
     };
 

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -1329,19 +1329,6 @@ TEST_CASE("migration: ReadOnly") {
             REQUIRE_NOTHROW(realm->update_schema(schema));
         }
 
-        SECTION("bump schema version") {
-            Schema schema = {
-                {"object", {
-                    {"value", PropertyType::Int},
-                }},
-            };
-            auto realm = realm_with_schema(schema);
-            REQUIRE_NOTHROW(realm->update_schema(schema, 1));
-        }
-    }
-
-    SECTION("disallowed mismatches") {
-
         SECTION("missing tables") {
             auto realm = realm_with_schema({
                 {"object", {
@@ -1356,8 +1343,21 @@ TEST_CASE("migration: ReadOnly") {
                     {"value", PropertyType::Int},
                 }},
             };
-            REQUIRE_THROWS(realm->update_schema(schema));
+            REQUIRE_NOTHROW(realm->update_schema(schema));
         }
+
+        SECTION("bump schema version") {
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int},
+                }},
+            };
+            auto realm = realm_with_schema(schema);
+            REQUIRE_NOTHROW(realm->update_schema(schema, 1));
+        }
+    }
+
+    SECTION("disallowed mismatches") {
 
         SECTION("missing columns in table") {
             auto realm = realm_with_schema({

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -1261,6 +1261,121 @@ TEST_CASE("migration: ReadOnly") {
     }
 }
 
+TEST_CASE("migration: ReadOnlyAlternative") {
+    TestFile config;
+
+    auto realm_with_schema = [&](Schema schema) {
+        {
+            auto realm = Realm::get_shared_realm(config);
+            realm->update_schema(std::move(schema));
+        }
+        config.schema_mode = SchemaMode::ReadOnlyAlternative;
+        return Realm::get_shared_realm(config);
+    };
+
+    SECTION("allowed schema mismatches") {
+        SECTION("index") {
+            auto realm = realm_with_schema({
+                {"object", {
+                    {"indexed", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{true}},
+                    {"unindexed", PropertyType::Int},
+                }},
+            });
+            Schema schema = {
+                {"object", {
+                    {"indexed", PropertyType::Int},
+                    {"unindexed", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{true}},
+                }},
+            };
+            REQUIRE_NOTHROW(realm->update_schema(schema));
+            REQUIRE(realm->schema() == schema);
+
+            for (auto& object_schema : realm->schema()) {
+                for (size_t i = 0; i < object_schema.persisted_properties.size(); ++i) {
+                    REQUIRE(i == object_schema.persisted_properties[i].table_column);
+                }
+            }
+        }
+
+        SECTION("extra tables") {
+            auto realm = realm_with_schema({
+                {"object", {
+                    {"value", PropertyType::Int},
+                }},
+                {"object 2", {
+                    {"value", PropertyType::Int},
+                }},
+            });
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int},
+                }},
+            };
+            REQUIRE_NOTHROW(realm->update_schema(schema));
+        }
+
+        SECTION("extra columns in table") {
+            auto realm = realm_with_schema({
+                {"object", {
+                    {"value", PropertyType::Int},
+                    {"value 2", PropertyType::Int},
+                }},
+            });
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int},
+                }},
+            };
+            REQUIRE_NOTHROW(realm->update_schema(schema));
+        }
+
+        SECTION("bump schema version") {
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int},
+                }},
+            };
+            auto realm = realm_with_schema(schema);
+            REQUIRE_NOTHROW(realm->update_schema(schema, 1));
+        }
+    }
+
+    SECTION("disallowed mismatches") {
+
+        SECTION("missing tables") {
+            auto realm = realm_with_schema({
+                {"object", {
+                    {"value", PropertyType::Int},
+                }},
+            });
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int},
+                }},
+                {"second object", {
+                    {"value", PropertyType::Int},
+                }},
+            };
+            REQUIRE_THROWS(realm->update_schema(schema));
+        }
+
+        SECTION("missing columns in table") {
+            auto realm = realm_with_schema({
+                {"object", {
+                    {"value", PropertyType::Int},
+                }},
+            });
+            Schema schema = {
+                {"object", {
+                    {"value", PropertyType::Int},
+                    {"value 2", PropertyType::Int},
+                }},
+            };
+            REQUIRE_THROWS(realm->update_schema(schema));
+        }
+    }
+}
+
 TEST_CASE("migration: ResetFile") {
     TestFile config;
     config.schema_mode = SchemaMode::ResetFile;

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -1269,7 +1269,7 @@ TEST_CASE("migration: ReadOnly") {
             auto realm = Realm::get_shared_realm(config);
             realm->update_schema(std::move(schema));
         }
-        config.schema_mode = SchemaMode::ReadOnly;
+        config.schema_mode = SchemaMode::ReadOnlyAlternative;
         return Realm::get_shared_realm(config);
     };
 

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -90,6 +90,12 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }
 
+        SECTION("migration function for read-only-alternative") {
+            config.schema_mode = SchemaMode::ReadOnlyAlternative;
+            config.migration_function = [](auto, auto, auto) { };
+            REQUIRE_THROWS(Realm::get_shared_realm(config));
+        }
+
         SECTION("migration function for additive-only") {
             config.schema_mode = SchemaMode::Additive;
             config.migration_function = [](auto, auto, auto) { };
@@ -98,6 +104,12 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
 
         SECTION("initialization function for read-only") {
             config.schema_mode = SchemaMode::ReadOnly;
+            config.initialization_function = [](auto) { };
+            REQUIRE_THROWS(Realm::get_shared_realm(config));
+        }
+
+        SECTION("initialization function for read-only-alternative") {
+            config.schema_mode = SchemaMode::ReadOnlyAlternative;
             config.initialization_function = [](auto) { };
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -91,7 +91,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
         }
 
         SECTION("migration function for read-only") {
-            config.schema_mode = SchemaMode::ReadOnly;
+            config.schema_mode = SchemaMode::ReadOnlyAlternative;
             config.migration_function = [](auto, auto, auto) { };
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }
@@ -109,7 +109,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
         }
 
         SECTION("initialization function for read-only") {
-            config.schema_mode = SchemaMode::ReadOnly;
+            config.schema_mode = SchemaMode::ReadOnlyAlternative;
             config.initialization_function = [](auto) { };
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -84,14 +84,14 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }
 
-        SECTION("migration function for read-only") {
-            config.schema_mode = SchemaMode::ReadOnly;
+        SECTION("migration function for immutable") {
+            config.schema_mode = SchemaMode::Immutable;
             config.migration_function = [](auto, auto, auto) { };
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }
 
-        SECTION("migration function for read-only-alternative") {
-            config.schema_mode = SchemaMode::ReadOnlyAlternative;
+        SECTION("migration function for read-only") {
+            config.schema_mode = SchemaMode::ReadOnly;
             config.migration_function = [](auto, auto, auto) { };
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }
@@ -102,14 +102,14 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }
 
-        SECTION("initialization function for read-only") {
-            config.schema_mode = SchemaMode::ReadOnly;
+        SECTION("initialization function for immutable") {
+            config.schema_mode = SchemaMode::Immutable;
             config.initialization_function = [](auto) { };
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }
 
-        SECTION("initialization function for read-only-alternative") {
-            config.schema_mode = SchemaMode::ReadOnlyAlternative;
+        SECTION("initialization function for read-only") {
+            config.schema_mode = SchemaMode::ReadOnly;
             config.initialization_function = [](auto) { };
             REQUIRE_THROWS(Realm::get_shared_realm(config));
         }
@@ -287,10 +287,10 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
         REQUIRE(realm2->schema_version() == 1);
     }
 
-    SECTION("should populate the table columns in the schema when opening as read-only") {
+    SECTION("should populate the table columns in the schema when opening as immutable") {
         Realm::get_shared_realm(config);
 
-        config.schema_mode = SchemaMode::ReadOnly;
+        config.schema_mode = SchemaMode::Immutable;
         auto realm = Realm::get_shared_realm(config);
         auto it = realm->schema().find("object");
         REQUIRE(it != realm->schema().end());
@@ -648,10 +648,10 @@ TEST_CASE("ShareRealm: in-memory mode from buffer") {
         auto realm = Realm::get_shared_realm(config);
         OwnedBinaryData realm_buffer = realm->write_copy();
 
-        // Open the buffer as a new (read-only in-memory) Realm
+        // Open the buffer as a new (immutable in-memory) Realm
         realm::Realm::Config config2;
         config2.in_memory = true;
-        config2.schema_mode = SchemaMode::ReadOnly;
+        config2.schema_mode = SchemaMode::Immutable;
         config2.realm_data = realm_buffer.get();
 
         auto realm2 = Realm::get_shared_realm(config2);
@@ -667,10 +667,10 @@ TEST_CASE("ShareRealm: in-memory mode from buffer") {
         // Test invalid configs
         realm::Realm::Config config3;
         config3.realm_data = realm_buffer.get();
-        REQUIRE_THROWS(Realm::get_shared_realm(config3)); // missing in_memory and read-only
+        REQUIRE_THROWS(Realm::get_shared_realm(config3)); // missing in_memory and immutable
 
         config3.in_memory = true;
-        config3.schema_mode = SchemaMode::ReadOnly;
+        config3.schema_mode = SchemaMode::Immutable;
         config3.path = "path";
         REQUIRE_THROWS(Realm::get_shared_realm(config3)); // both buffer and path
 


### PR DESCRIPTION
realm-java has a different semantics of read-only mode. In realm-java,
there is no limitation that the read-only Realm won't be changed by
sync or by the other process. realm-java only has a restriction that
user cannot apply write transactions on the read-only Realm instance.