### PR TITLE
Add support for arrays of all supported data types

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,6 +15,7 @@ set(SOURCES
     impl/collection_notifier.cpp
     impl/list_notifier.cpp
     impl/object_notifier.cpp
+    impl/primitive_list_notifier.cpp
     impl/realm_coordinator.cpp
     impl/results_notifier.cpp
     impl/transact_log_handler.cpp
@@ -53,6 +54,7 @@ set(HEADERS
     impl/list_notifier.hpp
     impl/object_accessor_impl.hpp
     impl/object_notifier.hpp
+    impl/primitive_list_notifier.hpp
     impl/realm_coordinator.hpp
     impl/results_notifier.hpp
     impl/transact_log_handler.hpp

--- a/src/impl/collection_change_builder.cpp
+++ b/src/impl/collection_change_builder.cpp
@@ -194,6 +194,8 @@ void CollectionChangeBuilder::for_each_col(Func&& f)
 
 void CollectionChangeBuilder::insert(size_t index, size_t count, bool track_moves)
 {
+    REALM_ASSERT(count != 0);
+
     for_each_col([=](auto& col) { col.shift_for_insert_at(index, count); });
     if (!track_moves)
         return;

--- a/src/impl/collection_change_builder.cpp
+++ b/src/impl/collection_change_builder.cpp
@@ -202,7 +202,7 @@ void CollectionChangeBuilder::insert(size_t index, size_t count, bool track_move
 
     for (auto& move : moves) {
         if (move.to >= index)
-            ++move.to;
+            move.to += count;
     }
 
     if (m_move_mapping.empty())

--- a/src/impl/collection_notifier.cpp
+++ b/src/impl/collection_notifier.cpp
@@ -51,6 +51,8 @@ CollectionNotifier::get_modification_checker(TransactionChangeInfo const& info,
 void DeepChangeChecker::find_related_tables(std::vector<RelatedTable>& out, Table const& table)
 {
     auto table_ndx = table.get_index_in_group();
+    if (table_ndx == npos)
+        return;
     if (any_of(begin(out), end(out), [=](auto& tbl) { return tbl.table_ndx == table_ndx; }))
         return;
 
@@ -393,6 +395,11 @@ void CollectionNotifier::detach()
     REALM_ASSERT(m_sg);
     do_detach_from(*m_sg);
     m_sg = nullptr;
+}
+
+SharedGroup& CollectionNotifier::source_shared_group()
+{
+    return *Realm::Internal::get_shared_group(*m_realm);
 }
 
 void CollectionNotifier::add_changes(CollectionChangeBuilder change)

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -21,6 +21,7 @@
 
 #include "impl/collection_change_builder.hpp"
 
+#include <realm/util/assert.hpp>
 #include <realm/version_id.hpp>
 
 #include <array>
@@ -323,6 +324,22 @@ private:
     RealmCoordinator* m_coordinator = nullptr;
     std::exception_ptr m_error;
 };
+
+// Find which column of the row in the table contains the given container.
+//
+// LinkViews and Subtables know what row of their parent they're in, but not
+// what column, so we have to just check each one.
+template<typename Table, typename T, typename U>
+size_t find_container_column(Table& table, size_t row_ndx, T const& expected, int type, U (Table::*getter)(size_t, size_t))
+{
+    for (size_t i = 0, count = table.get_column_count(); i != count; ++i) {
+        if (table.get_column_type(i) == type && (table.*getter)(i, row_ndx) == expected) {
+            return i;
+        }
+    }
+    REALM_UNREACHABLE();
+}
+
 
 } // namespace _impl
 } // namespace realm

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -192,6 +192,7 @@ protected:
     void add_changes(CollectionChangeBuilder change);
     void set_table(Table const& table);
     std::unique_lock<std::mutex> lock_target();
+    SharedGroup& source_shared_group();
 
     std::function<bool (size_t)> get_modification_checker(TransactionChangeInfo const&, Table const&);
 

--- a/src/impl/list_notifier.cpp
+++ b/src/impl/list_notifier.cpp
@@ -61,17 +61,9 @@ bool ListNotifier::do_add_required_change_info(TransactionChangeInfo& info)
         return false; // origin row was deleted after the notification was added
     }
 
-    // Find the lv's column, since that isn't tracked directly
     auto& table = m_lv->get_origin_table();
     size_t row_ndx = m_lv->get_origin_row_index();
-    size_t col_ndx = not_found;
-    for (size_t i = 0, count = table.get_column_count(); i != count; ++i) {
-        if (table.get_column_type(i) == type_LinkList && table.get_linklist(i, row_ndx) == m_lv) {
-            col_ndx = i;
-            break;
-        }
-    }
-    REALM_ASSERT(col_ndx != not_found);
+    size_t col_ndx = find_container_column(table, row_ndx, m_lv, type_LinkList, &Table::get_linklist);
     info.lists.push_back({table.get_index_in_group(), row_ndx, col_ndx, &m_change});
 
     m_info = &info;

--- a/src/impl/list_notifier.cpp
+++ b/src/impl/list_notifier.cpp
@@ -30,9 +30,7 @@ ListNotifier::ListNotifier(LinkViewRef lv, std::shared_ptr<Realm> realm)
 , m_prev_size(lv->size())
 {
     set_table(lv->get_target_table());
-
-    auto& sg = Realm::Internal::get_shared_group(*get_realm());
-    m_lv_handover = sg->export_linkview_for_handover(lv);
+    m_lv_handover = source_shared_group().export_linkview_for_handover(lv);
 }
 
 void ListNotifier::release_data() noexcept

--- a/src/impl/object_accessor_impl.hpp
+++ b/src/impl/object_accessor_impl.hpp
@@ -38,7 +38,7 @@ public:
     // (i.e. prop.type will always be Object or Array).
     CppContext(CppContext& c, Property const& prop)
     : realm(c.realm)
-    , object_schema(&*realm->schema().find(prop.object_type))
+    , object_schema(prop.type == PropertyType::Object ? &*realm->schema().find(prop.object_type) : c.object_schema)
     { }
 
     CppContext() = default;

--- a/src/impl/object_accessor_impl.hpp
+++ b/src/impl/object_accessor_impl.hpp
@@ -93,6 +93,10 @@ public:
     util::Any box(double v) const { return v; }
     util::Any box(float v) const { return v; }
     util::Any box(int64_t v) const { return v; }
+    util::Any box(util::Optional<bool> v) const { return v; }
+    util::Any box(util::Optional<double> v) const { return v; }
+    util::Any box(util::Optional<float> v) const { return v; }
+    util::Any box(util::Optional<int64_t> v) const { return v; }
     util::Any box(RowExpr) const;
 
     // Any properties are only supported by the Cocoa binding to enable reading

--- a/src/impl/object_notifier.cpp
+++ b/src/impl/object_notifier.cpp
@@ -29,8 +29,7 @@ ObjectNotifier::ObjectNotifier(Row const& row, std::shared_ptr<Realm> realm)
     REALM_ASSERT(row.get_table());
     set_table(*row.get_table());
 
-    auto& sg = Realm::Internal::get_shared_group(*get_realm());
-    m_handover = sg->export_for_handover(row);
+    m_handover = source_shared_group().export_for_handover(row);
 }
 
 void ObjectNotifier::release_data() noexcept

--- a/src/impl/primitive_list_notifier.cpp
+++ b/src/impl/primitive_list_notifier.cpp
@@ -85,6 +85,11 @@ void PrimitiveListNotifier::run()
         return;
     }
 
+    if (!m_change.deletions.empty() && m_change.deletions.begin()->second == std::numeric_limits<size_t>::max()) {
+        // Table was cleared, so set the deletions to the actual previous size
+        m_change.deletions.set(m_prev_size);
+    }
+
     m_prev_size = m_table->size();
 }
 

--- a/src/impl/primitive_list_notifier.cpp
+++ b/src/impl/primitive_list_notifier.cpp
@@ -1,0 +1,102 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2017 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "impl/primitive_list_notifier.hpp"
+
+#include "shared_realm.hpp"
+
+#include <realm/link_view.hpp>
+
+using namespace realm;
+using namespace realm::_impl;
+
+PrimitiveListNotifier::PrimitiveListNotifier(TableRef table, std::shared_ptr<Realm> realm)
+: CollectionNotifier(std::move(realm))
+, m_prev_size(table->size())
+{
+    set_table(*table->get_parent_table());
+    m_table_handover = source_shared_group().export_table_for_handover(table);
+}
+
+void PrimitiveListNotifier::release_data() noexcept
+{
+    m_table.reset();
+}
+
+void PrimitiveListNotifier::do_attach_to(SharedGroup& sg)
+{
+    REALM_ASSERT(m_table_handover);
+    REALM_ASSERT(!m_table);
+    m_table = sg.import_table_from_handover(std::move(m_table_handover));
+}
+
+void PrimitiveListNotifier::do_detach_from(SharedGroup& sg)
+{
+    REALM_ASSERT(!m_table_handover);
+    if (m_table) {
+        m_table_handover = sg.export_table_for_handover(m_table);
+        m_table = {};
+    }
+}
+
+bool PrimitiveListNotifier::do_add_required_change_info(TransactionChangeInfo& info)
+{
+    REALM_ASSERT(!m_table_handover);
+    if (!m_table || !m_table->is_attached()) {
+        return false; // origin row was deleted after the notification was added
+    }
+
+    // Find the tables's column, since that isn't tracked directly
+    auto& table = *m_table->get_parent_table();
+    size_t row_ndx = m_table->get_parent_row_index();
+    size_t col_ndx = not_found;
+    for (size_t i = 0, count = table.get_column_count(); i != count; ++i) {
+        if (table.get_column_type(i) == type_Table && table.get_subtable(i, row_ndx) == m_table) {
+            col_ndx = i;
+            break;
+        }
+    }
+    REALM_ASSERT(col_ndx != not_found);
+    info.lists.push_back({table.get_index_in_group(), row_ndx, col_ndx, &m_change});
+
+    m_info = &info;
+    return true;
+}
+
+void PrimitiveListNotifier::run()
+{
+    if (!m_table || !m_table->is_attached()) {
+        // Table was deleted entirely, so report all of the rows being removed
+        // if this is the first run after that
+        if (m_prev_size) {
+            m_change.deletions.set(m_prev_size);
+            m_prev_size = 0;
+        }
+        else {
+            m_change = {};
+        }
+        return;
+    }
+
+    m_prev_size = m_table->size();
+}
+
+void PrimitiveListNotifier::do_prepare_handover(SharedGroup&)
+{
+    add_changes(std::move(m_change));
+}

--- a/src/impl/primitive_list_notifier.cpp
+++ b/src/impl/primitive_list_notifier.cpp
@@ -61,17 +61,9 @@ bool PrimitiveListNotifier::do_add_required_change_info(TransactionChangeInfo& i
         return false; // origin row was deleted after the notification was added
     }
 
-    // Find the tables's column, since that isn't tracked directly
     auto& table = *m_table->get_parent_table();
     size_t row_ndx = m_table->get_parent_row_index();
-    size_t col_ndx = not_found;
-    for (size_t i = 0, count = table.get_column_count(); i != count; ++i) {
-        if (table.get_column_type(i) == type_Table && table.get_subtable(i, row_ndx) == m_table) {
-            col_ndx = i;
-            break;
-        }
-    }
-    REALM_ASSERT(col_ndx != not_found);
+    size_t col_ndx = find_container_column(table, row_ndx, m_table, type_Table, &Table::get_subtable);
     info.lists.push_back({table.get_index_in_group(), row_ndx, col_ndx, &m_change});
 
     m_info = &info;

--- a/src/impl/primitive_list_notifier.hpp
+++ b/src/impl/primitive_list_notifier.hpp
@@ -1,0 +1,59 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2017 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_OS_PRIMITIVE_LIST_NOTIFIER_HPP
+#define REALM_OS_PRIMITIVE_LIST_NOTIFIER_HPP
+
+#include "impl/collection_notifier.hpp"
+
+#include <realm/group_shared.hpp>
+
+namespace realm {
+namespace _impl {
+class PrimitiveListNotifier : public CollectionNotifier {
+public:
+    PrimitiveListNotifier(TableRef lv, std::shared_ptr<Realm> realm);
+
+private:
+    // The linkview, in handover form if this has not been attached to the main
+    // SharedGroup yet
+    TableRef m_table;
+    std::unique_ptr<SharedGroup::Handover<Table>> m_table_handover;
+
+    // The last-seen size of the Table so that we can report row deletions
+    // when the Table itself is deleted
+    size_t m_prev_size;
+
+    // The actual change, calculated in run() and delivered in prepare_handover()
+    CollectionChangeBuilder m_change;
+    TransactionChangeInfo* m_info;
+
+    void run() override;
+
+    void do_prepare_handover(SharedGroup&) override;
+
+    void do_attach_to(SharedGroup& sg) override;
+    void do_detach_from(SharedGroup& sg) override;
+
+    void release_data() noexcept override;
+    bool do_add_required_change_info(TransactionChangeInfo& info) override;
+};
+}
+}
+
+#endif // REALM_OS_PRIMITIVE_LIST_NOTIFIER_HPP

--- a/src/impl/primitive_list_notifier.hpp
+++ b/src/impl/primitive_list_notifier.hpp
@@ -30,7 +30,7 @@ public:
     PrimitiveListNotifier(TableRef lv, std::shared_ptr<Realm> realm);
 
 private:
-    // The linkview, in handover form if this has not been attached to the main
+    // The subtable, in handover form if this has not been attached to the main
     // SharedGroup yet
     TableRef m_table;
     std::unique_ptr<SharedGroup::Handover<Table>> m_table_handover;

--- a/src/impl/results_notifier.cpp
+++ b/src/impl/results_notifier.cpp
@@ -18,6 +18,8 @@
 
 #include "impl/results_notifier.hpp"
 
+#include "shared_realm.hpp"
+
 using namespace realm;
 using namespace realm::_impl;
 
@@ -28,7 +30,7 @@ ResultsNotifier::ResultsNotifier(Results& target)
 {
     Query q = target.get_query();
     set_table(*q.get_table());
-    m_query_handover = Realm::Internal::get_shared_group(*get_realm())->export_for_handover(q, MutableSourcePayload::Move);
+    m_query_handover = source_shared_group().export_for_handover(q, MutableSourcePayload::Move);
     DescriptorOrdering::generate_patch(target.get_descriptor_ordering(), m_ordering_handover);
 }
 
@@ -71,10 +73,31 @@ bool ResultsNotifier::do_add_required_change_info(TransactionChangeInfo& info)
     REALM_ASSERT(m_query);
     m_info = &info;
 
-    auto table_ndx = m_query->get_table()->get_index_in_group();
-    if (info.table_moves_needed.size() <= table_ndx)
-        info.table_moves_needed.resize(table_ndx + 1);
-    info.table_moves_needed[table_ndx] = true;
+    auto& table = *m_query->get_table();
+    if (!table.is_attached())
+        return false;
+
+    auto table_ndx = table.get_index_in_group();
+    if (table_ndx == npos) {
+        // is a subtable
+        // Find the tables's column, since that isn't tracked directly
+        auto& parent = *table.get_parent_table();
+        size_t row_ndx = table.get_parent_row_index();
+        size_t col_ndx = not_found;
+        for (size_t i = 0, count = parent.get_column_count(); i != count; ++i) {
+            if (parent.get_column_type(i) == type_Table && parent.get_subtable(i, row_ndx) == &table) {
+                col_ndx = i;
+                break;
+            }
+        }
+        REALM_ASSERT(col_ndx != not_found);
+        info.lists.push_back({parent.get_index_in_group(), row_ndx, col_ndx, &m_changes});
+    }
+    else {
+        if (info.table_moves_needed.size() <= table_ndx)
+            info.table_moves_needed.resize(table_ndx + 1);
+        info.table_moves_needed[table_ndx] = true;
+    }
 
     return has_run() && have_callbacks();
 }
