### PR TITLE
Add a missing check for deleted objects in add_notification_callback()

### DIFF
--- a/src/object.cpp
+++ b/src/object.cpp
@@ -68,6 +68,7 @@ Object& Object::operator=(Object&&) = default;
 
 NotificationToken Object::add_notification_callback(CollectionChangeCallback callback) &
 {
+    verify_attached();
     if (!m_notifier) {
         m_notifier = std::make_shared<_impl::ObjectNotifier>(m_row, m_realm);
         _impl::RealmCoordinator::register_notifier(m_notifier);

--- a/tests/object.cpp
+++ b/tests/object.cpp
@@ -280,6 +280,13 @@ TEST_CASE("object") {
             write([&] { row.move_last_over(); });
             REQUIRE_INDICES(change.deletions, 0);
         }
+
+        SECTION("observing deleted object throws") {
+            write([&] {
+                row.move_last_over();
+            });
+            REQUIRE_THROWS(require_change());
+        }
     }
 
     TestContext d(r);


### PR DESCRIPTION
Without this check it hits an assertion failure rather than throwing a useful error.

Reported by https://secure.helpscout.net/conversation/433478799/11309/