### PR TITLE
Use constexpr for NotVersioned

### DIFF
--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -38,7 +38,6 @@
 
 using namespace realm;
 
-// Make linker happy
 constexpr uint64_t ObjectStore::NotVersioned;
 
 namespace {

--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -38,7 +38,8 @@
 
 using namespace realm;
 
-const uint64_t ObjectStore::NotVersioned = std::numeric_limits<uint64_t>::max();
+// Make linker happy
+constexpr uint64_t ObjectStore::NotVersioned;
 
 namespace {
 const char * const c_metadataTableName = "metadata";
@@ -249,7 +250,6 @@ void validate_primary_column_uniqueness(Group const& group)
 }
 } // anonymous namespace
 
-// FIXME remove this after integrating OS's migration related logic into Realm java
 void ObjectStore::set_schema_version(Group& group, uint64_t version) {
     ::create_metadata_tables(group);
     ::set_schema_version(group, version);

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -42,7 +42,7 @@ std::string format(const char* fmt, Args&&... args);
 class ObjectStore {
 public:
     // Schema version used for uninitialized Realms
-    static const uint64_t NotVersioned;
+    static constexpr uint64_t NotVersioned = std::numeric_limits<uint64_t>::max();
 
     // Column name used for subtables which store an array
     static constexpr const char* const ArrayColumnName = "!ARRAY_VALUE";
@@ -53,7 +53,6 @@ public:
     // set the schema version without any checks
     // and the tables for the schema version and the primary key are created if they don't exist
     // NOTE: must be performed within a write transaction
-    // FIXME remove this after integrating OS's migration related logic into Realm java
     static void set_schema_version(Group& group, uint64_t version);
 
     // check if all of the changes in the list can be applied automatically, or


### PR DESCRIPTION
- Use constexpr for NotVersioned which is easier for java to do
  static_assert check.
- Remove FIXME for ObjectStore::set_schema_version. It is still useful
  for realm-java after switching to use Object Store schema:
  - It is useful for constructing schema related test cases.
  - It is used to create meta tables for realm-java's dynamic Realm.