### PR TITLE
Lower the maximum search distance for changes from 16 to 4

### DIFF
--- a/src/impl/collection_notifier.cpp
+++ b/src/impl/collection_notifier.cpp
@@ -134,7 +134,7 @@ bool DeepChangeChecker::check_row(Table const& table, size_t idx, size_t depth)
     if (depth >= m_current_path.size()) {
         // Don't mark any of the intermediate rows checked along the path as
         // not modified, as a search starting from them might hit a modification
-        for (size_t i = 1; i < m_current_path.size(); ++i)
+        for (size_t i = 0; i < m_current_path.size(); ++i)
             m_current_path[i].depth_exceeded = true;
         return false;
     }

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -90,7 +90,7 @@ private:
         size_t col;
         bool depth_exceeded;
     };
-    std::array<Path, 16> m_current_path;
+    std::array<Path, 4> m_current_path;
 
     bool check_row(Table const& table, size_t row_ndx, size_t depth = 0);
     bool check_outgoing_links(size_t table_ndx, Table const& table,


### PR DESCRIPTION
16 was a completely arbitrary choice to begin with, and has turned out to be too large to actually avoid problems in pathological cases. This doesn't fix the problems with strongly-connected object graphs, but should do a better job of mitigating them until we have time for a proper solution.

This is arguably a breaking change? The limit isn't something we've ever documented so maybe it doesn't really count. In practice the people who actually want changes to linked objects reported seem to usually only want it one level deep anyway.