### PR TITLE
Use release assertion in reset_for_testing

### DIFF
--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -212,14 +212,12 @@ void SyncManager::reset_for_testing()
         {
             std::lock_guard<std::mutex> lock(m_session_mutex);
 
-#if REALM_ASSERTIONS_ENABLED
             // Callers of `SyncManager::reset_for_testing` should ensure there are no active sessions
             // prior to calling `reset_for_testing`.
             auto no_active_sessions = std::none_of(m_sessions.begin(), m_sessions.end(), [](auto& element){
                 return element.second->existing_external_reference();
             });
-            REALM_ASSERT(no_active_sessions);
-#endif
+            REALM_ASSERT_RELEASE(no_active_sessions);
 
             // Destroy any inactive sessions.
             // FIXME: We shouldn't have any inactive sessions at this point! Sessions are expected to


### PR DESCRIPTION
This assertion attacked realm-java integration tests a lot.
And realm-java cannot enable assertion for CI build due to the speed
issues, this assertion is kind of turned into many ways of native
crashes for realm-java CI.
Change it to a release assertion so realm-java can crash earlier.