### PR TITLE
Describe true and false expressions

### DIFF
--- a/src/parser/query_builder.cpp
+++ b/src/parser/query_builder.cpp
@@ -63,6 +63,7 @@ struct TrueExpression : realm::Expression {
     void set_base_table(const Table*) override {}
     const Table* get_base_table() const override { return nullptr; }
     void verify_column() const override {}
+    std::string description() const override { return "true"; }
     std::unique_ptr<Expression> clone(QueryNodeHandoverPatches*) const override
     {
         return std::unique_ptr<Expression>(new TrueExpression(*this));
@@ -73,6 +74,7 @@ struct FalseExpression : realm::Expression {
     size_t find_first(size_t, size_t) const override { return realm::not_found; }
     void set_base_table(const Table*) override {}
     void verify_column() const override {}
+    std::string description() const override { return "false"; }
     const Table* get_base_table() const override { return nullptr; }
     std::unique_ptr<Expression> clone(QueryNodeHandoverPatches*) const override
     {


### PR DESCRIPTION
This is required to compile with core versions >= 3.2.0. It adds descriptions for query expressions which is part of the metrics feature. `description()` is a pure virtual method so if these are not present there will be a compile time error.