### PR TITLE
Fix crashes when deleted objects are imported from handover

### DIFF
--- a/src/list.cpp
+++ b/src/list.cpp
@@ -120,6 +120,8 @@ void List::validate(RowExpr row) const
 
 bool List::is_valid() const
 {
+    if (!m_realm)
+        return false;
     m_realm->verify_thread();
     if (m_link_view)
         return m_link_view->is_attached();

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -881,6 +881,8 @@ T Realm::resolve_thread_safe_reference(ThreadSafeReference<T> reference)
             // With reference imported, advance temporary Realm to our version
             T imported_value = std::move(reference).import_into_realm(temporary_realm);
             transaction::advance(*temporary_realm->m_shared_group, nullptr, current_version);
+            if (!imported_value.is_valid())
+                return T{};
             reference = ThreadSafeReference<T>(imported_value);
         }
     }


### PR DESCRIPTION
Fixes #528. Turns out we didn't actually have objectstore tests for this.