### PR TITLE
Fix SyncConfig initialization to be consistent between Clang and GCC >= 5

### DIFF
--- a/src/sync/sync_config.hpp
+++ b/src/sync/sync_config.hpp
@@ -112,10 +112,10 @@ struct SyncConfig {
     std::function<SyncSessionErrorHandler> error_handler;
     std::shared_ptr<ChangesetTransformer> transformer;
     util::Optional<std::array<char, 64>> realm_encryption_key;
-    bool client_validate_ssl = true;
+    bool client_validate_ssl;
     util::Optional<std::string> ssl_trust_certificate_path;
     std::function<sync::Session::SSLVerifyCallback> ssl_verify_callback;
-    bool is_partial = false;
+    bool is_partial;
     util::Optional<std::string> custom_partial_sync_identifier;
 
     bool validate_sync_history = true;
@@ -124,8 +124,6 @@ struct SyncConfig {
     // This will differ from `reference_realm_url` when partial sync is being used.
     std::string realm_url() const;
 
-#if __GNUC__ < 5
-    // GCC 4.9 does not support C++14 braced-init
     SyncConfig(std::shared_ptr<SyncUser> user, std::string reference_realm_url,
                SyncSessionStopPolicy stop_policy,
                std::function<SyncBindSessionHandler> bind_session_handler,
@@ -152,10 +150,6 @@ struct SyncConfig {
         , custom_partial_sync_identifier(std::move(custom_partial_sync_identifier))
     {
     }
-
-    SyncConfig() {}
-
-#endif
 };
 
 } // namespace realm

--- a/src/sync/sync_config.hpp
+++ b/src/sync/sync_config.hpp
@@ -115,9 +115,10 @@ struct SyncConfig {
     bool client_validate_ssl = true;
     util::Optional<std::string> ssl_trust_certificate_path;
     std::function<sync::Session::SSLVerifyCallback> ssl_verify_callback;
-    bool validate_sync_history = true;
     bool is_partial = false;
     util::Optional<std::string> custom_partial_sync_identifier;
+
+    bool validate_sync_history = true;
 
     // The URL that will be used when connecting to the object server.
     // This will differ from `reference_realm_url` when partial sync is being used.

--- a/tests/sync/session/session.cpp
+++ b/tests/sync/session/session.cpp
@@ -143,7 +143,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
         const std::string path = "/test1e";
         std::weak_ptr<SyncSession> weak_session;
         std::string on_disk_path;
-        SyncConfig config;
+        util::Optional<SyncConfig> config;
         auto user = SyncManager::shared().get_user({ "user1e", dummy_auth_url }, "not_a_real_token");
         {
             // Create the session within a nested scope, so we can control its lifetime.
@@ -163,7 +163,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
 
         // The next time we request it, it'll be created anew.
         // The call to `get_session()` should result in `SyncUser::register_session()` being called.
-        auto session = SyncManager::shared().get_session(on_disk_path, config);
+        auto session = SyncManager::shared().get_session(on_disk_path, *config);
         CHECK(session);
         session = user->session_for_on_disk_path(on_disk_path);
         CHECK(session);


### PR DESCRIPTION
Always use the `SyncConfig` constructor. It removes the potential for inconsistent initialization between the constructor and braced initializers. In addition, the default constructor is removed as it doesn't result in a meaningful `SyncConfig`.

At some point soon we should reevaluate how `SyncConfig` is used. It was initially intended to contain only two or three values, but has grown to over ten ☹️