### PR TITLE
add support to ssl_verify_callback option

### DIFF
--- a/src/sync/sync_config.hpp
+++ b/src/sync/sync_config.hpp
@@ -108,6 +108,7 @@ struct SyncConfig {
     util::Optional<std::array<char, 64>> realm_encryption_key;
     bool client_validate_ssl = true;
     util::Optional<std::string> ssl_trust_certificate_path;
+    std::function<sync::Session::SSLVerifyCallback> ssl_verify_callback;
 #if __GNUC__ < 5
     // GCC 4.9 does not support C++14 braced-init
     SyncConfig(std::shared_ptr<SyncUser> user, std::string realm_url, SyncSessionStopPolicy stop_policy,
@@ -115,7 +116,7 @@ struct SyncConfig {
                std::function<SyncSessionErrorHandler> error_handler = nullptr,
                std::shared_ptr<ChangesetTransformer> transformer = nullptr,
                util::Optional<std::array<char, 64>> realm_encryption_key = util::none,
-               bool client_validate_ssl = true, util::Optional<std::string> ssl_trust_certificate_path = util::none)
+               bool client_validate_ssl = true, util::Optional<std::string> ssl_trust_certificate_path = util::none, std::function<realm::sync::Session::SSLVerifyCallback> ssl_verify_callback = nullptr)
         : user(std::move(user))
         , realm_url(std::move(realm_url))
         , stop_policy(stop_policy)
@@ -125,6 +126,7 @@ struct SyncConfig {
         , realm_encryption_key(std::move(realm_encryption_key))
         , client_validate_ssl(client_validate_ssl)
         , ssl_trust_certificate_path(std::move(ssl_trust_certificate_path))
+        , ssl_verify_callback(std::move(ssl_verify_callback))
     {
     }
 

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -642,6 +642,7 @@ void SyncSession::create_sync_session()
     session_config.encryption_key = m_config.realm_encryption_key;
     session_config.verify_servers_ssl_certificate = m_config.client_validate_ssl;
     session_config.ssl_trust_certificate_path = m_config.ssl_trust_certificate_path;
+    session_config.ssl_verify_callback = m_config.ssl_verify_callback;
     m_session = std::make_unique<sync::Session>(m_client.client, m_realm_path, session_config);
 
     // The next time we get a token, call `bind()` instead of `refresh()`.


### PR DESCRIPTION
following the work on Sync repo https://github.com/realm/realm-sync/pull/1312 to allow the binding to pass a callback to validate the SSL certificate, this PR expose this option to the binding so we can set the callback when building the `SyncConf`

Will be used mainly for Java to allow Android trust manager to validate  the cert https://github.com/realm/realm-java/issues/4759