### PR TITLE
Make List property self=assignment a no-op

### DIFF
--- a/src/impl/object_accessor_impl.hpp
+++ b/src/impl/object_accessor_impl.hpp
@@ -82,6 +82,14 @@ public:
             fn(v);
     }
 
+    // Determine if `value` boxes the same List as `list`
+    bool is_same_list(List const& list, util::Any const& value)
+    {
+        if (auto list2 = any_cast<List>(&value))
+            return list == *list2;
+        return false;
+    }
+
     // Convert from core types to the boxed type
     util::Any box(BinaryData v) const { return std::string(v); }
     util::Any box(List v) const { return v; }

--- a/src/object_accessor.hpp
+++ b/src/object_accessor.hpp
@@ -89,14 +89,9 @@ void Object::set_property_value_impl(ContextType& ctx, const Property &property,
         if (property.type == PropertyType::LinkingObjects)
             throw ReadOnlyPropertyException(m_object_schema->name, property.name);
 
+        ContextType child_ctx(ctx, property);
         List list(m_realm, *m_row.get_table(), col, m_row.get_index());
-        list.remove_all();
-        if (!ctx.is_null(value)) {
-            ContextType child_ctx(ctx, property);
-            ctx.enumerate_list(value, [&](auto&& element) {
-                list.add(child_ctx, element, try_update);
-            });
-        }
+        list.assign(child_ctx, value, try_update);
         ctx.did_change();
         return;
     }


### PR DESCRIPTION
Doing this purely at the binding level misses the places where the assignment doesn't happen via the binding code.