### PR TITLE
Make ExternalCommitHelper robust on Windows

### DIFF
--- a/src/impl/windows/external_commit_helper.cpp
+++ b/src/impl/windows/external_commit_helper.cpp
@@ -17,69 +17,65 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #include "impl/external_commit_helper.hpp"
-
 #include "impl/realm_coordinator.hpp"
 
 #include <algorithm>
-#include <codecvt>
 
 using namespace realm;
 using namespace realm::_impl;
 
-static HANDLE CreateNotificationEvent(std::string realm_path)
-{
-    // replace backslashes because they're significant in object namespace names
-    std::replace(realm_path.begin(), realm_path.end(), '\\', '/');
-
-    std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> converter;
-    std::wstring path(L"Local\\" + converter.from_bytes(realm_path));
-
-    HANDLE event = CreateEventEx(nullptr, path.c_str(), CREATE_EVENT_MANUAL_RESET, SYNCHRONIZE | EVENT_MODIFY_STATE);
-    if (event == nullptr) {
-        throw std::system_error(GetLastError(), std::system_category());
-    }
-
-    return event;
-}
-
 ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent)
 : m_parent(parent)
-, m_event(CreateNotificationEvent(parent.get_path()))
-, m_close_mutex(CreateMutexEx(nullptr, nullptr, CREATE_MUTEX_INITIAL_OWNER, SYNCHRONIZE | MUTEX_MODIFY_STATE))
 {
+    std::string path = parent.get_path();
+    std::replace(path.begin(), path.end(), '\\', '/');
+    std::wstring shared_memory_name = L"Local\\Realm_ObjectStore_ExternalCommitHelper_SharedCondVar_" + std::wstring(path.begin(), path.end());
+#if REALM_WINDOWS
+    m_shared_memory = CreateFileMappingW(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, sizeof(*m_condvar_shared), shared_memory_name.c_str());
+    auto error = GetLastError();
+    m_condvar_shared = reinterpret_cast<InterprocessCondVar::SharedPart*>(MapViewOfFile(m_shared_memory, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(*m_condvar_shared)));
+#elif REALM_UWP
+    m_shared_memory = CreateFileMappingFromApp(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, sizeof(*m_condvar_shared), shared_memory_name.c_str());
+    auto error = GetLastError();
+    m_condvar_shared = reinterpret_cast<InterprocessCondVar::SharedPart*>(MapViewOfFileFromApp(m_shared_memory, FILE_MAP_ALL_ACCESS, 0, sizeof(*m_condvar_shared)));
+#endif
+    if (error == 0) {
+        InterprocessCondVar::init_shared_part(*m_condvar_shared);
+    } else if (error != ERROR_ALREADY_EXISTS) {
+        throw std::system_error(error, std::system_category());
+    }
+
+    m_mutex.set_shared_part(InterprocessMutex::SharedPart(), parent.get_path(), "ExternalCommitHelper_ControlMutex");
+    m_commit_available.set_shared_part(*m_condvar_shared, parent.get_path(),
+                                       "ExternalCommitHelper_CommitCondVar",
+                                       std::filesystem::temp_directory_path().u8string());
     m_thread = std::async(std::launch::async, [this]() { listen(); });
 }
 
 ExternalCommitHelper::~ExternalCommitHelper()
 {
-    ReleaseMutex(m_close_mutex);
+    {
+        std::lock_guard<InterprocessMutex> lock(m_mutex);
+        m_keep_listening = false;
+        m_commit_available.notify_all();
+    }
     m_thread.wait();
 
-    CloseHandle(m_event);
-    CloseHandle(m_close_mutex);
+    m_commit_available.release_shared_part();
+    UnmapViewOfFile(m_condvar_shared);
+    CloseHandle(m_shared_memory);
 }
 
 void ExternalCommitHelper::notify_others()
 {
-    SetEvent(m_event);
-    std::this_thread::yield();
-    ResetEvent(m_event);
+    m_commit_available.notify_all();
 }
 
 void ExternalCommitHelper::listen()
 {
-    std::array<HANDLE, 2> handles{ m_event, m_close_mutex };
-    while (true) {
-        DWORD wait_result = WaitForMultipleObjectsEx(handles.size(), handles.data(), false, INFINITE, false);
-        switch (wait_result) {
-        case WAIT_OBJECT_0: // event signaled
-            m_parent.on_change();
-            continue;
-        case WAIT_OBJECT_0 + 1: // mutex released
-            return; // exit the loop
-        case WAIT_FAILED:
-            throw std::system_error(GetLastError(), std::system_category());
-        }
+    std::lock_guard<InterprocessMutex> lock(m_mutex);
+    while (m_keep_listening) {
+        m_commit_available.wait(m_mutex, nullptr);
+        m_parent.on_change();
     }
-    REALM_UNREACHABLE();
 }

--- a/src/impl/windows/external_commit_helper.hpp
+++ b/src/impl/windows/external_commit_helper.hpp
@@ -22,8 +22,6 @@
 #include <windows.h>
 
 namespace realm {
-class Replication;
-
 namespace _impl {
 class RealmCoordinator;
 
@@ -42,10 +40,13 @@ private:
     // The listener thread
     std::future<void> m_thread;
 
-    HANDLE m_event;
-    HANDLE m_close_mutex;
+    HANDLE m_shared_memory;
+    InterprocessCondVar::SharedPart* m_condvar_shared;
+
+    InterprocessCondVar m_commit_available;
+    InterprocessMutex m_mutex;
+    bool m_keep_listening = true;
 };
 
 } // namespace _impl
 } // namespace realm
-


### PR DESCRIPTION
Starting with Core 3.0 we have a robust interprocess mutex and condition variable implementation on Windows we can use to reliably notify interested parties of commits at the Object Store level.

The implementation heavily borrows from `SharedGroup::wait_for_change()`. In fact, I believe the generic ExternalCommitHelper implementation should perform equally well on Windows - we’d be using it instead of this one if it only worked with synced realms.