@@ -104,7 +127,11 @@ void ResultsNotifier::calculate_changes()
 {
     size_t table_ndx = m_query->get_table()->get_index_in_group();
     if (has_run()) {
-        auto changes = table_ndx < m_info->tables.size() ? &m_info->tables[table_ndx] : nullptr;
+        CollectionChangeBuilder* changes = nullptr;
+        if (table_ndx == npos)
+            changes = &m_changes;
+        else if (table_ndx < m_info->tables.size())
+            changes = &m_info->tables[table_ndx];
 
         std::vector<size_t> next_rows;
         next_rows.reserve(m_tv.size());
@@ -143,6 +170,14 @@ void ResultsNotifier::calculate_changes()
 
 void ResultsNotifier::run()
 {
+    // Table's been deleted, so report all rows as deleted
+    if (!m_query->get_table()->is_attached()) {
+        m_changes = {};
+        m_changes.deletions.set(m_previous_rows.size());
+        m_previous_rows.clear();
+        return;
+    }
+
     if (!need_to_run())
         return;
 
@@ -172,7 +207,7 @@ void ResultsNotifier::do_prepare_handover(SharedGroup& sg)
 
         // add_changes() needs to be called even if there are no changes to
         // clear the skip flag on the callbacks
-        add_changes({});
+        add_changes(std::move(m_changes));
         return;
     }
 

--- a/src/impl/results_notifier.cpp
+++ b/src/impl/results_notifier.cpp
@@ -78,22 +78,13 @@ bool ResultsNotifier::do_add_required_change_info(TransactionChangeInfo& info)
         return false;
 
     auto table_ndx = table.get_index_in_group();
-    if (table_ndx == npos) {
-        // is a subtable
-        // Find the tables's column, since that isn't tracked directly
+    if (table_ndx == npos) { // is a subtable
         auto& parent = *table.get_parent_table();
         size_t row_ndx = table.get_parent_row_index();
-        size_t col_ndx = not_found;
-        for (size_t i = 0, count = parent.get_column_count(); i != count; ++i) {
-            if (parent.get_column_type(i) == type_Table && parent.get_subtable(i, row_ndx) == &table) {
-                col_ndx = i;
-                break;
-            }
-        }
-        REALM_ASSERT(col_ndx != not_found);
+        size_t col_ndx = find_container_column(parent, row_ndx, &table, type_Table, &Table::get_subtable);
         info.lists.push_back({parent.get_index_in_group(), row_ndx, col_ndx, &m_changes});
     }
-    else {
+    else { // is a top-level table
         if (info.table_moves_needed.size() <= table_ndx)
             info.table_moves_needed.resize(table_ndx + 1);
         info.table_moves_needed[table_ndx] = true;

--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -435,10 +435,11 @@ public:
             size_t col = path[1];
             mark_dirty(row, col);
 
+            m_active_table = nullptr;
+            m_is_top_level_table = false;
             if (auto table = find_list(current_table(), col, row)) {
                 m_active_table = table;
                 m_need_move_info = true;
-                m_is_top_level_table = false;
             }
         }
         return true;

--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -171,6 +171,12 @@ void KVOAdapter::before(SharedGroup& sg)
             changes.indices = builder.modifications;
             changes.indices.add(builder.deletions);
 
+            // Iterate over each of the rows which may have been shifted by
+            // the moves and check if it actually has been, or if it's ended
+            // up in the same place as it started (either because the moves were
+            // actually a swap that doesn't effect the rows in between, or the
+            // combination of moves happen to leave some intermediate rows in
+            // the same place)
             auto in_range = [](auto& it, auto end, size_t i) {
                 if (it != end && i >= it->second)
                     ++it;

--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -76,7 +76,8 @@ KVOAdapter::KVOAdapter(std::vector<BindingContext::ObserverState>& observers, Bi
     for (auto& observer : observers) {
         auto table = group.get_table(observer.table_ndx);
         for (size_t i = 0, count = table->get_column_count(); i < count; ++i) {
-            if (table->get_column_type(i) != type_LinkList)
+            auto type = table->get_column_type(i);
+            if (type != type_LinkList && type != type_Table)
                 continue;
             m_lists.push_back({&observer, i, {}});
         }

--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -432,8 +432,8 @@ public:
         if (len == 1) {
             // Mark the cell containing the subtable as modified since selecting
             // a table is always followed by a modification of some sort
-            size_t row = path[0];
-            size_t col = path[1];
+            size_t col = path[0];
+            size_t row = path[1];
             mark_dirty(row, col);
 
             m_active_table = nullptr;

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -159,11 +159,6 @@ PropertyType List::get_type() const
                        : ObjectSchema::from_core_type(*m_table->get_descriptor(), 0);
 }
 
-bool List::is_optional() const noexcept
-{
-    return m_table->is_nullable(0);
-}
-
 namespace {
 template<typename T>
 auto get(Table& table, size_t row)

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -19,7 +19,9 @@
 #include "list.hpp"
 
 #include "impl/list_notifier.hpp"
+#include "impl/primitive_list_notifier.hpp"
 #include "impl/realm_coordinator.hpp"
+#include "object_schema.hpp"
 #include "object_store.hpp"
 #include "results.hpp"
 #include "schema.hpp"
@@ -39,18 +41,46 @@ List& List::operator=(const List&) = default;
 List::List(List&&) = default;
 List& List::operator=(List&&) = default;
 
+List::List(std::shared_ptr<Realm> r, Table& parent_table, size_t col, size_t row)
+: m_realm(std::move(r))
+{
+    auto type = parent_table.get_column_type(col);
+    REALM_ASSERT(type == type_LinkList || type == type_Table);
+    if (type == type_LinkList) {
+        m_link_view = parent_table.get_linklist(col, row);
+        m_table.reset(&m_link_view->get_target_table());
+    }
+    else {
+        m_table = parent_table.get_subtable(col, row);
+    }
+}
+
 List::List(std::shared_ptr<Realm> r, LinkViewRef l) noexcept
 : m_realm(std::move(r))
 , m_link_view(std::move(l))
 {
+    m_table.reset(&m_link_view->get_target_table());
 }
 
-const ObjectSchema& List::get_object_schema() const
+List::List(std::shared_ptr<Realm> r, TableRef t) noexcept
+: m_realm(std::move(r))
+, m_table(std::move(t))
+{
+}
+
+static StringData object_name(Table const& table)
+{
+    return ObjectStore::object_type_for_table_name(table.get_name());
+}
+
+ObjectSchema const& List::get_object_schema() const
 {
     verify_attached();
+    REALM_ASSERT(m_link_view);
 
     if (!m_object_schema) {
-        auto object_type = ObjectStore::object_type_for_table_name(m_link_view->get_target_table().get_name());
+        REALM_ASSERT(get_type() == PropertyType::Object);
+        auto object_type = object_name(m_link_view->get_target_table());
         auto it = m_realm->schema().find(object_type);
         REALM_ASSERT(it != m_realm->schema().end());
         m_object_schema = &*it;
@@ -61,26 +91,21 @@ const ObjectSchema& List::get_object_schema() const
 Query List::get_query() const
 {
     verify_attached();
-    return m_link_view->get_target_table().where(m_link_view);
+    return m_link_view ? m_table->where(m_link_view) : m_table->where();
 }
 
 size_t List::get_origin_row_index() const
 {
     verify_attached();
-    return m_link_view->get_origin_row_index();
+    return m_link_view ? m_link_view->get_origin_row_index() : m_table->get_parent_row_index();
 }
 
 void List::verify_valid_row(size_t row_ndx, bool insertion) const
 {
-    size_t size = m_link_view->size();
-    if (row_ndx > size || (!insertion && row_ndx == size)) {
-        throw OutOfBoundsIndexException{row_ndx, size + insertion};
+    size_t s = size();
+    if (row_ndx > s || (!insertion && row_ndx == s)) {
+        throw OutOfBoundsIndexException{row_ndx, s + insertion};
     }
-}
-
-static StringData object_name(Table& table)
-{
-    return ObjectStore::object_type_for_table_name(table.get_name());
 }
 
 void List::validate(RowExpr row) const
@@ -96,7 +121,9 @@ void List::validate(RowExpr row) const
 bool List::is_valid() const
 {
     m_realm->verify_thread();
-    return m_link_view && m_link_view->is_attached();
+    if (m_link_view)
+        return m_link_view->is_attached();
+    return m_table && m_table->is_attached();
 }
 
 void List::verify_attached() const
@@ -117,43 +144,118 @@ void List::verify_in_transaction() const
 size_t List::size() const
 {
     verify_attached();
-    return m_link_view->size();
+    return m_link_view ? m_link_view->size() : m_table->size();
 }
 
-RowExpr List::get(size_t row_ndx) const
+size_t List::to_table_ndx(size_t row) const noexcept
+{
+    return m_link_view ? m_link_view->get(row).get_index() : row;
+}
+
+PropertyType List::get_type() const
 {
     verify_attached();
-    verify_valid_row(row_ndx);
-    return m_link_view->get(row_ndx);
+    return m_link_view ? PropertyType::Object
+                       : ObjectSchema::from_core_type(*m_table->get_descriptor(), 0);
 }
 
-size_t List::get_unchecked(size_t row_ndx) const noexcept
+bool List::is_optional() const noexcept
 {
-    return m_link_view->get(row_ndx).get_index();
+    return m_table->is_nullable(0);
 }
 
-size_t List::find(ConstRow const& row) const
+namespace {
+template<typename T>
+auto get(Table& table, size_t row)
+{
+    return table.get<T>(0, row);
+}
+
+template<>
+auto get<RowExpr>(Table& table, size_t row)
+{
+    return table.get(row);
+}
+}
+
+template<typename T>
+T List::get(size_t row_ndx) const
+{
+    verify_valid_row(row_ndx);
+    return ::get<T>(*m_table, to_table_ndx(row_ndx));
+}
+
+template RowExpr List::get(size_t) const;
+
+template<typename T>
+size_t List::find(T const& value) const
+{
+    verify_attached();
+    return m_table->find_first(0, value);
+}
+
+template<>
+size_t List::find(RowExpr const& row) const
 {
     verify_attached();
     if (!row.is_attached())
         return not_found;
     validate(row);
 
-    return m_link_view->find(row.get_index());
+    return m_link_view ? m_link_view->find(row.get_index()) : row.get_index();
 }
 
+size_t List::find(Query&& q) const
+{
+    verify_attached();
+    if (m_link_view) {
+        size_t index = get_query().and_query(std::move(q)).find();
+        return index == not_found ? index : m_link_view->find(index);
+    }
+    return q.find();
+}
+
+template<typename T>
+void List::add(T value)
+{
+    verify_in_transaction();
+    m_table->set(0, m_table->add_empty_row(), value);
+}
+
+template<>
 void List::add(size_t target_row_ndx)
 {
     verify_in_transaction();
     m_link_view->add(target_row_ndx);
 }
 
+template<>
 void List::add(RowExpr row)
 {
     validate(row);
     add(row.get_index());
 }
 
+template<>
+void List::add(int value)
+{
+    verify_in_transaction();
+    if (m_link_view)
+        add(static_cast<size_t>(value));
+    else
+        add(static_cast<int64_t>(value));
+}
+
+template<typename T>
+void List::insert(size_t row_ndx, T value)
+{
+    verify_in_transaction();
+    verify_valid_row(row_ndx, true);
+    m_table->insert_empty_row(row_ndx);
+    m_table->set(0, row_ndx, value);
+}
+
+template<>
 void List::insert(size_t row_ndx, size_t target_row_ndx)
 {
     verify_in_transaction();
@@ -161,10 +263,11 @@ void List::insert(size_t row_ndx, size_t target_row_ndx)
     m_link_view->insert(row_ndx, target_row_ndx);
 }
 
-void List::insert(size_t ndx, RowExpr row)
+template<>
+void List::insert(size_t row_ndx, RowExpr row)
 {
     validate(row);
-    insert(ndx, row.get_index());
+    insert(row_ndx, row.get_index());
 }
 
 void List::move(size_t source_ndx, size_t dest_ndx)
@@ -172,22 +275,58 @@ void List::move(size_t source_ndx, size_t dest_ndx)
     verify_in_transaction();
     verify_valid_row(source_ndx);
     verify_valid_row(dest_ndx); // Can't be one past end due to removing one earlier
-    m_link_view->move(source_ndx, dest_ndx);
+    if (source_ndx == dest_ndx)
+        return;
+
+    if (m_link_view)
+        m_link_view->move(source_ndx, dest_ndx);
+    else {
+        // If to and from are next to each other we can just swap instead
+        if (source_ndx == dest_ndx + 1 || dest_ndx == source_ndx + 1) {
+            m_table->swap_rows(source_ndx, dest_ndx);
+            return;
+        }
+
+        // Adjust the row indexes to compensate for the temporary row used
+        if (source_ndx > dest_ndx)
+            ++source_ndx;
+        else
+            ++dest_ndx;
+
+        m_table->insert_empty_row(dest_ndx);
+        m_table->swap_rows(source_ndx, dest_ndx);
+        m_table->remove(source_ndx);
+    }
 }
 
 void List::remove(size_t row_ndx)
 {
     verify_in_transaction();
     verify_valid_row(row_ndx);
-    m_link_view->remove(row_ndx);
+    if (m_link_view)
+        m_link_view->remove(row_ndx);
+    else
+        m_table->remove(row_ndx);
 }
 
 void List::remove_all()
 {
     verify_in_transaction();
-    m_link_view->clear();
+    if (m_link_view)
+        m_link_view->clear();
+    else
+        m_table->clear();
 }
 
+template<typename T>
+void List::set(size_t row_ndx, T value)
+{
+    verify_in_transaction();
+    verify_valid_row(row_ndx);
+    m_table->set(0, row_ndx, value);
+}
+
+template<>
 void List::set(size_t row_ndx, size_t target_row_ndx)
 {
     verify_in_transaction();
@@ -195,10 +334,11 @@ void List::set(size_t row_ndx, size_t target_row_ndx)
     m_link_view->set(row_ndx, target_row_ndx);
 }
 
-void List::set(size_t ndx, RowExpr row)
+template<>
+void List::set(size_t row_ndx, RowExpr row)
 {
     validate(row);
-    set(ndx, row.get_index());
+    set(row_ndx, row.get_index());
 }
 
 void List::swap(size_t ndx1, size_t ndx2)
@@ -206,19 +346,30 @@ void List::swap(size_t ndx1, size_t ndx2)
     verify_in_transaction();
     verify_valid_row(ndx1);
     verify_valid_row(ndx2);
-    m_link_view->swap(ndx1, ndx2);
+    if (m_link_view)
+        m_link_view->swap(ndx1, ndx2);
+    else
+        m_table->swap_rows(ndx1, ndx2);
 }
 
 void List::delete_all()
 {
     verify_in_transaction();
-    m_link_view->remove_all_target_rows();
+    if (m_link_view)
+        m_link_view->remove_all_target_rows();
+    else
+        m_table->clear();
 }
 
 Results List::sort(SortDescriptor order) const
 {
     verify_attached();
-    return Results(m_realm, m_link_view, util::none, std::move(order));
+    if (m_link_view)
+        return Results(m_realm, m_link_view, util::none, std::move(order));
+
+    DescriptorOrdering new_order;
+    new_order.append_sort(std::move(order));
+    return Results(m_realm, get_query(), std::move(new_order));
 }
 
 Results List::sort(std::vector<std::pair<std::string, bool>> const& keypaths) const
@@ -230,13 +381,15 @@ Results List::sort(std::vector<std::pair<std::string, bool>> const& keypaths) co
 Results List::filter(Query q) const
 {
     verify_attached();
-    return Results(m_realm, m_link_view, get_query().and_query(std::move(q)));
+    if (m_link_view)
+        return Results(m_realm, m_link_view, get_query().and_query(std::move(q)));
+    return Results(m_realm, get_query().and_query(std::move(q)));
 }
 
 Results List::as_results() const
 {
     verify_attached();
-    return Results(m_realm, m_link_view);
+    return m_link_view ? Results(m_realm, m_link_view) : Results(m_realm, *m_table);
 }
 
 Results List::snapshot() const
@@ -268,13 +421,13 @@ util::Optional<double> List::average(size_t column)
 // These definitions rely on that LinkViews are interned by core
 bool List::operator==(List const& rgt) const noexcept
 {
-    return m_link_view.get() == rgt.m_link_view.get();
+    return m_link_view == rgt.m_link_view && m_table.get() == rgt.m_table.get();
 }
 
 namespace std {
 size_t hash<realm::List>::operator()(realm::List const& list) const
 {
-    return std::hash<void*>()(list.m_link_view.get());
+    return std::hash<void*>()(list.m_link_view ? list.m_link_view.get() : (void*)list.m_table.get());
 }
 }
 
@@ -282,12 +435,38 @@ NotificationToken List::add_notification_callback(CollectionChangeCallback cb) &
 {
     verify_attached();
     if (!m_notifier) {
-        m_notifier = std::make_shared<ListNotifier>(m_link_view, m_realm);
+        if (get_type() == PropertyType::Object)
+            m_notifier = std::static_pointer_cast<_impl::CollectionNotifier>(std::make_shared<ListNotifier>(m_link_view, m_realm));
+        else
+            m_notifier = std::static_pointer_cast<_impl::CollectionNotifier>(std::make_shared<PrimitiveListNotifier>(m_table, m_realm));
         RealmCoordinator::register_notifier(m_notifier);
     }
     return {m_notifier, m_notifier->add_callback(std::move(cb))};
 }
 
 List::OutOfBoundsIndexException::OutOfBoundsIndexException(size_t r, size_t c)
-: std::out_of_range(util::format("Requested index %1 greater than max %2", r, c))
+: std::out_of_range(util::format("Requested index %1 greater than max %2", r, c - 1))
 , requested(r), valid_count(c) {}
+
+namespace realm {
+#define REALM_PRIMITIVE_LIST_TYPE(T) \
+    template T List::get<T>(size_t) const; \
+    template size_t List::find<T>(T const&) const; \
+    template void List::add<T>(T); \
+    template void List::insert<T>(size_t, T); \
+    template void List::set<T>(size_t, T);
+
+REALM_PRIMITIVE_LIST_TYPE(bool)
+REALM_PRIMITIVE_LIST_TYPE(int64_t)
+REALM_PRIMITIVE_LIST_TYPE(float)
+REALM_PRIMITIVE_LIST_TYPE(double)
+REALM_PRIMITIVE_LIST_TYPE(StringData)
+REALM_PRIMITIVE_LIST_TYPE(BinaryData)
+REALM_PRIMITIVE_LIST_TYPE(Timestamp)
+REALM_PRIMITIVE_LIST_TYPE(util::Optional<bool>)
+REALM_PRIMITIVE_LIST_TYPE(util::Optional<int64_t>)
+REALM_PRIMITIVE_LIST_TYPE(util::Optional<float>)
+REALM_PRIMITIVE_LIST_TYPE(util::Optional<double>)
+
+#undef REALM_PRIMITIVE_LIST_TYPE
+}

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -369,7 +369,6 @@ Results List::sort(SortDescriptor order) const
 
 Results List::sort(std::vector<std::pair<std::string, bool>> const& keypaths) const
 {
-    verify_attached();
     return as_results().sort(keypaths);
 }
 

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -254,12 +254,13 @@ util::Optional<Mixed> List::min(size_t column)
     return as_results().min(column);
 }
 
-util::Optional<Mixed> List::sum(size_t column)
+Mixed List::sum(size_t column)
 {
-    return as_results().sum(column);
+    // Results::sum() returns none only for Empty results
+    return *as_results().sum(column);
 }
 
-util::Optional<Mixed> List::average(size_t column)
+util::Optional<double> List::average(size_t column)
 {
     return as_results().average(column);
 }

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -403,7 +403,8 @@ util::Optional<Mixed> List::min(size_t column)
 
 Mixed List::sum(size_t column)
 {
-    // Results::sum() returns none only for Empty results
+    // Results::sum() returns none only for Mode::Empty Results, so we can
+    // safely ignore that possibility here
     return *as_results().sum(column);
 }
 

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -32,8 +32,6 @@
 #include <memory>
 
 namespace realm {
-using RowExpr = BasicRowExpr<Table>;
-
 class ObjectSchema;
 class Query;
 class Realm;
@@ -64,7 +62,6 @@ public:
 
     // Get the type of the values contained in this List
     PropertyType get_type() const;
-    bool is_optional() const noexcept;
 
     // Get the ObjectSchema of the values in this List
     // Only valid if get_type() returns PropertyType::Object
@@ -170,18 +167,7 @@ private:
 template<typename Fn>
 auto List::dispatch(Fn&& fn) const
 {
-    using PT = PropertyType;
-    switch (get_type()) {
-        case PT::Int:    return is_optional() ? fn((util::Optional<int64_t>*)0) : fn((int64_t*)0);
-        case PT::Bool:   return is_optional() ? fn((util::Optional<bool>*)0)    : fn((bool*)0);
-        case PT::Float:  return is_optional() ? fn((util::Optional<float>*)0)   : fn((float*)0);
-        case PT::Double: return is_optional() ? fn((util::Optional<double>*)0)  : fn((double*)0);
-        case PT::String: return fn((StringData*)0);
-        case PT::Data:   return fn((BinaryData*)0);
-        case PT::Date:   return fn((Timestamp*)0);
-        case PT::Object: return fn((RowExpr*)0);
-        default: REALM_COMPILER_HINT_UNREACHABLE();
-    }
+    return switch_on_type(get_type(), std::forward<Fn>(fn));
 }
 
 template<typename Context>

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -16,14 +16,17 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#ifndef REALM_LIST_HPP
-#define REALM_LIST_HPP
+#ifndef REALM_OS_LIST_HPP
+#define REALM_OS_LIST_HPP
 
 #include "collection_notifications.hpp"
 #include "impl/collection_notifier.hpp"
+#include "property.hpp"
+#include "util/compiler.hpp"
 
 #include <realm/link_view_fwd.hpp>
 #include <realm/row.hpp>
+#include <realm/table_ref.hpp>
 
 #include <functional>
 #include <memory>
@@ -45,7 +48,9 @@ class ListNotifier;
 class List {
 public:
     List() noexcept;
+    List(std::shared_ptr<Realm> r, Table& parent_table, size_t col, size_t row);
     List(std::shared_ptr<Realm> r, LinkViewRef l) noexcept;
+    List(std::shared_ptr<Realm> r, TableRef l) noexcept;
     ~List();
 
     List(const List&);
@@ -55,32 +60,42 @@ public:
 
     const std::shared_ptr<Realm>& get_realm() const { return m_realm; }
     Query get_query() const;
-    const ObjectSchema& get_object_schema() const;
     size_t get_origin_row_index() const;
+
+    // Get the type of the values contained in this List
+    PropertyType get_type() const;
+    bool is_optional() const noexcept;
+
+    // Get the ObjectSchema of the values in this List
+    // Only valid if get_type() returns PropertyType::Object
+    ObjectSchema const& get_object_schema() const;
 
     bool is_valid() const;
     void verify_attached() const;
     void verify_in_transaction() const;
 
     size_t size() const;
-    RowExpr get(size_t row_ndx) const;
-    size_t get_unchecked(size_t row_ndx) const noexcept;
-    size_t find(ConstRow const& row) const;
-
-    void add(size_t target_row_ndx);
-    void insert(size_t list_ndx, size_t target_row_ndx);
-    void set(size_t row_ndx, size_t target_row_ndx);
-
-    void add(RowExpr row);
-    void insert(size_t list_ndx, RowExpr row);
-    void set(size_t row_ndx, RowExpr row);
 
     void move(size_t source_ndx, size_t dest_ndx);
     void remove(size_t list_ndx);
     void remove_all();
     void swap(size_t ndx1, size_t ndx2);
-
     void delete_all();
+
+    template<typename T = RowExpr>
+    T get(size_t row_ndx) const;
+    template<typename T>
+    size_t find(T const& value) const;
+
+    // Find the index in the List of the first row matching the query
+    size_t find(Query&& query) const;
+
+    template<typename T>
+    void add(T value);
+    template<typename T>
+    void insert(size_t list_ndx, T value);
+    template<typename T>
+    void set(size_t row_ndx, T value);
 
     Results sort(SortDescriptor order) const;
     Results sort(std::vector<std::pair<std::string, bool>> const& keypaths) const;
@@ -97,29 +112,26 @@ public:
     // sum() returns 0,
     // Throws UnsupportedColumnTypeException for sum/average on timestamp or non-numeric column
     // Throws OutOfBoundsIndexException for an out-of-bounds column
-    util::Optional<Mixed> max(size_t column);
-    util::Optional<Mixed> min(size_t column);
-    util::Optional<double> average(size_t column);
-    Mixed sum(size_t column);
+    util::Optional<Mixed> max(size_t column=0);
+    util::Optional<Mixed> min(size_t column=0);
+    util::Optional<double> average(size_t column=0);
+    Mixed sum(size_t column=0);
 
     bool operator==(List const& rgt) const noexcept;
 
     NotificationToken add_notification_callback(CollectionChangeCallback cb) &;
 
-    template <typename ValueType, typename ContextType>
-    void add(ContextType& ctx, ValueType value, bool update=false);
-
-    template <typename ValueType, typename ContextType>
-    void insert(ContextType& ctx, size_t list_ndx, ValueType value, bool update=false);
-
-    template <typename ValueType, typename ContextType>
-    void set(ContextType& ctx, size_t list_ndx, ValueType value, bool update=false);
-
-    template <typename ValueType, typename ContextType>
-    size_t find(ContextType& ctx, ValueType value);
-
     template<typename Context>
     auto get(Context&, size_t row_ndx) const;
+    template<typename T, typename Context>
+    size_t find(Context&, T&& value) const;
+
+    template<typename T, typename Context>
+    void add(Context&, T&& value, bool update=false);
+    template<typename T, typename Context>
+    void insert(Context&, size_t list_ndx, T&& value, bool update=false);
+    template<typename T, typename Context>
+    void set(Context&, size_t row_ndx, T&& value, bool update=false);
 
     // The List object has been invalidated (due to the Realm being invalidated,
     // or the containing object being deleted)
@@ -141,48 +153,66 @@ private:
     std::shared_ptr<Realm> m_realm;
     mutable const ObjectSchema* m_object_schema = nullptr;
     LinkViewRef m_link_view;
-    _impl::CollectionNotifier::Handle<_impl::ListNotifier> m_notifier;
+    TableRef m_table;
+    _impl::CollectionNotifier::Handle<_impl::CollectionNotifier> m_notifier;
 
     void verify_valid_row(size_t row_ndx, bool insertion = false) const;
-    void validate(RowExpr row) const;
+    void validate(RowExpr) const;
+
+    template<typename Fn>
+    auto dispatch(Fn&&) const;
+
+    size_t to_table_ndx(size_t row) const noexcept;
 
     friend struct std::hash<List>;
 };
 
-template <typename ValueType, typename ContextType>
-void List::add(ContextType& ctx, ValueType value, bool update)
+template<typename Fn>
+auto List::dispatch(Fn&& fn) const
 {
-    verify_attached();
-    add(ctx.template unbox<RowExpr>(value, true, update));
-}
-
-template <typename ValueType, typename ContextType>
-void List::insert(ContextType& ctx, size_t list_ndx, ValueType value, bool update)
-{
-    verify_attached();
-    insert(list_ndx, ctx.template unbox<RowExpr>(value, true, update));
-}
-
-template <typename ValueType, typename ContextType>
-void List::set(ContextType& ctx, size_t list_ndx, ValueType value, bool update)
-{
-    verify_attached();
-    set(list_ndx, ctx.template unbox<RowExpr>(value, true, update));
-}
-
-template <typename ValueType, typename ContextType>
-size_t List::find(ContextType& ctx, ValueType value)
-{
-    verify_attached();
-    return find(ctx.template unbox<RowExpr>(value));
+    using PT = PropertyType;
+    switch (get_type()) {
+        case PT::Int:    return is_optional() ? fn((util::Optional<int64_t>*)0) : fn((int64_t*)0);
+        case PT::Bool:   return is_optional() ? fn((util::Optional<bool>*)0)    : fn((bool*)0);
+        case PT::Float:  return is_optional() ? fn((util::Optional<float>*)0)   : fn((float*)0);
+        case PT::Double: return is_optional() ? fn((util::Optional<double>*)0)  : fn((double*)0);
+        case PT::String: return fn((StringData*)0);
+        case PT::Data:   return fn((BinaryData*)0);
+        case PT::Date:   return fn((Timestamp*)0);
+        case PT::Object: return fn((RowExpr*)0);
+        default: REALM_COMPILER_HINT_UNREACHABLE();
+    }
 }
 
 template<typename Context>
 auto List::get(Context& ctx, size_t row_ndx) const
 {
-    return ctx.box(get(row_ndx));
+    return dispatch([&](auto t) { return ctx.box(get<std::decay_t<decltype(*t)>>(row_ndx)); });
 }
 
+template<typename T, typename Context>
+size_t List::find(Context& ctx, T&& value) const
+{
+    return dispatch([&](auto t) { return find(ctx.template unbox<std::decay_t<decltype(*t)>>(value)); });
+}
+
+template<typename T, typename Context>
+void List::add(Context& ctx, T&& value, bool update)
+{
+    dispatch([&](auto t) { add(ctx.template unbox<std::decay_t<decltype(*t)>>(value, true, update)); });
+}
+
+template<typename T, typename Context>
+void List::insert(Context& ctx, size_t list_ndx, T&& value, bool update)
+{
+    dispatch([&](auto t) { insert(list_ndx, ctx.template unbox<std::decay_t<decltype(*t)>>(value, true, update)); });
+}
+
+template<typename T, typename Context>
+void List::set(Context& ctx, size_t row_ndx, T&& value, bool update)
+{
+    dispatch([&](auto t) { set(row_ndx, ctx.template unbox<std::decay_t<decltype(*t)>>(value, true, update)); });
+}
 } // namespace realm
 
 namespace std {
@@ -191,4 +221,4 @@ template<> struct hash<realm::List> {
 };
 }
 
-#endif /* REALM_LIST_HPP */
+#endif // REALM_OS_LIST_HPP

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -173,31 +173,31 @@ auto List::dispatch(Fn&& fn) const
 template<typename Context>
 auto List::get(Context& ctx, size_t row_ndx) const
 {
-    return dispatch([&](auto t) { return ctx.box(get<std::decay_t<decltype(*t)>>(row_ndx)); });
+    return dispatch([&](auto t) { return ctx.box(this->get<std::decay_t<decltype(*t)>>(row_ndx)); });
 }
 
 template<typename T, typename Context>
 size_t List::find(Context& ctx, T&& value) const
 {
-    return dispatch([&](auto t) { return find(ctx.template unbox<std::decay_t<decltype(*t)>>(value)); });
+    return dispatch([&](auto t) { return this->find(ctx.template unbox<std::decay_t<decltype(*t)>>(value)); });
 }
 
 template<typename T, typename Context>
 void List::add(Context& ctx, T&& value, bool update)
 {
-    dispatch([&](auto t) { add(ctx.template unbox<std::decay_t<decltype(*t)>>(value, true, update)); });
+    dispatch([&](auto t) { this->add(ctx.template unbox<std::decay_t<decltype(*t)>>(value, true, update)); });
 }
 
 template<typename T, typename Context>
 void List::insert(Context& ctx, size_t list_ndx, T&& value, bool update)
 {
-    dispatch([&](auto t) { insert(list_ndx, ctx.template unbox<std::decay_t<decltype(*t)>>(value, true, update)); });
+    dispatch([&](auto t) { this->insert(list_ndx, ctx.template unbox<std::decay_t<decltype(*t)>>(value, true, update)); });
 }
 
 template<typename T, typename Context>
 void List::set(Context& ctx, size_t row_ndx, T&& value, bool update)
 {
-    dispatch([&](auto t) { set(row_ndx, ctx.template unbox<std::decay_t<decltype(*t)>>(value, true, update)); });
+    dispatch([&](auto t) { this->set(row_ndx, ctx.template unbox<std::decay_t<decltype(*t)>>(value, true, update)); });
 }
 } // namespace realm
 

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -94,13 +94,13 @@ public:
 
     // Get the min/max/average/sum of the given column
     // All but sum() returns none when there are zero matching rows
-    // sum() returns 0, except for when it returns none
+    // sum() returns 0,
     // Throws UnsupportedColumnTypeException for sum/average on timestamp or non-numeric column
     // Throws OutOfBoundsIndexException for an out-of-bounds column
     util::Optional<Mixed> max(size_t column);
     util::Optional<Mixed> min(size_t column);
-    util::Optional<Mixed> average(size_t column);
-    util::Optional<Mixed> sum(size_t column);
+    util::Optional<double> average(size_t column);
+    Mixed sum(size_t column);
 
     bool operator==(List const& rgt) const noexcept;
 

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -100,7 +100,7 @@ ObjectSchema::ObjectSchema(Group const& group, StringData name, size_t index) : 
 
         if (table->get_column_type(col) == type_Table) {
             auto subdesc = table->get_subdescriptor(col);
-            if (subdesc->get_column_count() != 1 || subdesc->get_column_name(0) != "!ARRAY_VALUE")
+            if (subdesc->get_column_count() != 1 || subdesc->get_column_name(0) != ObjectStore::ArrayColumnName)
                 continue;
         }
 

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -89,9 +89,6 @@ ObjectSchema::ObjectSchema(Group const& group, StringData name, size_t index) : 
     size_t count = table->get_column_count();
     persisted_properties.reserve(count);
     for (size_t col = 0; col < count; col++) {
-        if (table->get_column_type(col) == type_Table)
-            continue;
-
         StringData column_name = table->get_column_name(col);
 
 #if REALM_HAVE_SYNC_STABLE_IDS
@@ -100,6 +97,12 @@ ObjectSchema::ObjectSchema(Group const& group, StringData name, size_t index) : 
         if (column_name == sync::object_id_column_name)
             continue;
 #endif
+
+        if (table->get_column_type(col) == type_Table) {
+            auto subdesc = table->get_subdescriptor(col);
+            if (subdesc->get_column_count() != 1 || subdesc->get_column_name(0) != "!ARRAY_VALUE")
+                continue;
+        }
 
         Property property;
         property.name = column_name;
@@ -157,14 +160,7 @@ static void validate_property(Schema const& schema,
                               Property const** primary,
                               std::vector<ObjectSchemaValidationException>& exceptions)
 {
-    // currently only arrays of objects are allowed
-    if (is_array(prop.type)) {
-        if (prop.type != PropertyType::Object && prop.type != PropertyType::LinkingObjects) {
-            exceptions.emplace_back("Property '%1.%2' has unsupported type '%3'.",
-                                    object_name, prop.name, prop.type_string());
-        }
-    }
-    else if (prop.type == PropertyType::LinkingObjects) {
+    if (prop.type == PropertyType::LinkingObjects && !is_array(prop.type)) {
         exceptions.emplace_back("Linking Objects property '%1.%2' must be an array.",
                                 object_name, prop.name);
     }

--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -24,6 +24,7 @@
 #include "shared_realm.hpp"
 #include "util/format.hpp"
 
+#include <realm/descriptor.hpp>
 #include <realm/group.hpp>
 #include <realm/table.hpp>
 #include <realm/table_view.hpp>
@@ -115,6 +116,12 @@ void insert_column(Group& group, Table& table, Property const& property, size_t 
         REALM_ASSERT(link_table);
         table.insert_column_link(col_ndx, is_array(property.type) ? type_LinkList : type_Link,
                                  property.name, *link_table);
+    }
+    else if (is_array(property.type)) {
+        DescriptorRef desc;
+        table.insert_column(col_ndx, type_Table, property.name, &desc);
+        desc->add_column(to_core_type(property.type & ~PropertyType::Flags), "!ARRAY_VALUE",
+                         nullptr, is_nullable(property.type));
     }
     else {
         table.insert_column(col_ndx, to_core_type(property.type), property.name, is_nullable(property.type));

--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -120,7 +120,7 @@ void insert_column(Group& group, Table& table, Property const& property, size_t 
     else if (is_array(property.type)) {
         DescriptorRef desc;
         table.insert_column(col_ndx, type_Table, property.name, &desc);
-        desc->add_column(to_core_type(property.type & ~PropertyType::Flags), "!ARRAY_VALUE",
+        desc->add_column(to_core_type(property.type & ~PropertyType::Flags), ObjectStore::ArrayColumnName,
                          nullptr, is_nullable(property.type));
     }
     else {

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -44,6 +44,9 @@ public:
     // Schema version used for uninitialized Realms
     static const uint64_t NotVersioned;
 
+    // Column name used for subtables which store an array
+    static constexpr const char* const ArrayColumnName = "!ARRAY_VALUE";
+
     // get the last set schema version
     static uint64_t get_schema_version(Group const& group);
 

--- a/src/property.hpp
+++ b/src/property.hpp
@@ -25,6 +25,17 @@
 #include <string>
 
 namespace realm {
+namespace util {
+    template<typename> class Optional;
+}
+class StringData;
+class BinaryData;
+class Timestamp;
+class Table;
+
+template<typename> class BasicRowExpr;
+using RowExpr = BasicRowExpr<Table>;
+
 enum class PropertyType : unsigned char {
     Int    = 0,
     Bool   = 1,
@@ -141,6 +152,24 @@ inline constexpr bool is_array(PropertyType a)
 inline constexpr bool is_nullable(PropertyType a)
 {
     return to_underlying(a & PropertyType::Nullable) == to_underlying(PropertyType::Nullable);
+}
+
+template<typename Fn>
+static auto switch_on_type(PropertyType type, Fn&& fn)
+{
+    using PT = PropertyType;
+    bool is_optional = is_nullable(type);
+    switch (type & ~PropertyType::Flags) {
+        case PT::Int:    return is_optional ? fn((util::Optional<int64_t>*)0) : fn((int64_t*)0);
+        case PT::Bool:   return is_optional ? fn((util::Optional<bool>*)0)    : fn((bool*)0);
+        case PT::Float:  return is_optional ? fn((util::Optional<float>*)0)   : fn((float*)0);
+        case PT::Double: return is_optional ? fn((util::Optional<double>*)0)  : fn((double*)0);
+        case PT::String: return fn((StringData*)0);
+        case PT::Data:   return fn((BinaryData*)0);
+        case PT::Date:   return fn((Timestamp*)0);
+        case PT::Object: return fn((RowExpr*)0);
+        default: REALM_COMPILER_HINT_UNREACHABLE();
+    }
 }
 
 static const char *string_for_property_type(PropertyType type)

--- a/src/results.cpp
+++ b/src/results.cpp
@@ -745,6 +745,6 @@ Results::UnsupportedColumnTypeException::UnsupportedColumnTypeException(size_t c
                                 string_for_property_type(ObjectSchema::from_core_type(*table->get_descriptor(), column))))
 , column_index(column)
 , column_name(table->get_column_name(column))
-, column_type(table->get_column_type(column))
+, property_type(ObjectSchema::from_core_type(*table->get_descriptor(), column))
 {
 }

--- a/src/results.cpp
+++ b/src/results.cpp
@@ -487,11 +487,6 @@ PropertyType Results::get_type() const
     }
 }
 
-bool Results::is_optional() const noexcept
-{
-    return m_table && m_table->is_attached() && m_table->is_nullable(0);
-}
-
 Query Results::get_query() const
 {
     validate_read();

--- a/src/results.cpp
+++ b/src/results.cpp
@@ -600,7 +600,6 @@ Results Results::distinct(realm::DistinctDescriptor&& uniqueness)
 Results Results::snapshot() const &
 {
     validate_read();
-
     return Results(*this).snapshot();
 }
 
@@ -646,13 +645,6 @@ void Results::prepare_async()
     m_wants_background_updates = true;
     m_notifier = std::make_shared<_impl::ResultsNotifier>(*this);
     _impl::RealmCoordinator::register_notifier(m_notifier);
-}
-
-NotificationToken Results::async(std::function<void (std::exception_ptr)> target)
-{
-    prepare_async();
-    auto wrap = [=](CollectionChangeSet, std::exception_ptr e) { target(e); };
-    return {m_notifier, m_notifier->add_callback(wrap)};
 }
 
 NotificationToken Results::add_notification_callback(CollectionChangeCallback cb) &

--- a/src/results.cpp
+++ b/src/results.cpp
@@ -583,8 +583,12 @@ Results Results::sort(std::vector<std::pair<std::string, bool>> const& keypaths)
     if (keypaths.empty())
         return *this;
     if (get_type() != PropertyType::Object) {
-        if (keypaths.size() != 1 || keypaths[0].first != "self")
-            throw std::invalid_argument("bad");
+        if (keypaths.size() != 1)
+            throw std::invalid_argument(util::format("Cannot sort array of '%1' on more than one key path",
+                                                     string_for_property_type(get_type())));
+        if (keypaths[0].first != "self")
+            throw std::invalid_argument(util::format("Cannot sort on key path '%1': arrays of '%2' can only be sorted on 'self'",
+                                                     keypaths[0].first, string_for_property_type(get_type())));
         return sort({*m_table, {{0}}, {keypaths[0].second}});
     }
 
@@ -626,8 +630,12 @@ Results Results::distinct(std::vector<std::string> const& keypaths) const
     if (keypaths.empty())
         return *this;
     if (get_type() != PropertyType::Object) {
-        if (keypaths.size() != 1 || keypaths[0] != "self")
-            throw std::invalid_argument("bad");
+        if (keypaths.size() != 1)
+            throw std::invalid_argument(util::format("Cannot sort array of '%1' on more than one key path",
+                                                     string_for_property_type(get_type())));
+        if (keypaths[0] != "self")
+            throw std::invalid_argument(util::format("Cannot sort on key path '%1': arrays of '%2' can only be sorted on 'self'",
+                                                     keypaths[0], string_for_property_type(get_type())));
         return distinct({*m_table, {{0}}});
     }
 

--- a/src/results.cpp
+++ b/src/results.cpp
@@ -398,7 +398,7 @@ util::Optional<Mixed> Results::sum(size_t column)
                      [=](auto const&) -> Timestamp { throw UnsupportedColumnTypeException{column, m_table.get(), "sum"}; });
 }
 
-util::Optional<Mixed> Results::average(size_t column)
+util::Optional<double> Results::average(size_t column)
 {
     size_t value_count = 0;
     auto results = aggregate(column, "average",
@@ -406,7 +406,7 @@ util::Optional<Mixed> Results::average(size_t column)
                              [&](auto const& table) { return table.average_float(column, &value_count); },
                              [&](auto const& table) { return table.average_double(column, &value_count); },
                              [&](auto const&) -> Timestamp { throw UnsupportedColumnTypeException{column, m_table.get(), "average"}; });
-    return value_count == 0 ? none : results;
+    return value_count == 0 ? none : util::make_optional(results->get_double());
 }
 
 void Results::clear()

--- a/src/results.hpp
+++ b/src/results.hpp
@@ -235,6 +235,8 @@ private:
 
     void prepare_async();
 
+    util::Optional<RowExpr> try_get(size_t);
+
     template<typename Int, typename Float, typename Double, typename Timestamp>
     util::Optional<Mixed> aggregate(size_t column,
                                     const char* name,

--- a/src/results.hpp
+++ b/src/results.hpp
@@ -118,7 +118,8 @@ public:
     Results sort(std::vector<std::pair<std::string, bool>> const& keypaths) const;
 
     // Create a new Results by removing duplicates
-    Results distinct(DistinctDescriptor&& uniqueness);
+    Results distinct(DistinctDescriptor&& uniqueness) const;
+    Results distinct(std::vector<std::string> const& keypaths) const;
 
     // Return a snapshot of this Results that never updates to reflect changes in the underlying data.
     Results snapshot() const &;

--- a/src/results.hpp
+++ b/src/results.hpp
@@ -178,7 +178,7 @@ public:
     struct UnsupportedColumnTypeException : public std::logic_error {
         size_t column_index;
         StringData column_name;
-        DataType column_type;
+        PropertyType property_type;
 
         UnsupportedColumnTypeException(size_t column, const Table* table, const char* operation);
     };

--- a/src/results.hpp
+++ b/src/results.hpp
@@ -257,7 +257,7 @@ private:
 template<typename Func>
 NotificationToken Results::async(Func&& target)
 {
-    return add_notification_callback([target = std::forward<Func>(target)](CollectionChangeSet const&, std::exception_ptr e) {
+    return this->add_notification_callback([target = std::forward<Func>(target)](CollectionChangeSet const&, std::exception_ptr e) {
         target(e);
     });
 }
@@ -271,14 +271,14 @@ auto Results::dispatch(Fn&& fn) const
 template<typename Context>
 auto Results::get(Context& ctx, size_t row_ndx)
 {
-    return dispatch([&](auto t) { return ctx.box(get<std::decay_t<decltype(*t)>>(row_ndx)); });
+    return dispatch([&](auto t) { return ctx.box(this->get<std::decay_t<decltype(*t)>>(row_ndx)); });
 }
 
 template<typename Context>
 auto Results::first(Context& ctx)
 {
     return dispatch([&](auto t) {
-        auto value = first<std::decay_t<decltype(*t)>>();
+        auto value = this->first<std::decay_t<decltype(*t)>>();
         return value ? static_cast<decltype(ctx.no_value())>(ctx.box(*value)) : ctx.no_value();
     });
 }
@@ -287,7 +287,7 @@ template<typename Context>
 auto Results::last(Context& ctx)
 {
     return dispatch([&](auto t) {
-        auto value = last<std::decay_t<decltype(*t)>>();
+        auto value = this->last<std::decay_t<decltype(*t)>>();
         return value ? static_cast<decltype(ctx.no_value())>(ctx.box(*value)) : ctx.no_value();
     });
 }
@@ -295,7 +295,7 @@ auto Results::last(Context& ctx)
 template<typename Context, typename T>
 size_t Results::index_of(Context& ctx, T value)
 {
-    return dispatch([&](auto t) { return index_of(ctx.template unbox<std::decay_t<decltype(*t)>>(value)); });
+    return dispatch([&](auto t) { return this->index_of(ctx.template unbox<std::decay_t<decltype(*t)>>(value)); });
 }
 } // namespace realm
 

--- a/src/results.hpp
+++ b/src/results.hpp
@@ -242,6 +242,7 @@ private:
                                     const char* name,
                                     Int agg_int, Float agg_float,
                                     Double agg_double, Timestamp agg_timestamp);
+    void prepare_for_aggregate(size_t column, const char* name);
 
     void set_table_view(TableView&& tv);
 };

--- a/src/results.hpp
+++ b/src/results.hpp
@@ -277,9 +277,10 @@ auto Results::get(Context& ctx, size_t row_ndx)
 template<typename Context>
 auto Results::first(Context& ctx)
 {
-    return dispatch([&](auto t) {
+    // GCC 4.9 complains about `ctx` not being defined within the lambda without this goofy capture
+    return dispatch([this, ctx = &ctx](auto t) {
         auto value = this->first<std::decay_t<decltype(*t)>>();
-        return value ? static_cast<decltype(ctx.no_value())>(ctx.box(*value)) : ctx.no_value();
+        return value ? static_cast<decltype(ctx->no_value())>(ctx->box(*value)) : ctx->no_value();
     });
 }
 

--- a/src/results.hpp
+++ b/src/results.hpp
@@ -135,7 +135,7 @@ public:
     // Throws OutOfBoundsIndexException for an out-of-bounds column
     util::Optional<Mixed> max(size_t column);
     util::Optional<Mixed> min(size_t column);
-    util::Optional<Mixed> average(size_t column);
+    util::Optional<double> average(size_t column);
     util::Optional<Mixed> sum(size_t column);
 
     enum class Mode {

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -51,10 +51,7 @@ typedef std::weak_ptr<Realm> WeakRealm;
 namespace _impl {
     class AnyHandover;
     class CollectionNotifier;
-    class ListNotifier;
-    class ObjectNotifier;
     class RealmCoordinator;
-    class ResultsNotifier;
     class RealmFriend;
 }
 
@@ -313,10 +310,7 @@ public:
     // without making it public to everyone
     class Internal {
         friend class _impl::CollectionNotifier;
-        friend class _impl::ListNotifier;
-        friend class _impl::ObjectNotifier;
         friend class _impl::RealmCoordinator;
-        friend class _impl::ResultsNotifier;
         friend class ThreadSafeReferenceBase;
         friend class GlobalNotifier;
         friend class TestHelper;

--- a/src/thread_safe_reference.cpp
+++ b/src/thread_safe_reference.cpp
@@ -78,12 +78,15 @@ void ThreadSafeReferenceBase::invalidate() {
 
 ThreadSafeReference<List>::ThreadSafeReference(List const& list)
 : ThreadSafeReferenceBase(list.get_realm())
-, m_link_view(get_source_shared_group().export_linkview_for_handover(list.m_link_view)) { }
+, m_link_view(get_source_shared_group().export_linkview_for_handover(list.m_link_view))
+, m_table(get_source_shared_group().export_table_for_handover(list.m_table))
+{ }
 
 List ThreadSafeReference<List>::import_into_realm(SharedRealm realm) && {
     return invalidate_after_import<List>(*realm, [&](SharedGroup& shared_group) {
-        LinkViewRef link_view = shared_group.import_linkview_from_handover(std::move(m_link_view));
-        return List(std::move(realm), std::move(link_view));
+        if (auto link_view = shared_group.import_linkview_from_handover(std::move(m_link_view)))
+            return List(std::move(realm), std::move(link_view));
+        return List(std::move(realm), shared_group.import_table_from_handover(std::move(m_table)));
     });
 }
 

--- a/src/thread_safe_reference.hpp
+++ b/src/thread_safe_reference.hpp
@@ -66,23 +66,14 @@ private:
 };
 
 template <typename T>
-class ThreadSafeReference: public ThreadSafeReferenceBase {
-private:
-    friend Realm;
-
-    // Precondition: The associated Realm is for the current thread and is not in a write transaction;.
-    ThreadSafeReference(T value);
-
-    // Precondition: Realm and handover are on same version
-    T import_into_realm(std::shared_ptr<Realm> realm) &&;
-};
+class ThreadSafeReference;
 
 template<>
 class ThreadSafeReference<List>: public ThreadSafeReferenceBase {
-private:
-    friend Realm;
+    friend class Realm;
 
     std::unique_ptr<SharedGroup::Handover<LinkView>> m_link_view;
+    std::unique_ptr<SharedGroup::Handover<Table>> m_table;
 
     // Precondition: The associated Realm is for the current thread and is not in a write transaction;.
     ThreadSafeReference(List const& value);
@@ -93,8 +84,7 @@ private:
 
 template<>
 class ThreadSafeReference<Object>: public ThreadSafeReferenceBase {
-private:
-    friend Realm;
+    friend class Realm;
 
     std::unique_ptr<SharedGroup::Handover<Row>> m_row;
     std::string m_object_schema_name;
@@ -108,8 +98,7 @@ private:
 
 template<>
 class ThreadSafeReference<Results>: public ThreadSafeReferenceBase {
-private:
-    friend Realm;
+    friend class Realm;
 
     std::unique_ptr<SharedGroup::Handover<Query>> m_query;
     DescriptorOrdering::HandoverPatch m_ordering_patch;

--- a/src/util/compiler.hpp
+++ b/src/util/compiler.hpp
@@ -41,4 +41,11 @@
 #define REALM_COMPILER_HINT_UNREACHABLE abort
 #endif
 
+#if __GNUC__ < 5 && !defined(__clang__)
+#define REALM_NO_BRACED_INIT 1
+#else
+#define REALM_NO_BRACED_INIT 0
+#endif
+
+
 #endif // REALM_UTIL_COMPILER_HPP

--- a/src/util/compiler.hpp
+++ b/src/util/compiler.hpp
@@ -41,11 +41,4 @@
 #define REALM_COMPILER_HINT_UNREACHABLE abort
 #endif
 
-#if __GNUC__ < 5 && !defined(__clang__)
-#define REALM_NO_BRACED_INIT 1
-#else
-#define REALM_NO_BRACED_INIT 0
-#endif
-
-
 #endif // REALM_UTIL_COMPILER_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCES
     object.cpp
     object_store.cpp
     parser.cpp
+    primitive_list.cpp
     realm.cpp
     results.cpp
     schema.cpp

--- a/tests/list.cpp
+++ b/tests/list.cpp
@@ -616,12 +616,14 @@ TEST_CASE("list") {
         REQUIRE_THROWS_WITH(results.get(10), "Requested index 10 greater than max 9");
         REQUIRE(results.get_mode() == Results::Mode::TableView);
 
+#if REALM_VERSION_MAJOR > 2
         // Zero sort columns should leave it in LinkView mode
         results = list.sort({*target, {}, {}});
         for (size_t i = 0; i < 10; ++i)
             REQUIRE(results.get(i).get_index() == i);
         REQUIRE_THROWS_WITH(results.get(10), "Requested index 10 greater than max 9");
         REQUIRE(results.get_mode() == Results::Mode::LinkView);
+#endif
     }
 
     SECTION("filter()") {

--- a/tests/list.cpp
+++ b/tests/list.cpp
@@ -20,6 +20,7 @@
 
 #include "util/test_file.hpp"
 #include "util/index_helpers.hpp"
+#include "util/templated_test_case.hpp"
 
 #include "binding_context.hpp"
 #include "list.hpp"
@@ -602,11 +603,25 @@ TEST_CASE("list") {
         REQUIRE(&results.get_object_schema() == objectschema);
         REQUIRE(results.get_mode() == Results::Mode::LinkView);
         REQUIRE(results.size() == 10);
-        REQUIRE(results.sum(0) == 45);
 
-        for (size_t i = 0; i < 10; ++i) {
+        // Aggregates don't inherently have to convert to TableView, but do
+        // because aggregates aren't implemented for LinkView
+        REQUIRE(results.sum(0) == 45);
+        REQUIRE(results.get_mode() == Results::Mode::TableView);
+
+        // Reset to LinkView mode to test implicit conversion to TableView on get()
+        results = list.sort({*target, {{0}}, {false}});
+        for (size_t i = 0; i < 10; ++i)
             REQUIRE(results.get(i).get_index() == 9 - i);
-        }
+        REQUIRE_THROWS_WITH(results.get(10), "Requested index 10 greater than max 9");
+        REQUIRE(results.get_mode() == Results::Mode::TableView);
+
+        // Zero sort columns should leave it in LinkView mode
+        results = list.sort({*target, {}, {}});
+        for (size_t i = 0; i < 10; ++i)
+            REQUIRE(results.get(i).get_index() == i);
+        REQUIRE_THROWS_WITH(results.get(10), "Requested index 10 greater than max 9");
+        REQUIRE(results.get_mode() == Results::Mode::LinkView);
     }
 
     SECTION("filter()") {
@@ -660,13 +675,43 @@ TEST_CASE("list") {
         REQUIRE(&list.get_object_schema() == objectschema);
     }
 
+    SECTION("delete_all()") {
+        List list(r, lv);
+        r->begin_transaction();
+        list.delete_all();
+        REQUIRE(lv->size() == 0);
+        REQUIRE(target->size() == 0);
+        r->cancel_transaction();
+    }
+
+    SECTION("as_results().clear()") {
+        List list(r, lv);
+        r->begin_transaction();
+        list.as_results().clear();
+        REQUIRE(lv->size() == 0);
+        REQUIRE(target->size() == 0);
+        r->cancel_transaction();
+    }
+
+    SECTION("snapshot().clear()") {
+        List list(r, lv);
+        r->begin_transaction();
+        auto snapshot = list.snapshot();
+        snapshot.clear();
+        REQUIRE(snapshot.size() == 10);
+        REQUIRE(list.size() == 0);
+        REQUIRE(lv->size() == 0);
+        REQUIRE(target->size() == 0);
+        r->cancel_transaction();
+    }
+
     SECTION("add(RowExpr)") {
         List list(r, lv);
         r->begin_transaction();
         SECTION("adds rows from the correct table") {
             list.add(target->get(5));
             REQUIRE(list.size() == 11);
-            REQUIRE(list.get_unchecked(10) == 5);
+            REQUIRE(list.get(10).get_index() == 5);
         }
 
         SECTION("throws for rows from the wrong table") {
@@ -682,7 +727,7 @@ TEST_CASE("list") {
         SECTION("insert rows from the correct table") {
             list.insert(0, target->get(5));
             REQUIRE(list.size() == 11);
-            REQUIRE(list.get_unchecked(0) == 5);
+            REQUIRE(list.get(0).get_index() == 5);
         }
 
         SECTION("throws for rows from the wrong table") {
@@ -703,7 +748,7 @@ TEST_CASE("list") {
         SECTION("assigns for rows from the correct table") {
             list.set(0, target->get(5));
             REQUIRE(list.size() == 10);
-            REQUIRE(list.get_unchecked(0) == 5);
+            REQUIRE(list.get(0).get_index() == 5);
         }
 
         SECTION("throws for rows from the wrong table") {
@@ -723,15 +768,44 @@ TEST_CASE("list") {
             REQUIRE(list.find(target->get(5)) == 5);
         }
 
+        SECTION("returns index in list and not index in table") {
+            r->begin_transaction();
+            list.remove(1);
+            REQUIRE(list.find(target->get(5)) == 4);
+            REQUIRE(list.as_results().index_of(target->get(5)) == 4);
+            r->cancel_transaction();
+        }
+
         SECTION("returns npos for values not in the list") {
             r->begin_transaction();
             list.remove(1);
             REQUIRE(list.find(target->get(1)) == npos);
+            REQUIRE(list.as_results().index_of(target->get(1)) == npos);
             r->cancel_transaction();
         }
 
         SECTION("throws for row in wrong table") {
             REQUIRE_THROWS(list.find(origin->get(0)));
+            REQUIRE_THROWS(list.as_results().index_of(origin->get(0)));
+        }
+    }
+
+    SECTION("find(Query)") {
+        List list(r, lv);
+
+        SECTION("returns index in list for values in the list") {
+            REQUIRE(list.find(std::move(target->where().equal(0, 5))) == 5);
+        }
+
+        SECTION("returns index in list and not index in table") {
+            r->begin_transaction();
+            list.remove(1);
+            REQUIRE(list.find(std::move(target->where().equal(0, 5))) == 4);
+            r->cancel_transaction();
+        }
+
+        SECTION("returns npos for values not in the list") {
+            REQUIRE(list.find(std::move(target->where().equal(0, 11))) == npos);
         }
     }
 
@@ -743,14 +817,14 @@ TEST_CASE("list") {
         SECTION("adds boxed RowExpr") {
             list.add(ctx, util::Any(target->get(5)));
             REQUIRE(list.size() == 11);
-            REQUIRE(list.get_unchecked(10) == 5);
+            REQUIRE(list.get(10).get_index() == 5);
         }
 
         SECTION("adds boxed realm::Object") {
             realm::Object obj(r, list.get_object_schema(), target->get(5));
             list.add(ctx, util::Any(obj));
             REQUIRE(list.size() == 11);
-            REQUIRE(list.get_unchecked(10) == 5);
+            REQUIRE(list.get(10).get_index() == 5);
         }
 
         SECTION("creates new object for dictionary") {

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -514,7 +514,7 @@ TEST_CASE("migration: Automatic") {
             realm->commit_transaction();
 
             realm->update_schema(set_optional(schema, "object", "value", true), 2);
-            for (int64_t i = 0; i < 10; ++i)
+            for (int i = 0; i < 10; ++i)
                 REQUIRE(table->get_int(0, i) == i);
         }
 

--- a/tests/primitive_list.cpp
+++ b/tests/primitive_list.cpp
@@ -335,11 +335,13 @@ TEMPLATE_TEST_CASE("primitive list", ::Int, ::Bool, ::Float, ::Double, ::String,
             REQUIRE_FALSE(results.is_valid());
         }
 
+#if 0 // FIXME: depends on https://github.com/realm/realm-core/pull/2807
         SECTION("close") {
             r->close();
             REQUIRE_FALSE(list.is_valid());
             REQUIRE_FALSE(results.is_valid());
         }
+#endif
 
         SECTION("delete row") {
             table->move_last_over(0);
@@ -362,10 +364,12 @@ TEMPLATE_TEST_CASE("primitive list", ::Int, ::Bool, ::Float, ::Double, ::String,
             REQUIRE_THROWS(list.verify_attached());
         }
 
+#if 0 // FIXME: depends on https://github.com/realm/realm-core/pull/2807
         SECTION("close") {
             r->close();
             REQUIRE_THROWS(list.verify_attached());
         }
+#endif
 
         SECTION("delete row") {
             table->move_last_over(0);
@@ -386,10 +390,12 @@ TEMPLATE_TEST_CASE("primitive list", ::Int, ::Bool, ::Float, ::Double, ::String,
             REQUIRE_THROWS(list.verify_in_transaction());
         }
 
+#if 0 // FIXME: depends on https://github.com/realm/realm-core/pull/2807
         SECTION("close") {
             r->close();
             REQUIRE_THROWS(list.verify_in_transaction());
         }
+#endif
 
         SECTION("delete row") {
             table->move_last_over(0);

--- a/tests/primitive_list.cpp
+++ b/tests/primitive_list.cpp
@@ -116,15 +116,15 @@ struct Date : Base<PropertyType::Date, Timestamp> {
     static Timestamp max() { return Timestamp(1, 1); }
 };
 
-template<typename Base>
-struct BoxedOptional : Base {
-    using Type = util::Optional<typename Base::Type>;
+template<typename BaseT>
+struct BoxedOptional : BaseT {
+    using Type = util::Optional<typename BaseT::Type>;
     using Boxed = Type;
-    static PropertyType property_type() { return Base::property_type()|PropertyType::Nullable; }
+    static PropertyType property_type() { return BaseT::property_type()|PropertyType::Nullable; }
     static std::vector<Type> values()
     {
         std::vector<Type> ret;
-        for (auto v : Base::values())
+        for (auto v : BaseT::values())
             ret.push_back(Type(v));
         ret.push_back(util::none);
         return ret;
@@ -136,13 +136,13 @@ struct BoxedOptional : Base {
     static auto unwrap(Type value, Fn&& fn) { return value ? fn(*value) : fn(null()); }
 };
 
-template<typename Base>
-struct UnboxedOptional : Base {
-    static PropertyType property_type() { return Base::property_type()|PropertyType::Nullable; }
-    static auto values()
+template<typename BaseT>
+struct UnboxedOptional : BaseT {
+    static PropertyType property_type() { return BaseT::property_type()|PropertyType::Nullable; }
+    static auto values() -> decltype(BaseT::values())
     {
-        auto ret = Base::values();
-        ret.push_back(typename Base::Type());
+        auto ret = BaseT::values();
+        ret.push_back(typename BaseT::Type());
         return ret;
     }
 };

--- a/tests/primitive_list.cpp
+++ b/tests/primitive_list.cpp
@@ -189,7 +189,7 @@ struct StringifyingContext {
         return ss.str();
     }
 
-    std::string box(RowExpr row) { return std::to_string(row.get_index()); }
+    std::string box(RowExpr row) { return util::to_string(row.get_index()); }
 };
 
 namespace Catch {

--- a/tests/primitive_list.cpp
+++ b/tests/primitive_list.cpp
@@ -735,6 +735,23 @@ TEMPLATE_TEST_CASE("primitive list", ::Int, ::Bool, ::Float, ::Double, ::String,
             REQUIRE_INDICES(rchange.insertions, 0);
         }
 
+        SECTION("clear list") {
+            auto token = list.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
+                change = c;
+            });
+            auto rtoken = results.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
+                rchange = c;
+            });
+            advance_and_notify(*r);
+
+            r->begin_transaction();
+            list.remove_all();
+            r->commit_transaction();
+            advance_and_notify(*r);
+            REQUIRE(change.deletions.count() == values.size());
+            REQUIRE(rchange.deletions.count() == values.size());
+        }
+
         SECTION("delete containing row") {
             size_t calls = 0;
             auto token = list.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {

--- a/tests/primitive_list.cpp
+++ b/tests/primitive_list.cpp
@@ -1,0 +1,724 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2017 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "catch.hpp"
+
+#include "util/event_loop.hpp"
+#include "util/index_helpers.hpp"
+#include "util/templated_test_case.hpp"
+#include "util/test_file.hpp"
+
+#include "binding_context.hpp"
+#include "list.hpp"
+#include "object.hpp"
+#include "object_schema.hpp"
+#include "property.hpp"
+#include "results.hpp"
+#include "schema.hpp"
+#include "thread_safe_reference.hpp"
+
+#include "impl/realm_coordinator.hpp"
+#include "impl/object_accessor_impl.hpp"
+
+#include <realm/group_shared.hpp>
+#include <realm/link_view.hpp>
+#include <realm/query_expression.hpp>
+#include <realm/version.hpp>
+
+#include <numeric>
+
+using namespace realm;
+
+template<PropertyType prop_type, typename T>
+struct Base {
+    using Type = T;
+    using Wrapped = T;
+    using Boxed = T;
+
+    static PropertyType property_type() { return prop_type; }
+    static std::vector<int64_t> values() { return {3, 1, 2}; }
+    static Wrapped unwrap(T value) { return value; }
+    static util::Any to_any(T value) { return value; }
+
+    static T min() { abort(); }
+    static T max() { abort(); }
+    static T sum() { abort(); }
+    static double average() { abort(); }
+
+    static bool can_sum() { return std::is_arithmetic<T>::value; }
+    static bool can_average() { return std::is_arithmetic<T>::value; }
+    static bool can_minmax() { return std::is_arithmetic<T>::value; }
+};
+
+struct Int : Base<PropertyType::Int, int64_t> {
+    static std::vector<int64_t> values() { return {3, 1, 2}; }
+    static int64_t min() { return 1; }
+    static int64_t max() { return 3; }
+    static int64_t sum() { return 6; }
+    static double average() { return 2.0; }
+};
+
+struct Bool : Base<PropertyType::Bool, bool> {
+    static std::vector<bool> values() { return {true, false}; }
+    static bool can_sum() { return false; }
+    static bool can_average() { return false; }
+    static bool can_minmax() { return false; }
+};
+
+struct Float : Base<PropertyType::Float, float> {
+    static std::vector<float> values() { return {3.3f, 1.1f, 2.2f}; }
+    static float min() { return 1.1f; }
+    static float max() { return 3.3; }
+    static auto sum() { return Approx(6.6f); }
+    static auto average() { return Approx(2.2); }
+};
+
+struct Double : Base<PropertyType::Double, double> {
+    static std::vector<double> values() { return {3.3, 1.1, 2.2}; }
+    static double min() { return 1.1; }
+    static double max() { return 3.3; }
+    static auto sum() { return Approx(6.6); }
+    static auto average() { return Approx(2.2); }
+};
+
+struct String : Base<PropertyType::String, StringData> {
+    using Boxed = std::string;
+    static std::vector<StringData> values() { return {"c", "a", "b"}; }
+    static util::Any to_any(StringData value) { return value ? std::string(value) : util::Any(); }
+};
+
+struct Binary : Base<PropertyType::Data, BinaryData> {
+    using Boxed = std::string;
+    static std::vector<BinaryData> values() { return {BinaryData("a", 1)}; }
+    static util::Any to_any(BinaryData value) { return value ? std::string(value) : util::Any(); }
+};
+
+struct Date : Base<PropertyType::Date, Timestamp> {
+    static std::vector<Timestamp> values() { return {Timestamp(1, 1)}; }
+    static bool can_minmax() { return true; }
+    static Timestamp min() { return Timestamp(1, 1); }
+    static Timestamp max() { return Timestamp(1, 1); }
+};
+
+template<typename Base>
+struct BoxedOptional : Base {
+    using Type = util::Optional<typename Base::Type>;
+    using Boxed = Type;
+    static PropertyType property_type() { return Base::property_type()|PropertyType::Nullable; }
+    static std::vector<Type> values()
+    {
+        std::vector<Type> ret;
+        for (auto v : Base::values())
+            ret.push_back(Type(v));
+        ret.push_back(util::none);
+        return ret;
+    }
+    static auto unwrap(Type value) { return *value; }
+    static util::Any to_any(Type value) { return value ? util::Any(*value) : util::Any(); }
+};
+
+template<typename Base>
+struct UnboxedOptional : Base {
+    static PropertyType property_type() { return Base::property_type()|PropertyType::Nullable; }
+    static auto values()
+    {
+        auto ret = Base::values();
+        ret.push_back(typename Base::Type());
+        return ret;
+    }
+};
+
+template<typename T>
+T get(Mixed) { abort(); }
+
+template<> int64_t get(Mixed m) { return m.get_int(); }
+template<> float get(Mixed m) { return m.get_type() == type_Float ? m.get_float() : m.get_double(); }
+template<> double get(Mixed m) { return m.get_double(); }
+template<> Timestamp get(Mixed m) { return m.get_timestamp(); }
+
+namespace realm {
+template<typename T>
+bool operator==(List const& list, std::vector<T> const& values) {
+    if (list.size() != values.size())
+        return false;
+    for (size_t i = 0; i < values.size(); ++i) {
+        if (list.get<T>(i) != values[i])
+            return false;
+    }
+    return true;
+}
+
+template<typename T>
+bool operator==(Results& results, std::vector<T> const& values) {
+    if (results.size() != values.size())
+        return false;
+    for (size_t i = 0; i < values.size(); ++i) {
+        if (results.get<T>(i) != values[i])
+            return false;
+    }
+    return true;
+}
+}
+
+struct StringifyingContext {
+    template<typename T>
+    std::string box(T value)
+    {
+        std::stringstream ss;
+        ss << value;
+        return ss.str();
+    }
+
+    std::string box(RowExpr row) { return std::to_string(row.get_index()); }
+};
+
+namespace Catch {
+template<>
+struct StringMaker<List> {
+    static std::string convert(List const& list)
+    {
+        std::stringstream ss;
+        auto type = list.get_type();
+        ss << string_for_property_type(type & ~PropertyType::Flags);
+        if (is_nullable(type))
+            ss << "?";
+        ss << "{";
+
+        StringifyingContext ctx;
+        for (size_t i = 0, count = list.size(); i < count; ++i)
+            ss << list.get(ctx, i) << ", ";
+        auto str = ss.str();
+        str.pop_back();
+        str.back() = '}';
+        return str;
+    }
+};
+template<>
+struct StringMaker<Results> {
+    static std::string convert(Results const& r)
+    {
+        auto& results = const_cast<Results&>(r);
+        std::stringstream ss;
+        auto type = results.get_type();
+        ss << string_for_property_type(type & ~PropertyType::Flags);
+        if (is_nullable(type))
+            ss << "?";
+        ss << "{";
+
+        StringifyingContext ctx;
+        for (size_t i = 0, count = results.size(); i < count; ++i)
+            ss << results.get(ctx, i) << ", ";
+        auto str = ss.str();
+        str.pop_back();
+        str.back() = '}';
+        return str;
+    }
+};
+template<>
+struct StringMaker<util::None> {
+    static std::string convert(util::None)
+    {
+        return "[none]";
+    }
+};
+} // namespace Catch
+
+namespace std {
+template<>
+constexpr bool less<void>::operator()<Timestamp&, Timestamp&>(Timestamp& a, Timestamp& b) const
+{
+    if (b.is_null())
+        return false;
+    if (a.is_null())
+        return true;
+    return a < b;
+}
+
+template<>
+constexpr bool greater<void>::operator()<Timestamp&, Timestamp&>(Timestamp& a, Timestamp& b) const
+{
+    if (a.is_null())
+        return false;
+    if (b.is_null())
+        return true;
+    return a > b;
+}
+}
+
+TEMPLATE_TEST_CASE("primitive list", ::Int, ::Bool, ::Float, ::Double, ::String, ::Binary, ::Date,
+                   BoxedOptional<::Int>, BoxedOptional<::Bool>, BoxedOptional<::Float>, BoxedOptional<::Double>,
+                   UnboxedOptional<::String>, UnboxedOptional<::Binary>, UnboxedOptional<::Date>) {
+    auto values = TestType::values();
+    using T = typename TestType::Type;
+    using W = typename TestType::Wrapped;
+    using Boxed = typename TestType::Boxed;
+
+    InMemoryTestFile config;
+    config.automatic_change_notifications = false;
+    config.cache = false;
+    config.schema = Schema{
+        {"object", {
+            {"value", PropertyType::Array|TestType::property_type()}
+        }},
+    };
+    auto r = Realm::get_shared_realm(config);
+
+    auto table = r->read_group().get_table("class_object");
+    r->begin_transaction();
+    table->add_empty_row();
+
+    List list(r, *table, 0, 0);
+    auto results = list.as_results();
+    CppContext ctx(r);
+
+    SECTION("get_realm()") {
+        REQUIRE(list.get_realm() == r);
+        REQUIRE(results.get_realm() == r);
+    }
+
+    SECTION("get_query()") {
+        REQUIRE(list.get_query().count() == 0);
+        REQUIRE(results.get_query().count() == 0);
+        list.add(static_cast<T>(values[0]));
+        REQUIRE(list.get_query().count() == 1);
+        REQUIRE(results.get_query().count() == 1);
+    }
+
+    SECTION("get_origin_row_index()") {
+        REQUIRE(list.get_origin_row_index() == 0);
+        table->insert_empty_row(0);
+        REQUIRE(list.get_origin_row_index() == 1);
+    }
+
+    SECTION("get_type()") {
+        REQUIRE(list.get_type() == TestType::property_type());
+        REQUIRE(results.get_type() == TestType::property_type());
+    }
+
+    SECTION("is_optional()") {
+        REQUIRE_FALSE(list.is_optional());
+    }
+
+    SECTION("is_valid()") {
+        REQUIRE(list.is_valid());
+        REQUIRE(results.is_valid());
+
+        SECTION("invalidate") {
+            r->invalidate();
+            REQUIRE_FALSE(list.is_valid());
+            REQUIRE_FALSE(results.is_valid());
+        }
+
+        SECTION("close") {
+            r->close();
+            REQUIRE_FALSE(list.is_valid());
+            REQUIRE_FALSE(results.is_valid());
+        }
+
+        SECTION("delete row") {
+            table->move_last_over(0);
+            REQUIRE_FALSE(list.is_valid());
+            REQUIRE_FALSE(results.is_valid());
+        }
+
+        SECTION("rollback transaction creating list") {
+            r->cancel_transaction();
+            REQUIRE_FALSE(list.is_valid());
+            REQUIRE_FALSE(results.is_valid());
+        }
+    }
+
+    SECTION("verify_attached()") {
+        REQUIRE_NOTHROW(list.verify_attached());
+
+        SECTION("invalidate") {
+            r->invalidate();
+            REQUIRE_THROWS(list.verify_attached());
+        }
+
+        SECTION("close") {
+            r->close();
+            REQUIRE_THROWS(list.verify_attached());
+        }
+
+        SECTION("delete row") {
+            table->move_last_over(0);
+            REQUIRE_THROWS(list.verify_attached());
+        }
+
+        SECTION("rollback transaction creating list") {
+            r->cancel_transaction();
+            REQUIRE_THROWS(list.verify_attached());
+        }
+    }
+
+    SECTION("verify_in_transaction()") {
+        REQUIRE_NOTHROW(list.verify_in_transaction());
+
+        SECTION("invalidate") {
+            r->invalidate();
+            REQUIRE_THROWS(list.verify_in_transaction());
+        }
+
+        SECTION("close") {
+            r->close();
+            REQUIRE_THROWS(list.verify_in_transaction());
+        }
+
+        SECTION("delete row") {
+            table->move_last_over(0);
+            REQUIRE_THROWS(list.verify_in_transaction());
+        }
+
+        SECTION("end write") {
+            r->commit_transaction();
+            REQUIRE_THROWS(list.verify_in_transaction());
+        }
+    }
+
+    if (!list.is_valid() || !r->is_in_transaction())
+        return;
+
+    for (T value : values)
+        list.add(value);
+
+    SECTION("move()") {
+        if (list.size() < 3)
+            return;
+
+        list.move(1, 2);
+        std::swap(values[1], values[2]);
+        REQUIRE(list == values);
+        REQUIRE(results == values);
+
+        list.move(2, 1);
+        std::swap(values[1], values[2]);
+        REQUIRE(list == values);
+        REQUIRE(results == values);
+
+        list.move(0, 2);
+        std::rotate(values.begin(), values.begin() + 1, values.begin() + 3);
+        REQUIRE(list == values);
+        REQUIRE(results == values);
+
+        list.move(2, 0);
+        std::rotate(values.begin(), values.begin() + 2, values.begin() + 3);
+        REQUIRE(list == values);
+        REQUIRE(results == values);
+    }
+
+    SECTION("remove()") {
+        if (list.size() < 3)
+            return;
+
+        list.remove(1);
+        values.erase(values.begin() + 1);
+        REQUIRE(list == values);
+        REQUIRE(results == values);
+    }
+
+    SECTION("remove_all()") {
+        list.remove_all();
+        REQUIRE(list.size() == 0);
+        REQUIRE(results.size() == 0);
+    }
+
+    SECTION("swap()") {
+        if (list.size() < 3)
+            return;
+
+        list.swap(0, 2);
+        std::swap(values[0], values[2]);
+        REQUIRE(list == values);
+        REQUIRE(results == values);
+    }
+
+    SECTION("delete_all()") {
+        list.delete_all();
+        REQUIRE(list.size() == 0);
+        REQUIRE(results.size() == 0);
+    }
+
+    SECTION("clear()") {
+        results.clear();
+        REQUIRE(list.size() == 0);
+        REQUIRE(results.size() == 0);
+    }
+
+    SECTION("get()") {
+        for (size_t i = 0; i < values.size(); ++i) {
+            CAPTURE(i);
+            REQUIRE(list.get<T>(i) == values[i]);
+            REQUIRE(results.get<T>(i) == values[i]);
+            REQUIRE(any_cast<Boxed>(list.get(ctx, i)) == Boxed(values[i]));
+            REQUIRE(any_cast<Boxed>(results.get(ctx, i)) == Boxed(values[i]));
+        }
+    }
+
+    SECTION("first()") {
+        REQUIRE(*results.first<T>() == values.front());
+        REQUIRE(any_cast<Boxed>(*results.first(ctx)) == Boxed(values.front()));
+        list.remove_all();
+        REQUIRE(results.first<T>() == util::none);
+    }
+
+    SECTION("last()") {
+        REQUIRE(*results.last<T>() == values.back());
+        list.remove_all();
+        REQUIRE(results.last<T>() == util::none);
+    }
+
+    SECTION("set()") {
+        for (size_t i = 0; i < values.size(); ++i) {
+            CAPTURE(i);
+            auto rev = values.size() - i - 1;
+            list.set(i, static_cast<T>(values[rev]));
+            REQUIRE(list.get<T>(i) == values[rev]);
+            REQUIRE(results.get<T>(i) == values[rev]);
+        }
+        for (size_t i = 0; i < values.size(); ++i) {
+            CAPTURE(i);
+            list.set(ctx, i, TestType::to_any(values[i]));
+            REQUIRE(list.get<T>(i) == values[i]);
+            REQUIRE(results.get<T>(i) == values[i]);
+        }
+
+        REQUIRE_THROWS(list.set(list.size(), static_cast<T>(values[0])));
+    }
+
+    SECTION("find()") {
+        // cast to T needed for vector<bool>'s wonky proxy
+        for (size_t i = 0; i < values.size(); ++i) {
+            CAPTURE(i);
+            REQUIRE(list.find(static_cast<T>(values[i])) == i);
+            REQUIRE(results.index_of(static_cast<T>(values[i])) == i);
+
+            REQUIRE(list.find(ctx, TestType::to_any(values[i])) == i);
+            REQUIRE(results.index_of(ctx, TestType::to_any(values[i])) == i);
+        }
+
+        list.remove(0);
+        REQUIRE(list.find(static_cast<T>(values[0])) == npos);
+        REQUIRE(results.index_of(static_cast<T>(values[0])) == npos);
+
+        REQUIRE(list.find(ctx, TestType::to_any(values[0])) == npos);
+        REQUIRE(results.index_of(ctx, TestType::to_any(values[0])) == npos);
+    }
+
+    SECTION("index_of()") {
+        REQUIRE_THROWS(results.index_of(table->get(0)));
+    }
+
+    SECTION("sort()") {
+        auto subtable = table->get_subtable(0, 0);
+
+        auto sorted = list.sort(SortDescriptor(*subtable, {{0}}, {true}));
+        auto sorted2 = list.sort({{"self", true}});
+        std::sort(begin(values), end(values), std::less<>());
+        REQUIRE(sorted == values);
+        REQUIRE(sorted2 == values);
+
+        sorted = list.sort(SortDescriptor(*subtable, {{0}}, {false}));
+        sorted2 = list.sort({{"self", false}});
+        std::sort(begin(values), end(values), std::greater<>());
+        REQUIRE(sorted == values);
+        REQUIRE(sorted2 == values);
+    }
+
+    SECTION("filter()") {
+        T v = values.front();
+        values.erase(values.begin());
+
+        Results filtered = list.filter(table->get_subtable(0, 0)->column<W>(0) != TestType::unwrap(v));
+        REQUIRE(filtered == values);
+
+        filtered = list.filter(table->get_subtable(0, 0)->column<W>(0) == TestType::unwrap(v));
+        REQUIRE(filtered.size() == 1);
+        REQUIRE(*filtered.first<T>() == v);
+    }
+
+    SECTION("min()") {
+        if (!TestType::can_minmax()) {
+            REQUIRE_THROWS(list.min());
+            REQUIRE_THROWS(results.min());
+            return;
+        }
+
+        REQUIRE(get<W>(*list.min()) == TestType::min());
+        REQUIRE(get<W>(*results.min()) == TestType::min());
+        list.remove_all();
+        REQUIRE(list.min() == util::none);
+        REQUIRE(results.min() == util::none);
+    }
+
+    SECTION("max()") {
+        if (!TestType::can_minmax()) {
+            REQUIRE_THROWS(list.max());
+            REQUIRE_THROWS(results.max());
+            return;
+        }
+
+        REQUIRE(get<W>(*list.max()) == TestType::max());
+        REQUIRE(get<W>(*results.max()) == TestType::max());
+        list.remove_all();
+        REQUIRE(list.max() == util::none);
+        REQUIRE(results.max() == util::none);
+    }
+
+    SECTION("sum()") {
+        if (!TestType::can_sum()) {
+            REQUIRE_THROWS(list.sum());
+            return;
+        }
+
+        REQUIRE(get<W>(list.sum()) == TestType::sum());
+        REQUIRE(get<W>(*results.sum()) == TestType::sum());
+        list.remove_all();
+        REQUIRE(get<W>(list.sum()) == W{});
+        REQUIRE(get<W>(*results.sum()) == W{});
+    }
+
+    SECTION("average()") {
+        if (!TestType::can_average()) {
+            REQUIRE_THROWS(list.average());
+            return;
+        }
+
+        REQUIRE(*list.average() == TestType::average());
+        REQUIRE(*results.average() == TestType::average());
+        list.remove_all();
+        REQUIRE(list.average() == util::none);
+        REQUIRE(results.average() == util::none);
+    }
+
+    SECTION("operator==()") {
+        table->add_empty_row();
+        REQUIRE(list == List(r, *table, 0, 0));
+        REQUIRE_FALSE(list == List(r, *table, 0, 1));
+    }
+
+    SECTION("hash") {
+        table->add_empty_row();
+        std::hash<List> h;
+        REQUIRE(h(list) == h(List(r, *table, 0, 0)));
+        REQUIRE_FALSE(h(list) == h(List(r, *table, 0, 1)));
+    }
+
+    SECTION("handover") {
+        r->commit_transaction();
+
+        auto handover = r->obtain_thread_safe_reference(list);
+        auto list2 = r->resolve_thread_safe_reference(std::move(handover));
+        REQUIRE(list == list2);
+
+        auto results_handover = r->obtain_thread_safe_reference(results);
+        auto results2 = r->resolve_thread_safe_reference(std::move(results_handover));
+        REQUIRE(results2 == values);
+    }
+
+    SECTION("notifications") {
+        r->commit_transaction();
+
+        CollectionChangeSet change, rchange;
+        SECTION("add value to list") {
+            auto token = list.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
+                change = c;
+            });
+            auto rtoken = results.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
+                rchange = c;
+            });
+            advance_and_notify(*r);
+
+            r->begin_transaction();
+            list.insert(0, static_cast<T>(values[0]));
+            r->commit_transaction();
+            advance_and_notify(*r);
+            REQUIRE_INDICES(change.insertions, 0);
+            REQUIRE_INDICES(rchange.insertions, 0);
+        }
+
+        SECTION("delete containing row") {
+            size_t calls = 0;
+            auto token = list.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
+                change = c;
+                ++calls;
+            });
+            auto rtoken = results.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
+                rchange = c;
+                ++calls;
+            });
+            advance_and_notify(*r);
+            REQUIRE(calls == 2);
+
+            r->begin_transaction();
+            table->move_last_over(0);
+            r->commit_transaction();
+            advance_and_notify(*r);
+            REQUIRE(calls == 4);
+            REQUIRE(change.deletions.count() == values.size());
+            REQUIRE(rchange.deletions.count() == values.size());
+
+            r->begin_transaction();
+            table->add_empty_row();
+            r->commit_transaction();
+            advance_and_notify(*r);
+            REQUIRE(calls == 4);
+        }
+    }
+
+#if REALM_ENABLE_SYNC && REALM_HAVE_SYNC_STABLE_IDS
+    SECTION("sync compatibility") {
+        if (!util::EventLoop::has_implementation())
+            return;
+
+        SyncServer server;
+        SyncTestFile sync_config(server, "shared");
+        sync_config.schema = config.schema;
+        sync_config.schema_version = 0;
+
+        {
+            auto r = Realm::get_shared_realm(sync_config);
+            r->begin_transaction();
+
+            CppContext ctx(r);
+            auto obj = Object::create(ctx, r, *r->schema().find("object"), util::Any(AnyDict{}));
+            auto list = any_cast<List>(obj.get_property_value<util::Any>(ctx, "value"));
+            list.add(static_cast<T>(values[0]));
+
+            r->commit_transaction();
+            wait_for_upload(*r);
+        }
+
+        util::File::remove(sync_config.path);
+
+        {
+            auto r = Realm::get_shared_realm(sync_config);
+            auto table = r->read_group().get_table("class_object");
+
+            util::EventLoop::main().run_until([&] {
+                return table->size() == 1;
+            });
+
+            CppContext ctx(r);
+            Object obj(r, "object", 0);
+            auto list = any_cast<List>(obj.get_property_value<util::Any>(ctx, "value"));
+            REQUIRE(list.get<T>(0) == values[0]);
+        }
+    }
+#endif
+}

--- a/tests/primitive_list.cpp
+++ b/tests/primitive_list.cpp
@@ -310,10 +310,6 @@ TEMPLATE_TEST_CASE("primitive list", ::Int, ::Bool, ::Float, ::Double, ::String,
         REQUIRE(results.get_type() == TestType::property_type());
     }
 
-    SECTION("is_optional()") {
-        REQUIRE_FALSE(list.is_optional());
-    }
-
     SECTION("is_valid()") {
         REQUIRE(list.is_valid());
         REQUIRE(results.is_valid());

--- a/tests/primitive_list.cpp
+++ b/tests/primitive_list.cpp
@@ -245,7 +245,7 @@ struct StringMaker<util::None> {
 
 namespace std {
 template<>
-constexpr bool less<void>::operator()<Timestamp&, Timestamp&>(Timestamp& a, Timestamp& b) const
+bool less<void>::operator()<Timestamp&, Timestamp&>(Timestamp& a, Timestamp& b) const
 {
     if (b.is_null())
         return false;
@@ -255,7 +255,7 @@ constexpr bool less<void>::operator()<Timestamp&, Timestamp&>(Timestamp& a, Time
 }
 
 template<>
-constexpr bool greater<void>::operator()<Timestamp&, Timestamp&>(Timestamp& a, Timestamp& b) const
+bool greater<void>::operator()<Timestamp&, Timestamp&>(Timestamp& a, Timestamp& b) const
 {
     if (a.is_null())
         return false;

--- a/tests/primitive_list.cpp
+++ b/tests/primitive_list.cpp
@@ -51,7 +51,6 @@ struct Base {
     using Boxed = T;
 
     static PropertyType property_type() { return prop_type; }
-    static std::vector<int64_t> values() { return {3, 1, 2}; }
     static util::Any to_any(T value) { return value; }
 
     template<typename Fn>

--- a/tests/primitive_list.cpp
+++ b/tests/primitive_list.cpp
@@ -559,6 +559,7 @@ TEMPLATE_TEST_CASE("primitive list", ::Int, ::Bool, ::Float, ::Double, ::String,
         }
     }
 
+#if REALM_VERSION_MAJOR > 2
     SECTION("filtered index_of()") {
         REQUIRE_THROWS(results.index_of(table->get(0)));
         auto q = TestType::unwrap(values[0], [&] (auto v) { return table->get_subtable(0, 0)->column<W>(0) != v; });
@@ -568,6 +569,7 @@ TEMPLATE_TEST_CASE("primitive list", ::Int, ::Bool, ::Float, ::Double, ::String,
             REQUIRE(filtered.index_of(static_cast<T>(values[i])) == i - 1);
         }
     }
+#endif
 
     SECTION("sort()") {
         auto subtable = table->get_subtable(0, 0);

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -2759,9 +2759,9 @@ TEMPLATE_TEST_CASE("results: aggregate", ResultsFromTable, ResultsFromQuery, Res
         }
 
         SECTION("average") {
-            REQUIRE(results.average(0)->get_double() == 1.0);
-            REQUIRE(results.average(1)->get_double() == 1.0);
-            REQUIRE(results.average(2)->get_double() == 1.0);
+            REQUIRE(results.average(0) == 1.0);
+            REQUIRE(results.average(1) == 1.0);
+            REQUIRE(results.average(2) == 1.0);
             REQUIRE_THROWS_AS(results.average(3), Results::UnsupportedColumnTypeException);
         }
 

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -1062,15 +1062,7 @@ TEST_CASE("notifications: sync") {
         // Start the server and wait for the Realm to be uploaded so that sync
         // makes some writes to the Realm and bumps the version
         server.start();
-        std::condition_variable cv;
-        std::mutex wait_mutex;
-        std::atomic<bool> wait_flag(false);
-        SyncManager::shared().get_session(config.path, *config.sync_config)->wait_for_upload_completion([&](auto) {
-            wait_flag = true;
-            cv.notify_one();
-        });
-        std::unique_lock<std::mutex> lock(wait_mutex);
-        cv.wait(lock, [&]() { return wait_flag == true; });
+        wait_for_upload(*r);
 
         // Make sure that the notifications still get delivered rather than
         // waiting forever due to that we don't get a commit notification from
@@ -1851,7 +1843,7 @@ TEST_CASE("results: error messages") {
     r->commit_transaction();
 
     SECTION("out of bounds access") {
-        REQUIRE_THROWS_WITH(results.get(5), "Requested index 5 greater than max 1");
+        REQUIRE_THROWS_WITH(results.get(5), "Requested index 5 greater than max 0");
     }
 
     SECTION("unsupported aggregate operation") {

--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -19,6 +19,7 @@
 #include "catch.hpp"
 
 #include "object_schema.hpp"
+#include "object_store.hpp"
 #include "property.hpp"
 #include "schema.hpp"
 #include "util/format.hpp"
@@ -122,7 +123,7 @@ TEST_CASE("ObjectSchema") {
 
         auto add_list = [](TableRef table, DataType type, StringData name, bool nullable) {
             size_t col = table->add_column(type_Table, name);
-            table->get_subdescriptor(col)->add_column(type, "!ARRAY_VALUE", nullptr, nullable);
+            table->get_subdescriptor(col)->add_column(type, ObjectStore::ArrayColumnName, nullptr, nullable);
         };
 
         add_list(table, type_Int, "int array", false);

--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -116,8 +116,29 @@ TEST_CASE("ObjectSchema") {
         table->add_column(type_Binary, "data?", true);
         table->add_column(type_Timestamp, "date?", true);
 
-        size_t col = table->add_column(type_Table, "subtable");
+        table->add_column(type_Table, "subtable 1");
+        size_t col = table->add_column(type_Table, "subtable 2");
         table->get_subdescriptor(col)->add_column(type_Int, "value");
+
+        auto add_list = [](TableRef table, DataType type, StringData name, bool nullable) {
+            size_t col = table->add_column(type_Table, name);
+            table->get_subdescriptor(col)->add_column(type, "!ARRAY_VALUE", nullptr, nullable);
+        };
+
+        add_list(table, type_Int, "int array", false);
+        add_list(table, type_Bool, "bool array", false);
+        add_list(table, type_Float, "float array", false);
+        add_list(table, type_Double, "double array", false);
+        add_list(table, type_String, "string array", false);
+        add_list(table, type_Binary, "data array", false);
+        add_list(table, type_Timestamp, "date array", false);
+        add_list(table, type_Int, "int? array", true);
+        add_list(table, type_Bool, "bool? array", true);
+        add_list(table, type_Float, "float? array", true);
+        add_list(table, type_Double, "double? array", true);
+        add_list(table, type_String, "string? array", true);
+        add_list(table, type_Binary, "data? array", true);
+        add_list(table, type_Timestamp, "date? array", true);
 
         size_t indexed_start = table->get_column_count();
         table->add_column(type_Int, "indexed int");
@@ -136,8 +157,8 @@ TEST_CASE("ObjectSchema") {
         ObjectSchema os(g, "table");
 
 #define REQUIRE_PROPERTY(name, type, ...) do { \
-    auto prop = os.property_for_name(name); \
-    REQUIRE(prop); \
+    Property* prop; \
+    REQUIRE((prop = os.property_for_name(name))); \
     REQUIRE((*prop == Property{name, PropertyType::type, __VA_ARGS__})); \
     REQUIRE(prop->table_column == expected_col++); \
 } while (0)
@@ -146,7 +167,6 @@ TEST_CASE("ObjectSchema") {
 
         REQUIRE(os.property_for_name("nonexistent property") == nullptr);
 
-        // bools are (primary, indexed, nullable)
         REQUIRE_PROPERTY("pk", Int, Property::IsPrimary{true});
 
         REQUIRE_PROPERTY("int", Int);
@@ -169,8 +189,24 @@ TEST_CASE("ObjectSchema") {
         REQUIRE_PROPERTY("date?", Date|PropertyType::Nullable);
 
         // Unsupported column type should be skipped entirely
-        REQUIRE(os.property_for_name("subtable") == nullptr);
-        ++expected_col;
+        REQUIRE(os.property_for_name("subtable 1") == nullptr);
+        REQUIRE(os.property_for_name("subtable 2") == nullptr);
+        expected_col += 2;
+
+        REQUIRE_PROPERTY("int array", Int|PropertyType::Array);
+        REQUIRE_PROPERTY("bool array", Bool|PropertyType::Array);
+        REQUIRE_PROPERTY("float array", Float|PropertyType::Array);
+        REQUIRE_PROPERTY("double array", Double|PropertyType::Array);
+        REQUIRE_PROPERTY("string array", String|PropertyType::Array);
+        REQUIRE_PROPERTY("data array", Data|PropertyType::Array);
+        REQUIRE_PROPERTY("date array", Date|PropertyType::Array);
+        REQUIRE_PROPERTY("int? array", Int|PropertyType::Array|PropertyType::Nullable);
+        REQUIRE_PROPERTY("bool? array", Bool|PropertyType::Array|PropertyType::Nullable);
+        REQUIRE_PROPERTY("float? array", Float|PropertyType::Array|PropertyType::Nullable);
+        REQUIRE_PROPERTY("double? array", Double|PropertyType::Array|PropertyType::Nullable);
+        REQUIRE_PROPERTY("string? array", String|PropertyType::Array|PropertyType::Nullable);
+        REQUIRE_PROPERTY("data? array", Data|PropertyType::Array|PropertyType::Nullable);
+        REQUIRE_PROPERTY("date? array", Date|PropertyType::Array|PropertyType::Nullable);
 
         REQUIRE_PROPERTY("indexed int", Int, Property::IsPrimary{false}, Property::IsIndexed{true});
         REQUIRE_PROPERTY("indexed bool", Bool, Property::IsPrimary{false}, Property::IsIndexed{true});
@@ -469,15 +505,6 @@ TEST_CASE("Schema") {
                 }}
             };
             REQUIRE_NOTHROW(schema.validate());
-        }
-
-        SECTION("rejects non-object arrays") {
-            Schema schema = {
-                {"object", {
-                    {"int", PropertyType::Int|PropertyType::Array},
-                }}
-            };
-            REQUIRE_THROWS_CONTAINING(schema.validate(), "Property 'object.int' has unsupported type 'array<int>'");
         }
     }
 

--- a/tests/sync/session/progress_notifications.cpp
+++ b/tests/sync/session/progress_notifications.cpp
@@ -46,7 +46,6 @@ TEST_CASE("progress notification", "[sync]") {
 
     const std::string dummy_auth_url = "https://realm.example.org";
 
-    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
     // Disable file-related functionality and metadata functionality for testing purposes.
     SyncManager::shared().configure_file_system(tmp_dir(), SyncManager::MetadataMode::NoMetadata);

--- a/tests/sync/session/session.cpp
+++ b/tests/sync/session/session.cpp
@@ -42,7 +42,6 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
     if (!EventLoop::has_implementation())
         return;
 
-    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
     const std::string dummy_auth_url = "https://realm.example.org";
     SyncManager::shared().configure_file_system(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
@@ -187,7 +186,6 @@ TEST_CASE("sync: log-in", "[sync]") {
     if (!EventLoop::has_implementation())
         return;
 
-    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
     const std::string dummy_auth_url = "https://realm.example.org";
     // Disable file-related functionality and metadata functionality for testing purposes.
@@ -227,7 +225,6 @@ TEST_CASE("sync: token refreshing", "[sync]") {
     if (!EventLoop::has_implementation())
         return;
 
-    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
     const std::string dummy_auth_url = "https://realm.example.org";
     // Disable file-related functionality and metadata functionality for testing purposes.
@@ -273,7 +270,6 @@ TEST_CASE("sync: token refreshing", "[sync]") {
 
 TEST_CASE("SyncSession: close() API", "[sync]") {
     using PublicState = realm::SyncSession::PublicState;
-    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
 
     auto user = SyncManager::shared().get_user({ "close-api-tests-user", "https://realm.example.org" }, "not_a_real_token");
@@ -326,7 +322,6 @@ TEST_CASE("SyncSession: close() API", "[sync]") {
 
 TEST_CASE("sync: error handling", "[sync]") {
     using ProtocolError = realm::sync::ProtocolError;
-    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
     SyncManager::shared().configure_file_system(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
 
@@ -406,7 +401,6 @@ TEST_CASE("sync: stop policy behavior", "[sync]") {
     if (!EventLoop::has_implementation())
         return;
 
-    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     // Server is initially stopped so we can control when the session exits the dying state.
     SyncServer server(false);
     auto schema = Schema{
@@ -518,7 +512,6 @@ TEST_CASE("sync: encrypt local realm file", "[sync]") {
     if (!EventLoop::has_implementation())
         return;
 
-    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
     // Disable file-related functionality and metadata functionality for testing purposes.
     SyncManager::shared().configure_file_system(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
@@ -579,7 +572,6 @@ TEST_CASE("sync: non-synced metadata table doesn't result in non-additive schema
     if (!EventLoop::has_implementation())
         return;
 
-    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
     // Disable file-related functionality and metadata functionality for testing purposes.
     SyncManager::shared().configure_file_system(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
@@ -588,18 +580,6 @@ TEST_CASE("sync: non-synced metadata table doesn't result in non-additive schema
         auto& user = *realm.config().sync_config->user;
         REQUIRE(user.state() != SyncUser::State::Error);
         return user.session_for_on_disk_path(realm.config().path);
-    };
-
-    auto wait_for_upload_completion = [=](Realm& realm) {
-        std::atomic<bool> complete{false};
-        session_for_realm(realm)->wait_for_upload_completion([&](std::error_code) { complete = true; });
-        EventLoop::main().run_until([&] { return complete == true; });
-    };
-
-    auto wait_for_download_completion = [=](Realm& realm) {
-        std::atomic<bool> complete{false};
-        session_for_realm(realm)->wait_for_download_completion([&](std::error_code) { complete = true; });
-        EventLoop::main().run_until([&] { return complete == true; });
     };
 
     // Create a synced Realm containing a class with two properties.
@@ -614,7 +594,7 @@ TEST_CASE("sync: non-synced metadata table doesn't result in non-additive schema
         };
 
         auto realm1 = Realm::get_shared_realm(config1);
-        wait_for_upload_completion(*realm1);
+        wait_for_upload(*realm1);
     }
 
     // Download the existing Realm into a second local file without specifying a schema,
@@ -623,7 +603,7 @@ TEST_CASE("sync: non-synced metadata table doesn't result in non-additive schema
     config2.schema_version = 1;
     {
         auto realm2 = Realm::get_shared_realm(config2);
-        wait_for_download_completion(*realm2);
+        wait_for_download(*realm2);
     }
 
     // Open the just-downloaded Realm while specifying a schema that contains a class with
@@ -649,7 +629,6 @@ TEST_CASE("sync: stable IDs", "[sync]") {
     if (!EventLoop::has_implementation())
         return;
 
-    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
     // Disable file-related functionality and metadata functionality for testing purposes.
     SyncManager::shared().configure_file_system(tmp_dir(), SyncManager::MetadataMode::NoMetadata);

--- a/tests/transaction_log_parsing.cpp
+++ b/tests/transaction_log_parsing.cpp
@@ -2127,6 +2127,8 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
 
         // ----------------------------------------------------------------------
 
+#if REALM_VERSION_MAJOR > 2
+
         SECTION("int array: add()") {
             auto changes = observe({r}, [&] {
                 tr->add_empty_row();
@@ -2341,6 +2343,7 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             });
             REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::SetAll, {}}));
         }
+#endif // REALM_VERSION_MAJOR > 2
     }
 }
 

--- a/tests/transaction_log_parsing.cpp
+++ b/tests/transaction_log_parsing.cpp
@@ -127,6 +127,102 @@ private:
     }
 };
 
+struct ArrayChange {
+    BindingContext::ColumnInfo::Kind kind;
+    IndexSet indices;
+};
+
+static bool operator==(ArrayChange const& a, ArrayChange const& b)
+{
+    return a.kind == b.kind
+        && std::equal(a.indices.as_indexes().begin(), a.indices.as_indexes().end(),
+                      b.indices.as_indexes().begin(), b.indices.as_indexes().end());
+}
+
+namespace Catch {
+template<>
+struct StringMaker<ArrayChange> {
+    static std::string convert(ArrayChange const& c)
+    {
+        std::stringstream ss;
+        switch (c.kind) {
+            case BindingContext::ColumnInfo::Kind::Insert: ss << "Insert{"; break;
+            case BindingContext::ColumnInfo::Kind::Remove: ss << "Remove{"; break;
+            case BindingContext::ColumnInfo::Kind::Set: ss << "Set{"; break;
+            case BindingContext::ColumnInfo::Kind::SetAll: return "SetAll";
+            case BindingContext::ColumnInfo::Kind::None: return "None";
+        }
+        for (auto& range : c.indices)
+            ss << range.first << "-" << range.second << ", ";
+        auto str = ss.str();
+        str.pop_back();
+        str.back() = '}';
+        return str;
+    }
+};
+} // namespace Catch
+
+class KVOContext : public BindingContext {
+public:
+    KVOContext(std::initializer_list<Row> rows)
+    {
+        m_result.reserve(rows.size());
+        for (auto& row : rows) {
+            m_result.push_back(ObserverState{row.get_table()->get_index_in_group(),
+                row.get_index(), (void *)(uintptr_t)m_result.size()});
+        }
+    }
+
+    bool modified(size_t index, size_t col) const noexcept
+    {
+        auto it = std::find_if(begin(m_result), end(m_result),
+                               [=](auto&& change) { return (void *)(uintptr_t)index == change.info; });
+        if (it == m_result.end() || col >= it->changes.size())
+            return false;
+        return it->changes[col].kind != BindingContext::ColumnInfo::Kind::None;
+    }
+
+    bool invalidated(size_t index) const noexcept
+    {
+        return std::find(begin(m_invalidated), end(m_invalidated), (void *)(uintptr_t)index) != end(m_invalidated);
+    }
+
+
+    ArrayChange array_change(size_t index, size_t col) const noexcept
+    {
+        auto& changes = m_result[index].changes;
+        if (changes.size() <= col)
+            return {ColumnInfo::Kind::None, {}};
+        auto& column = changes[col];
+        return {column.kind, column.indices};
+    }
+
+    size_t initial_column_index(size_t index, size_t col) const noexcept
+    {
+        auto it = std::find_if(begin(m_result), end(m_result),
+                               [=](auto&& change) { return (void *)(uintptr_t)index == change.info; });
+        if (it == m_result.end() || col >= it->changes.size())
+            return npos;
+        return it->changes[col].initial_column_index;
+    }
+
+private:
+    std::vector<ObserverState> m_result;
+    std::vector<void*> m_invalidated;
+
+    std::vector<ObserverState> get_observed_rows() override
+    {
+        return m_result;
+    }
+
+    void did_change(std::vector<ObserverState> const& observers,
+                    std::vector<void*> const& invalidated, bool) override
+    {
+        m_invalidated = invalidated;
+        m_result = observers;
+    }
+};
+
 TEST_CASE("Transaction log parsing: schema change validation") {
     InMemoryTestFile config;
     config.automatic_change_notifications = false;
@@ -1258,7 +1354,8 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
             {"origin", {
                 {"pk", PropertyType::Int, Property::IsPrimary{true}},
                 {"link", PropertyType::Object|PropertyType::Nullable, "target"},
-                {"array", PropertyType::Array|PropertyType::Object, "target"}
+                {"array", PropertyType::Array|PropertyType::Object, "target"},
+                {"int array", PropertyType::Array|PropertyType::Int},
             }},
             {"origin 2", {
                 {"pk", PropertyType::Int, Property::IsPrimary{true}},
@@ -1299,85 +1396,45 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
         LinkViewRef lv2 = origin->get_linklist(2, 1);
         lv2->add(0);
 
+        TableRef tr = origin->get_subtable(3, 0);
+        tr->add_empty_row(10);
+        for (int i = 0; i < 10; ++i)
+            tr->set_int(0, i, i);
+        TableRef tr2 = origin->get_subtable(3, 1);
+        tr2->add_empty_row(10);
+
         realm->read_group().get_table("class_origin 2")->add_empty_row();
 
         realm->commit_transaction();
 
-        class Context : public BindingContext {
-        public:
-            Context(std::initializer_list<Row> rows)
-            {
-                m_result.reserve(rows.size());
-                for (auto& row : rows) {
-                    m_result.push_back(ObserverState{row.get_table()->get_index_in_group(), row.get_index(),
-                        (void *)(uintptr_t)m_result.size()});
-                }
-            }
-
-            bool modified(size_t index, size_t col) const noexcept
-            {
-                auto it = std::find_if(begin(m_result), end(m_result),
-                                       [=](auto&& change) { return (void *)(uintptr_t)index == change.info; });
-                if (it == m_result.end() || col >= it->changes.size())
-                    return false;
-                return it->changes[col].kind != BindingContext::ColumnInfo::Kind::None;
-            }
-
-            bool invalidated(size_t index) const noexcept
-            {
-                return std::find(begin(m_invalidated), end(m_invalidated), (void *)(uintptr_t)index) != end(m_invalidated);
-            }
-
-            bool has_array_change(size_t index, size_t col, ColumnInfo::Kind kind, IndexSet values) const noexcept
-            {
-                auto& changes = m_result[index].changes;
-                if (changes.size() <= col)
-                    return kind == ColumnInfo::Kind::None;
-                auto& column = changes[col];
-                return column.kind == kind && std::equal(column.indices.as_indexes().begin(), column.indices.as_indexes().end(),
-                                                         values.as_indexes().begin(), values.as_indexes().end());
-            }
-
-            size_t initial_column_index(size_t index, size_t col) const noexcept
-            {
-                auto it = std::find_if(begin(m_result), end(m_result),
-                                       [=](auto&& change) { return (void *)(uintptr_t)index == change.info; });
-                if (it == m_result.end() || col >= it->changes.size())
-                    return npos;
-                return it->changes[col].initial_column_index;
-            }
-
-        private:
-            std::vector<ObserverState> m_result;
-            std::vector<void*> m_invalidated;
-
-            std::vector<ObserverState> get_observed_rows() override
-            {
-                return m_result;
-            }
-
-            void did_change(std::vector<ObserverState> const& observers,
-                            std::vector<void*> const& invalidated, bool) override
-            {
-                m_invalidated = invalidated;
-                m_result = observers;
-            }
-        };
-
         auto observe = [&](std::initializer_list<Row> rows, auto&& fn) {
-            auto history = make_in_realm_history(config.path);
-            auto sg = std::make_unique<SharedGroup>(*history, config.options());
-            auto& group = sg->begin_read();
+            auto realm2 = Realm::get_shared_realm(config);
+            auto& group = realm2->read_group();
 
-            Context observer(rows);
-            observer.realm = realm;
+            KVOContext observer(rows);
+            observer.realm = realm2;
+            realm2->m_binding_context.reset(&observer);
 
             realm->begin_transaction();
             fn();
             realm->commit_transaction();
 
-            _impl::NotifierPackage notifiers;
-            _impl::transaction::advance(sg, &observer, notifiers);
+            realm2->refresh();
+            realm2->m_binding_context.release();
+
+            return observer;
+        };
+
+        auto observe_rollback = [&](std::initializer_list<Row> rows, auto&& fn) {
+            KVOContext observer(rows);
+            observer.realm = realm;
+            realm->m_binding_context.reset(&observer);
+
+            realm->begin_transaction();
+            fn();
+            realm->cancel_transaction();
+
+            realm->m_binding_context.release();
             return observer;
         };
 
@@ -1795,104 +1852,192 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
         }
 
         using Kind = BindingContext::ColumnInfo::Kind;
+        Row r = origin->get(0);
         SECTION("array: add()") {
-            Row r = origin->get(0);
             auto changes = observe({r}, [&] {
                 lv->add(0);
             });
-            REQUIRE(changes.has_array_change(0, 2, Kind::Insert, {10}));
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Insert, {10}}));
         }
 
         SECTION("array: insert()") {
-            Row r = origin->get(0);
             auto changes = observe({r}, [&] {
                 lv->insert(4, 0);
                 lv->insert(2, 0);
                 lv->insert(8, 0);
             });
-            REQUIRE(changes.has_array_change(0, 2, Kind::Insert, {2, 5, 8}));
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Insert, {2, 5, 8}}));
         }
 
         SECTION("array: remove()") {
-            Row r = origin->get(0);
             auto changes = observe({r}, [&] {
                 lv->remove(0);
                 lv->remove(2);
             });
-            REQUIRE(changes.has_array_change(0, 2, Kind::Remove, {0, 3}));
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Remove, {0, 3}}));
         }
 
         SECTION("array: set()") {
-            Row r = origin->get(0);
             auto changes = observe({r}, [&] {
                 lv->set(0, 3);
                 lv->set(2, 3);
             });
-            REQUIRE(changes.has_array_change(0, 2, Kind::Set, {0, 2}));
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Set, {0, 2}}));
         }
 
         SECTION("array: move()") {
-            Row r = origin->get(0);
-            auto changes = observe({r}, [&] {
-                lv->move(5, 3);
-            });
-            REQUIRE(changes.has_array_change(0, 2, Kind::Set, {3, 4, 5}));
+            SECTION("swap forward") {
+                auto changes = observe({r}, [&] {
+                    lv->move(3, 4);
+                });
+                REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Set, {3, 4}}));
+            }
+
+            SECTION("swap backwards") {
+                auto changes = observe({r}, [&] {
+                    lv->move(4, 3);
+                });
+                REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Set, {3, 4}}));
+            }
+
+            SECTION("move fowards") {
+                auto changes = observe({r}, [&] {
+                    lv->move(3, 5);
+                });
+                REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Set, {3, 4, 5}}));
+            }
+
+            SECTION("move backwards") {
+                auto changes = observe({r}, [&] {
+                    lv->move(5, 3);
+                });
+                REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Set, {3, 4, 5}}));
+            }
+
+            SECTION("multiple moves collapsing to nothing") {
+                auto changes = observe({r}, [&] {
+                    lv->move(3, 4);
+                    lv->move(4, 5);
+                    lv->move(5, 3);
+                });
+                REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::None, {}}));
+            }
+
+            SECTION("multiple moves") {
+                auto changes = observe({r}, [&] {
+                    lv->move(3, 6);
+                    lv->move(6, 4);
+                });
+                REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Set, {3, 4}}));
+
+                changes = observe({r}, [&] {
+                    lv->move(3, 6);
+                    lv->move(6, 0);
+                });
+                REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Set, {0, 1, 2, 3}}));
+
+                changes = observe({r}, [&] {
+                    lv->move(9, 0);
+                    lv->move(1, 7);
+                });
+                REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Set, {0, 7, 8, 9}}));
+            }
         }
 
         SECTION("array: swap()") {
-            Row r = origin->get(0);
             auto changes = observe({r}, [&] {
                 lv->swap(5, 3);
             });
-            REQUIRE(changes.has_array_change(0, 2, Kind::Set, {3, 5}));
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Set, {3, 5}}));
         }
 
         SECTION("array: clear()") {
-            Row r = origin->get(0);
             auto changes = observe({r}, [&] {
                 lv->clear();
             });
-            REQUIRE(changes.has_array_change(0, 2, Kind::Remove, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Remove, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}));
         }
 
         SECTION("array: clear() after add()") {
-            Row r = origin->get(0);
             auto changes = observe({r}, [&] {
                 lv->add(0);
                 lv->clear();
             });
-            REQUIRE(changes.has_array_change(0, 2, Kind::Remove, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Remove, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}));
         }
 
         SECTION("array: clear() after set()") {
-            Row r = origin->get(0);
             auto changes = observe({r}, [&] {
                 lv->set(5, 3);
                 lv->clear();
             });
-            REQUIRE(changes.has_array_change(0, 2, Kind::Remove, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Remove, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}));
         }
 
         SECTION("array: clear() after remove()") {
-            Row r = origin->get(0);
             auto changes = observe({r}, [&] {
                 lv->remove(2);
                 lv->clear();
             });
-            REQUIRE(changes.has_array_change(0, 2, Kind::Remove, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}));
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Remove, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}));
+        }
+
+        SECTION("array: rollback clear()") {
+            auto changes = observe_rollback({r}, [&] {
+                lv->clear();
+            });
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Insert, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}));
+        }
+
+        SECTION("array: rollback clear() after add()") {
+            auto changes = observe_rollback({r}, [&] {
+                lv->add(0);
+                lv->clear();
+            });
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Insert, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}));
+        }
+
+        SECTION("array: rollback clear() after set()") {
+            auto changes = observe_rollback({r}, [&] {
+                lv->set(5, 3);
+                lv->clear();
+            });
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Insert, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}));
+        }
+
+        SECTION("array: rollback clear() after remove()") {
+            auto changes = observe_rollback({r}, [&] {
+                lv->remove(2);
+                lv->clear();
+            });
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Insert, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}));
+        }
+
+        SECTION("array: rollback add after clear()") {
+            auto changes = observe_rollback({r}, [&] {
+                lv->clear();
+                lv->add(0);
+            });
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::SetAll, {}}));
         }
 
         SECTION("array: multiple change kinds") {
-            Row r = origin->get(0);
             auto changes = observe({r}, [&] {
                 lv->add(0);
                 lv->remove(0);
             });
-            REQUIRE(changes.has_array_change(0, 2, Kind::SetAll, {}));
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::SetAll, {}}));
+        }
+
+        SECTION("array: modify newly inserted row") {
+            auto changes = observe({r}, [&] {
+                lv->add(0);
+                lv->set(lv->size() - 1, 1);
+            });
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Insert, {10}}));
         }
 
         SECTION("array: modifying different array does not produce changes") {
-            Row r = origin->get(0);
             auto changes = observe({r}, [&] {
                 lv2->add(0);
             });
@@ -1900,7 +2045,6 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
         }
 
         SECTION("array: modifying different table does not produce changes") {
-            Row r = origin->get(0);
             auto changes = observe({r}, [&] {
                 realm->read_group().get_table("class_origin 2")->get_linklist(2, 0)->add(0);
             });
@@ -1908,28 +2052,24 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
         }
 
         SECTION("array: moving the observed object via insert_empty_row() does not interrupt tracking") {
-            Row r = origin->get(0);
             auto changes = observe({r}, [&] {
                 lv->add(0);
                 origin->insert_empty_row(0);
                 lv->add(0);
             });
-            REQUIRE(changes.has_array_change(0, 2, Kind::Insert, {10, 11}));
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Insert, {10, 11}}));
         }
 
         SECTION("array: moving the observed object via swap() does not interrupt tracking") {
-            Row r = origin->get(0);
             auto changes = observe({r}, [&] {
                 lv->add(0);
                 origin->swap_rows(0, 2);
                 lv->add(0);
             });
-            REQUIRE(changes.has_array_change(0, 2, Kind::Insert, {10, 11}));
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Insert, {10, 11}}));
         }
 
         SECTION("array: moving the observed object via move_last_over() does not interrupt tracking") {
-            Row r = origin->get(0);
-
             realm->begin_transaction();
             origin->swap_rows(0, 1);
             realm->commit_transaction();
@@ -1939,11 +2079,10 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
                 origin->move_last_over(0);
                 lv->add(0);
             });
