### PR TITLE
Copy sync-1.x.realm to the correct place when building in Xcode

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,7 +59,8 @@ if(REALM_ENABLE_SYNC)
 endif()
 
 target_link_libraries(tests realm-object-store ${PLATFORM_LIBRARIES})
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/sync-1.x.realm ${CMAKE_CURRENT_BINARY_DIR}/sync-1.x.realm COPYONLY)
+add_custom_command(TARGET tests POST_BUILD
+                   COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/sync-1.x.realm $<TARGET_FILE_DIR:tests>)
 
 create_coverage_target(generate-coverage tests)
 

--- a/tests/sync/session/session.cpp
+++ b/tests/sync/session/session.cpp
@@ -672,6 +672,7 @@ TEST_CASE("sync: Migration from Sync 1.x to Sync 2.x", "[sync]") {
 
     {
         std::ifstream src("sync-1.x.realm", std::ios::binary);
+        REQUIRE(src.good());
         std::ofstream dst(config.path, std::ios::binary);
 
         dst << src.rdbuf();


### PR DESCRIPTION
When building the project in Xcode, the tests binary ends up at `tests/Debug/tests` but the realm file was being copied to `tests/sync-1.x.realm`, so it failed to find the file. The copy needs to be done at build time rather than configure time to support build systems which support multiple configurations.