### PR TITLE
Express the guards around override_session in terms of the sync version

### DIFF
--- a/src/feature_checks.hpp
+++ b/src/feature_checks.hpp
@@ -31,6 +31,7 @@
 
 #include <realm/sync/version.hpp>
 #define REALM_HAVE_SYNC_STABLE_IDS (REALM_SYNC_VER_MAJOR > 1)
+#define REALM_HAVE_SYNC_OVERRIDE_SERVER (REALM_SYNC_VER_MAJOR > 1)
 
 #else
 

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -130,7 +130,7 @@ struct SyncSession::State {
         return false;
     }
 
-#if (REALM_VERSION_MAJOR >= 4)
+#if REALM_HAVE_SYNC_OVERRIDE_SERVER
     virtual void override_server(std::unique_lock<std::mutex>&, SyncSession&, std::string, int) const { }
 #endif
 
@@ -165,7 +165,7 @@ struct sync_session_states::WaitingForAccessToken : public SyncSession::State {
             session.m_session_has_been_bound = true;
         }
 
-#if (REALM_VERSION_MAJOR >= 4)
+#if REALM_HAVE_SYNC_OVERRIDE_SERVER
         if (session.m_server_override)
             session.m_session->override_server(session.m_server_override->address, session.m_server_override->port);
 #endif
@@ -238,7 +238,7 @@ struct sync_session_states::WaitingForAccessToken : public SyncSession::State {
         return true;
     }
 
-#if (REALM_VERSION_MAJOR >= 4)
+#if REALM_HAVE_SYNC_OVERRIDE_SERVER
     void override_server(std::unique_lock<std::mutex>&, SyncSession& session,
                          std::string address, int port) const override
     {
@@ -310,7 +310,7 @@ struct sync_session_states::Active : public SyncSession::State {
         session.m_session->cancel_reconnect_delay();
     }
 
-#if (REALM_VERSION_MAJOR >= 4)
+#if REALM_HAVE_SYNC_OVERRIDE_SERVER
     void override_server(std::unique_lock<std::mutex>&, SyncSession& session,
                          std::string address, int port) const override
     {
@@ -369,7 +369,7 @@ struct sync_session_states::Dying : public SyncSession::State {
         return true;
     }
 
-#if (REALM_VERSION_MAJOR >= 4)
+#if REALM_HAVE_SYNC_OVERRIDE_SERVER
     void override_server(std::unique_lock<std::mutex>&, SyncSession& session,
                          std::string address, int port) const override
     {
@@ -416,7 +416,7 @@ struct sync_session_states::Inactive : public SyncSession::State {
         return true;
     }
 
-#if (REALM_VERSION_MAJOR >= 4)
+#if REALM_HAVE_SYNC_OVERRIDE_SERVER
     void override_server(std::unique_lock<std::mutex>&, SyncSession& session,
                          std::string address, int port) const override
     {
@@ -883,7 +883,7 @@ void SyncSession::bind_with_admin_token(std::string admin_token, std::string ser
     m_state->bind_with_admin_token(lock, *this, admin_token, server_url);
 }
 
-#if (REALM_VERSION_MAJOR >= 4)
+#if REALM_HAVE_SYNC_OVERRIDE_SERVER
 void SyncSession::override_server(std::string address, int port)
 {
     std::unique_lock<std::mutex> lock(m_state_mutex);

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -19,10 +19,11 @@
 #ifndef REALM_OS_SYNC_SESSION_HPP
 #define REALM_OS_SYNC_SESSION_HPP
 
+#include "feature_checks.hpp"
+#include "sync/sync_config.hpp"
+
 #include <realm/util/optional.hpp>
 #include <realm/version_id.hpp>
-
-#include "sync/sync_config.hpp"
 
 #include <mutex>
 #include <unordered_map>
@@ -143,13 +144,13 @@ public:
     // Inform the sync session that it should log out.
     void log_out();
 
+#if REALM_HAVE_SYNC_OVERRIDE_SERVER
     // Override the address and port of the server that this `SyncSession` is connected to. If the
     // session is already connected, it will disconnect and then reconnect to the specified address.
     // If it's not already connected, future connection attempts will be to the specified address.
     //
     // NOTE: This is intended for use only in very specific circumstances. Please check with the
     // object store team before using it.
-#if (REALM_VERSION_MAJOR >= 4)
     void override_server(std::string address, int port);
 #endif
 
@@ -320,7 +321,7 @@ private:
     };
     std::vector<CompletionWaitPackage> m_completion_wait_packages;
 
-#if (REALM_VERSION_MAJOR >= 4)
+#if REALM_HAVE_SYNC_OVERRIDE_SERVER
     struct ServerOverride {
         std::string address;
         int port;


### PR DESCRIPTION
We test only the major version as there's no easy way to distinguish between 2.0.0 and previous release candidates.

This addresses post-merge feedback that was given on #568.