-            REQUIRE(changes.has_array_change(0, 2, Kind::Insert, {10, 11}));
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Insert, {10, 11}}));
         }
 
         SECTION("array: moving the observed object via merge_rows() does not interrupt tracking") {
-            Row r = origin->get(0);
             auto changes = observe({r}, [&] {
                 size_t old = r.get_index();
                 size_t row = origin->add_empty_row();
@@ -1952,7 +2091,7 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
                 origin->move_last_over(old);
                 lv->add(0);
             });
-            REQUIRE(changes.has_array_change(0, 2, Kind::Insert, {10, 11}));
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Insert, {10, 11}}));
             REQUIRE(r.is_attached());
 
             // add two rows so that the new row doesn't just get moved over the old one
@@ -1964,18 +2103,243 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
                 origin->move_last_over(old);
                 lv->add(0);
             });
-            REQUIRE(changes.has_array_change(0, 2, Kind::Insert, {12, 13}));
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Insert, {12, 13}}));
         }
 
         SECTION("array: deleting the containing row after making changes discards the changes") {
-            Row r = origin->get(0);
             auto changes = observe({r}, [&] {
                 lv->insert(4, 0);
                 lv->insert(2, 0);
                 lv->insert(8, 0);
                 r.move_last_over();
             });
-            REQUIRE(changes.has_array_change(0, 2, Kind::None, {}));
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::None, {}}));
+        }
+
+        SECTION("array: moving the observed column with insert_column() does not interrupt tracking") {
+            auto changes = observe({r}, [&] {
+                lv->insert(4, 0);
+                origin->insert_column(0, type_Int, "new col");
+                lv->insert(2, 0);
+            });
+            REQUIRE(changes.array_change(0, 2) == (ArrayChange{Kind::Insert, {2, 5}}));
+        }
+
+        // ----------------------------------------------------------------------
+
+        SECTION("int array: add()") {
+            auto changes = observe({r}, [&] {
+                tr->add_empty_row();
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::Insert, {10}}));
+        }
+
+        SECTION("int array: insert()") {
+            auto changes = observe({r}, [&] {
+                tr->insert_empty_row(4);
+                tr->insert_empty_row(2);
+                tr->insert_empty_row(8);
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::Insert, {2, 5, 8}}));
+        }
+
+        SECTION("int array: remove()") {
+            auto changes = observe({r}, [&] {
+                tr->remove(0);
+                tr->remove(2);
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::Remove, {0, 3}}));
+        }
+
+        SECTION("int array: set()") {
+            auto changes = observe({r}, [&] {
+                tr->set_int(0, 0, 3);
+                tr->set_int(0, 2, 3);
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::Set, {0, 2}}));
+        }
+
+        SECTION("int array: move()") {
+            auto changes = observe({r}, [&] {
+                // list.move(8, 2);
+                tr->insert_empty_row(2);
+                tr->swap_rows(9, 2);
+                tr->remove(9);
+
+                // list.move(4, 6);
+                tr->insert_empty_row(7);
+                tr->swap_rows(4, 7);
+                tr->remove(4);
+
+                //      0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+                // Now: 0, 1, 8, 2, 4, 5, 3, 6, 7, 9
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::Set, {2, 3, 6, 7, 8}}));
+        }
+
+        SECTION("int array: swap()") {
+            SECTION("adjacent") {
+                auto changes = observe({r}, [&] {
+                    tr->swap_rows(5, 4);
+                });
+                REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::Set, {4, 5}}));
+            }
+            SECTION("non-adjacent") {
+                auto changes = observe({r}, [&] {
+                    tr->swap_rows(5, 3);
+                });
+                REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::Set, {3, 5}}));
+            }
+        }
+
+        SECTION("int array: clear()") {
+            auto changes = observe({r}, [&] {
+                tr->clear();
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::Remove, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}));
+        }
+
+        SECTION("int array: clear() after add()") {
+            auto changes = observe({r}, [&] {
+                tr->add_empty_row();
+                tr->clear();
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::Remove, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}));
+        }
+
+        SECTION("int array: clear() after set()") {
+            auto changes = observe({r}, [&] {
+                tr->set_int(0, 5, 3);
+                tr->clear();
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::Remove, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}));
+        }
+
+        SECTION("int array: clear() after remove()") {
+            auto changes = observe({r}, [&] {
+                tr->remove(2);
+                tr->clear();
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::Remove, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}));
+        }
+
+        SECTION("int array: multiple change kinds") {
+            auto changes = observe({r}, [&] {
+                tr->add_empty_row();
+                tr->remove(0);
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::SetAll, {}}));
+        }
+
+        SECTION("int array: modifying different array does not produce changes") {
+            auto changes = observe({r}, [&] {
+                tr2->add_empty_row();
+            });
+            REQUIRE_FALSE(changes.modified(0, 3));
+        }
+
+        SECTION("int array: moving the observed object via insert_empty_row() does not interrupt tracking") {
+            auto changes = observe({r}, [&] {
+                tr->add_empty_row();
+                origin->insert_empty_row(0);
+                tr->add_empty_row();
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::Insert, {10, 11}}));
+        }
+
+        SECTION("int array: moving the observed object via swap() does not interrupt tracking") {
+            auto changes = observe({r}, [&] {
+                tr->add_empty_row();
+                origin->swap_rows(0, 2);
+                tr->add_empty_row();
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::Insert, {10, 11}}));
+        }
+
+        SECTION("int array: moving the observed object via move_last_over() does not interrupt tracking") {
+            realm->begin_transaction();
+            origin->swap_rows(0, 1);
+            realm->commit_transaction();
+
+            auto changes = observe({r}, [&] {
+                tr->add_empty_row();
+                origin->move_last_over(0);
+                tr->add_empty_row();
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::Insert, {10, 11}}));
+        }
+
+        SECTION("int array: moving the observed object via merge_rows() does not interrupt tracking") {
+            auto changes = observe({r}, [&] {
+                size_t old = r.get_index();
+                size_t row = origin->add_empty_row();
+                tr->add_empty_row();
+                origin->merge_rows(old, row);
+                origin->move_last_over(old);
+                tr->add_empty_row();
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::Insert, {10, 11}}));
+            REQUIRE(r.is_attached());
+
+            // add two rows so that the new row doesn't just get moved over the old one
+            changes = observe({r}, [&] {
+                size_t old = r.get_index();
+                size_t row = origin->add_empty_row(2);
+                tr->add_empty_row();
+                origin->merge_rows(old, row);
+                origin->move_last_over(old);
+                tr->add_empty_row();
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::Insert, {12, 13}}));
+        }
+
+        SECTION("int array: deleting the containing row after making changes discards the changes") {
+            auto changes = observe({r}, [&] {
+                tr->insert_empty_row(4);
+                tr->insert_empty_row(2);
+                tr->insert_empty_row(8);
+                r.move_last_over();
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::None, {}}));
+        }
+
+        SECTION("int array: rollback clear()") {
+            auto changes = observe_rollback({r}, [&] {
+                tr->clear();
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::Insert, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}));
+        }
+
+        SECTION("int array: rollback clear() after add()") {
+            auto changes = observe_rollback({r}, [&] {
+                tr->add_empty_row();
+                tr->clear();
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::Insert, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}));
+        }
+
+        SECTION("int array: rollback clear() after set()") {
+            auto changes = observe_rollback({r}, [&] {
+                tr->set_int(0, 5, 3);
+                tr->clear();
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::Insert, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}));
+        }
+
+        SECTION("int array: rollback clear() after remove()") {
+            auto changes = observe_rollback({r}, [&] {
+                tr->remove(2);
+                tr->clear();
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::Insert, {0, 1, 2, 3, 4, 5, 6, 7, 8, 9}}));
+        }
+
+        SECTION("int array: rollback add() after clear()") {
+            auto changes = observe_rollback({r}, [&] {
+                tr->clear();
+                tr->add_empty_row();
+            });
+            REQUIRE(changes.array_change(0, 3) == (ArrayChange{Kind::SetAll, {}}));
         }
     }
 }
