### PR TITLE
Add List::delete_at(size_t)

### DIFF
--- a/src/list.cpp
+++ b/src/list.cpp
@@ -349,6 +349,16 @@ void List::swap(size_t ndx1, size_t ndx2)
         m_table->swap_rows(ndx1, ndx2);
 }
 
+void List::delete_at(size_t row_ndx)
+{
+    verify_in_transaction();
+    verify_valid_row(row_ndx);
+    if (m_link_view)
+        m_link_view->remove_target_row(row_ndx);
+    else
+        m_table->remove(row_ndx);
+}
+
 void List::delete_all()
 {
     verify_in_transaction();

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -77,6 +77,7 @@ public:
     void remove(size_t list_ndx);
     void remove_all();
     void swap(size_t ndx1, size_t ndx2);
+    void delete_at(size_t list_ndx);
     void delete_all();
 
     template<typename T = RowExpr>

--- a/tests/list.cpp
+++ b/tests/list.cpp
@@ -677,6 +677,17 @@ TEST_CASE("list") {
         REQUIRE(&list.get_object_schema() == objectschema);
     }
 
+    SECTION("delete_at()") {
+        List list(r, lv);
+        r->begin_transaction();
+        auto initial_view_size = lv->size();
+        auto initial_target_size = target->size();
+        list.delete_at(1);
+        REQUIRE(lv->size() == initial_view_size - 1);
+        REQUIRE(target->size() == initial_target_size - 1);
+        r->cancel_transaction();
+    }
+
     SECTION("delete_all()") {
         List list(r, lv);
         r->begin_transaction();


### PR DESCRIPTION
`List` has `delete_all()` to delete all target objects, but does not have a method to delete single target object in `List`
This PR adds `List.delete_at(size_t)` to achieve that.