### PR TITLE
Fix reconnect not happening correctly in some network situations.

### DIFF
--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -287,6 +287,10 @@ struct sync_session_states::Active : public SyncSession::State {
         (*session.m_session.*waiter)(std::move(callback));
         return true;
     }
+
+    void handle_reconnect(std::unique_lock<std::mutex>&, SyncSession& session) const override {
+        session.m_session->cancel_reconnect_delay();
+    }
 };
 
 struct sync_session_states::Dying : public SyncSession::State {


### PR DESCRIPTION
Fixes https://github.com/realm/realm-sync/issues/1691

If an Object Store Session becomes active and the user then enables airplane mode (e.g. to demo Sync), then the Sync layer correctly detects this and starts using incremental backoff, but Object Store Session stays in `Active` mode.

This is a problem as `SyncManager::reconnect()` doesn't have any effect when a binding detects that network comes back.

This PR changes it, so it is now possible to cancel the reconnect delay even when the session is considered active from the point of view of Object Store.