@@ -2225,7 +2589,7 @@ TEST_CASE("DeepChangeChecker") {
         REQUIRE(checker(3));
     }
 
-    SECTION("changes made to subtables do not mark containing row as modified") {
+    SECTION("changes made to subtables mark the containing row as modified") {
         {
             std::unique_ptr<Replication> history;
             std::unique_ptr<SharedGroup> shared_group;
@@ -2247,6 +2611,6 @@ TEST_CASE("DeepChangeChecker") {
             table->get_subtable(0, 0)->add_empty_row();
         });
         _impl::DeepChangeChecker checker(info, *table, tables);
-        REQUIRE_FALSE(checker(0));
+        REQUIRE(checker(0));
     }
 }

--- a/tests/util/index_helpers.hpp
+++ b/tests/util/index_helpers.hpp
@@ -21,7 +21,7 @@
     std::initializer_list<size_t> expected = {__VA_ARGS__}; \
     auto actual = index_set.as_indexes(); \
     INFO("Checking " #index_set); \
-    REQUIRE(expected.size() == std::distance(actual.begin(), actual.end())); \
+    REQUIRE(expected.size() == static_cast<size_t>(std::distance(actual.begin(), actual.end()))); \
     auto begin = actual.begin(); \
     for (auto index : expected) { \
         REQUIRE(*begin++ == index); \

--- a/tests/util/test_file.hpp
+++ b/tests/util/test_file.hpp
@@ -102,6 +102,9 @@ struct SyncTestFile : TestFile {
     SyncTestFile(SyncServer& server, std::string name="");
 };
 
+void wait_for_upload(realm::Realm& realm);
+void wait_for_download(realm::Realm& realm);
+
 #endif // REALM_ENABLE_SYNC
 
 #endif


### PR DESCRIPTION
Depends on https://github.com/realm/realm-core/pull/2785, so this will fail on CI for now.

The only API changes here are that `List` and `Results` now have templated versions of `get()`/`set()`/etc. so that they can be used with non-object types; everything else is just updating the innards of everything to work properly when non-Object array types are used.

