### PR TITLE
Add support for permission offer/response

### DIFF
--- a/src/sync/sync_permission.cpp
+++ b/src/sync/sync_permission.cpp
@@ -38,21 +38,21 @@ using namespace std::chrono;
 // MARK: - Utility
 
 namespace {
-Permission::AccessLevel extract_access_level(Object& permission, CppContext& context)
+AccessLevel extract_access_level(Object& permission, CppContext& context)
 {
     auto may_manage = permission.get_property_value<util::Any>(context, "mayManage");
     if (may_manage.has_value() && any_cast<bool>(may_manage))
-        return Permission::AccessLevel::Admin;
+        return AccessLevel::Admin;
 
     auto may_write = permission.get_property_value<util::Any>(context, "mayWrite");
     if (may_write.has_value() && any_cast<bool>(may_write))
-        return Permission::AccessLevel::Write;
+        return AccessLevel::Write;
 
     auto may_read = permission.get_property_value<util::Any>(context, "mayRead");
     if (may_read.has_value() && any_cast<bool>(may_read))
-        return Permission::AccessLevel::Read;
+        return AccessLevel::Read;
 
-    return Permission::AccessLevel::None;
+    return AccessLevel::None;
 }
 
 /// Turn a system time point value into the 64-bit integer representing ns since the Unix epoch.
@@ -157,7 +157,91 @@ void Permissions::set_permission(std::shared_ptr<SyncUser> user,
                                  PermissionChangeCallback callback,
                                  const ConfigMaker& make_config)
 {
-    const auto realm_url = user->server_url() + permission.path;
+    auto props = AnyDict{
+        {"userId", permission.condition.user_id},
+        {"realmUrl", user->server_url() + permission.path},
+        {"mayRead", permission.access != AccessLevel::None},
+        {"mayWrite", permission.access == AccessLevel::Write || permission.access == AccessLevel::Admin},
+        {"mayManage", permission.access == AccessLevel::Admin},
+    };
+    switch (permission.condition.type) {
+        case Permission::Condition::Type::KeyValue:
+            props.insert({"metadataKey", permission.condition.key_value.first});
+            props.insert({"metadataValue", permission.condition.key_value.second});
+            break;
+        default:
+            break;
+    }
+    auto cb = [callback=std::move(callback)](Object*, std::exception_ptr exception) {
+        if (exception) {
+            callback(exception);
+        } else {
+            callback(nullptr);
+        }
+    };
+    perform_async_operation("PermissionChange", std::move(user), std::move(cb), std::move(props), make_config);
+}
+
+void Permissions::delete_permission(std::shared_ptr<SyncUser> user,
+                                    Permission permission,
+                                    PermissionChangeCallback callback,
+                                    const ConfigMaker& make_config)
+{
+    permission.access = AccessLevel::None;
+    set_permission(std::move(user), std::move(permission), std::move(callback), make_config);
+}
+
+void Permissions::make_offer(std::shared_ptr<SyncUser> user,
+                             PermissionOffer offer,
+                             PermissionOfferCallback callback,
+                             const ConfigMaker& make_config)
+{
+    auto props = AnyDict{
+        {"expiresAt", std::move(offer.expiration)},
+        {"userId", user->identity()},
+        {"realmUrl", user->server_url() + offer.path},
+        {"mayRead", offer.access != AccessLevel::None},
+        {"mayWrite", offer.access == AccessLevel::Write || offer.access == AccessLevel::Admin},
+        {"mayManage", offer.access == AccessLevel::Admin},
+    };
+    auto cb = [callback=std::move(callback)](Object* object, std::exception_ptr exception) {
+        if (exception) {
+            callback(none, exception);
+        } else {
+            CppContext context;
+            auto token = any_cast<std::string>(object->get_property_value<util::Any>(context, "token"));
+            callback(util::make_optional<std::string>(std::move(token)), nullptr);
+        }
+    };
+    perform_async_operation("PermissionOffer", std::move(user), std::move(cb), std::move(props), make_config);
+}
+
+void Permissions::accept_offer(std::shared_ptr<SyncUser> user,
+                               const std::string& token,
+                               PermissionOfferCallback callback,
+                               const ConfigMaker& make_config)
+{
+    auto props = AnyDict{
+        {"token", token},
+    };
+    auto cb = [callback=std::move(callback)](Object* object, std::exception_ptr exception) {
+        if (exception) {
+            callback(none, exception);
+        } else {
+            CppContext context;
+            auto token = any_cast<std::string>(object->get_property_value<util::Any>(context, "realmUrl"));
+            callback(util::make_optional<std::string>(std::move(token)), nullptr);
+        }
+    };
+    perform_async_operation("PermissionOfferResponse", std::move(user), std::move(cb), std::move(props), make_config);
+}
+
+void Permissions::perform_async_operation(const std::string& object_type,
+                                          std::shared_ptr<SyncUser> user,
+                                          std::function<void(Object*, std::exception_ptr)> handler,
+                                          AnyDict additional_props,
+                                          const ConfigMaker& make_config)
+{;
     auto realm = Permissions::management_realm(std::move(user), make_config);
     CppContext context;
 
@@ -166,38 +250,27 @@ void Permissions::set_permission(std::shared_ptr<SyncUser> user,
     int64_t s_arg = ns_since_epoch / (int64_t)Timestamp::nanoseconds_per_second;
     int32_t ns_arg = ns_since_epoch % Timestamp::nanoseconds_per_second;
 
-    // Write the permission object.
-    realm->begin_transaction();
-    auto raw = Object::create<util::Any>(context, realm, *realm->schema().find("PermissionChange"), AnyDict{
+    auto props = AnyDict{
         {"id", util::uuid_string()},
         {"createdAt", Timestamp(s_arg, ns_arg)},
         {"updatedAt", Timestamp(s_arg, ns_arg)},
-        {"userId", permission.condition.user_id},
-        {"realmUrl", realm_url},
-        {"mayRead", permission.access != Permission::AccessLevel::None},
-        {"mayWrite", permission.access == Permission::AccessLevel::Write || permission.access == Permission::AccessLevel::Admin},
-        {"mayManage", permission.access == Permission::AccessLevel::Admin},
-    }, false);
-
-    // Set condition properties based on type
-    switch (permission.condition.type) {
-        case Permission::Condition::Type::KeyValue:
-            raw.set_property_value<util::Any>(context, "metadataKey", permission.condition.key_value.first, false);
-            raw.set_property_value<util::Any>(context, "metadataValue", permission.condition.key_value.second, false);
-            break;
-        default:
-            break;
+    };
+    for (auto&& prop : additional_props) {
+        props.insert(prop);
     }
 
+    // Write the permission object.
+    realm->begin_transaction();
+    auto raw = Object::create<util::Any>(context, realm, *realm->schema().find(object_type), std::move(props), false);
     auto object = std::make_shared<_impl::NotificationWrapper<Object>>(std::move(raw));
     realm->commit_transaction();
 
     // Observe the permission object until the permission change has been processed or failed.
     // The notifier is automatically unregistered upon the completion of the permission
     // change, one way or another.
-    auto block = [object, callback=std::move(callback)](CollectionChangeSet, std::exception_ptr ex) mutable {
+    auto block = [object, handler=std::move(handler)](CollectionChangeSet, std::exception_ptr ex) mutable {
         if (ex) {
-            callback(ex);
+            handler(nullptr, ex);
             object.reset();
             return;
         }
@@ -213,26 +286,17 @@ void Permissions::set_permission(std::shared_ptr<SyncUser> user,
         if (auto code = any_cast<long long>(status_code)) {
             // The permission change failed because an error was returned from the server.
             auto status = object->get_property_value<util::Any>(context, "statusMessage");
-            std::string error_str = status.has_value()
-                                  ? any_cast<std::string>(status)
-                                  : util::format("Error code: %1", code);
-            callback(std::make_exception_ptr(PermissionChangeException(error_str, code)));
+            std::string error_str = (status.has_value()
+                                     ? any_cast<std::string>(status)
+                                     : util::format("Error code: %1", code));
+            handler(nullptr, std::make_exception_ptr(PermissionActionException(error_str, code)));
         }
         else {
-            callback({});
+            handler(&*object, nullptr);
         }
         object.reset();
     };
     object->add_notification_callback(std::move(block));
-}
-
-void Permissions::delete_permission(std::shared_ptr<SyncUser> user,
-                                    Permission permission,
-                                    PermissionChangeCallback callback,
-                                    const ConfigMaker& make_config)
-{
-    permission.access = Permission::AccessLevel::None;
-    set_permission(std::move(user), std::move(permission), std::move(callback), make_config);
 }
 
 SharedRealm Permissions::management_realm(std::shared_ptr<SyncUser> user, const ConfigMaker& make_config)
@@ -261,7 +325,6 @@ SharedRealm Permissions::management_realm(std::shared_ptr<SyncUser> user, const 
             Property{"id",                PropertyType::String, Property::IsPrimary{true}},
             Property{"createdAt",         PropertyType::Date},
             Property{"updatedAt",         PropertyType::Date},
-            Property{"expiresAt",         PropertyType::Date},
             Property{"statusCode",        PropertyType::Int|PropertyType::Nullable},
             Property{"statusMessage",     PropertyType::String|PropertyType::Nullable},
             Property{"token",             PropertyType::String|PropertyType::Nullable},
@@ -269,6 +332,7 @@ SharedRealm Permissions::management_realm(std::shared_ptr<SyncUser> user, const 
             Property{"mayRead",           PropertyType::Bool},
             Property{"mayWrite",          PropertyType::Bool},
             Property{"mayManage",         PropertyType::Bool},
+            Property{"expiresAt",         PropertyType::Date|PropertyType::Nullable},
         }},
         {"PermissionOfferResponse", {
             Property{"id",                PropertyType::String, Property::IsPrimary{true}},
@@ -276,8 +340,8 @@ SharedRealm Permissions::management_realm(std::shared_ptr<SyncUser> user, const 
             Property{"updatedAt",         PropertyType::Date},
             Property{"statusCode",        PropertyType::Int|PropertyType::Nullable},
             Property{"statusMessage",     PropertyType::String|PropertyType::Nullable},
-            Property{"token",             PropertyType::String|PropertyType::Nullable},
-            Property{"realmUrl",          PropertyType::String},
+            Property{"token",             PropertyType::String},
+            Property{"realmUrl",          PropertyType::String|PropertyType::Nullable},
         }},
     };
     config.schema_version = 0;

--- a/src/sync/sync_permission.cpp
+++ b/src/sync/sync_permission.cpp
@@ -42,7 +42,7 @@ namespace {
 // Make a handler that extracts either an exception pointer, or the string value
 // of the property with the specified name.
 Permissions::AsyncOperationHandler make_handler_extracting_property(std::string property,
-                                                                    PermissionOfferCallback callback)
+                                                                    Permissions::PermissionOfferCallback callback)
 {
     return [property=std::move(property),
             callback=std::move(callback)](Object* object, std::exception_ptr exception) {

--- a/src/sync/sync_permission.hpp
+++ b/src/sync/sync_permission.hpp
@@ -22,11 +22,23 @@
 #include "results.hpp"
 #include "shared_realm.hpp"
 
+#include "util/any.hpp"
+
 namespace realm {
 
 class Permissions;
 class SyncUser;
 class Object;
+
+// A permission encapsulates a single access level.
+// Each level includes all the capabilities of the level
+// above it (for example, 'write' implies 'read').
+enum class AccessLevel {
+    None,
+    Read,
+    Write,
+    Admin,
+};
 
 // Permission object used to represent a user permission.
 // Permission objects can be passed into or returned by various permissions
@@ -35,15 +47,6 @@ struct Permission {
     // The path of the Realm to which this permission pertains.
     std::string path;
 
-    // A permission encapsulates a single access level.
-    // Each level includes all the capabilities of the level
-    // above it (for example, 'write' implies 'read').
-    enum class AccessLevel {
-        None,
-        Read,
-        Write,
-        Admin,
-    };
     AccessLevel access;
 
     // Return the string description of an `AccessLevel`.
@@ -96,6 +99,12 @@ struct Permission {
     Permission(std::string path, AccessLevel, Condition, Timestamp updated_at=Timestamp());
 };
 
+struct PermissionOffer {
+    std::string path;
+    AccessLevel access;
+    Timestamp expiration;
+};
+
 class Permissions {
 public:
     // Consumers of these APIs need to pass in a method which creates a Config with the proper
@@ -105,10 +114,14 @@ public:
     // Callback used to asynchronously vend permissions results.
     using PermissionResultsCallback = std::function<void(Results, std::exception_ptr)>;
 
+    // Callback used to asynchronously vend permission offer or response URL.
+    using PermissionOfferCallback = std::function<void(util::Optional<std::string>, std::exception_ptr)>;
+
     // Asynchronously retrieve a `Results` containing the permissions for the provided user.
     static void get_permissions(std::shared_ptr<SyncUser>, PermissionResultsCallback, const ConfigMaker&);
 
     // Callback used to monitor success or errors when changing permissions
+    // or accepting a permission offer.
     // `exception_ptr` is null_ptr on success
     using PermissionChangeCallback = std::function<void(std::exception_ptr)>;
 
@@ -118,15 +131,40 @@ public:
     // Delete a permission as the provided user.
     static void delete_permission(std::shared_ptr<SyncUser>, Permission, PermissionChangeCallback, const ConfigMaker&);
 
+    // Create a permission offer. The callback will be passed the token, if successful.
+    static void make_offer(std::shared_ptr<SyncUser>, PermissionOffer, PermissionOfferCallback, const ConfigMaker&);
+
+    // Accept a permission offer based on the token value within the offer.
+    static void accept_offer(std::shared_ptr<SyncUser>, const std::string&, PermissionOfferCallback, const ConfigMaker&);
+
 private:
     static SharedRealm management_realm(std::shared_ptr<SyncUser>, const ConfigMaker&);
     static SharedRealm permission_realm(std::shared_ptr<SyncUser>, const ConfigMaker&);
+
+    /**
+     Perform an asynchronous operation that involves writing an object to the
+     user's management Realm, and then waiting for the operation to succeed or
+     fail.
+
+     The object in question must have at least `id`, `createdAt`, and `updatedAt`,
+     properties to be set as part of the request, and it must report its success
+     or failure by setting its `statusCode` and `statusMessage` properties.
+
+     The callback is invoked upon success or failure, and will be called with
+     exactly one of its two arguments not set to null. The object can be used to
+     extract additional data to be returned to the caller.
+     */
+    static void perform_async_operation(const std::string& object_type,
+                                        std::shared_ptr<SyncUser>,
+                                        std::function<void(Object*, std::exception_ptr)>,
+                                        std::map<std::string, util::Any>,
+                                        const ConfigMaker&);
 };
 
-struct PermissionChangeException : std::runtime_error {
+struct PermissionActionException : std::runtime_error {
     long long code;
 
-    PermissionChangeException(std::string message, long long code)
+    PermissionActionException(std::string message, long long code)
     : std::runtime_error(std::move(message))
     , code(code)
     { }

--- a/src/sync/sync_permission.hpp
+++ b/src/sync/sync_permission.hpp
@@ -139,15 +139,11 @@ public:
     // Accept a permission offer based on the token value within the offer.
     static void accept_offer(std::shared_ptr<SyncUser>, const std::string&, PermissionOfferCallback, const ConfigMaker&);
 
+    using AsyncOperationHandler = std::function<void(Object*, std::exception_ptr)>;
+
 private:
     static SharedRealm management_realm(std::shared_ptr<SyncUser>, const ConfigMaker&);
     static SharedRealm permission_realm(std::shared_ptr<SyncUser>, const ConfigMaker&);
-
-    using AsyncOperationHandler = std::function<void(Object*, std::exception_ptr)>;
-
-    // Make a handler that extracts either an exception pointer, or the string value
-    // of the property with the specified name.
-    static AsyncOperationHandler make_handler_extracting_property(std::string, PermissionOfferCallback);
 
     /**
      Perform an asynchronous operation that involves writing an object to the

--- a/src/sync/sync_permission.hpp
+++ b/src/sync/sync_permission.hpp
@@ -22,13 +22,15 @@
 #include "results.hpp"
 #include "shared_realm.hpp"
 
-#include "util/any.hpp"
-
 namespace realm {
 
 class Permissions;
 class SyncUser;
 class Object;
+
+namespace util {
+    class Any;
+}
 
 // A permission encapsulates a single access level.
 // Each level includes all the capabilities of the level
@@ -141,6 +143,12 @@ private:
     static SharedRealm management_realm(std::shared_ptr<SyncUser>, const ConfigMaker&);
     static SharedRealm permission_realm(std::shared_ptr<SyncUser>, const ConfigMaker&);
 
+    using AsyncOperationHandler = std::function<void(Object*, std::exception_ptr)>;
+
+    // Make a handler that extracts either an exception pointer, or the string value
+    // of the property with the specified name.
+    static AsyncOperationHandler make_handler_extracting_property(std::string, PermissionOfferCallback);
+
     /**
      Perform an asynchronous operation that involves writing an object to the
      user's management Realm, and then waiting for the operation to succeed or
@@ -156,7 +164,7 @@ private:
      */
     static void perform_async_operation(const std::string& object_type,
                                         std::shared_ptr<SyncUser>,
-                                        std::function<void(Object*, std::exception_ptr)>,
+                                        AsyncOperationHandler,
                                         std::map<std::string, util::Any>,
                                         const ConfigMaker&);
 };


### PR DESCRIPTION
Changes:
- Added APIs for creating permission offers and accepting them
- Refactored some code to facilitate reuse
- Renamed a few types to reflect their new, expanded usage

Rationale: right now, most bindings (Cocoa included) use the object store APIs to get and change permissions, but binding-level APIs to create and accept permission offers. This API allows the existing object store machinery to be used to perform the latter task as well.

More detailed description.
1. I broke most of the existing method for changing permissions into a new method, `perform_async_operation()`. This method basically creates an object, writes it to the management Realm, and observes it until its status code indicates either success or failure. Then it calls a callback.
2. Changing permissions, creating offers, and accepting offers now call into `perform_async_operation()` with customization options (e.g. what object to create, what additional properties to set on it).