### PR TITLE
Defer delivery of the initial notification when a callback is added from within a callback on the same collection

### DIFF
--- a/src/impl/collection_notifier.cpp
+++ b/src/impl/collection_notifier.cpp
@@ -213,8 +213,10 @@ void CollectionNotifier::remove_callback(size_t token)
         }
 
         size_t idx = distance(begin(m_callbacks), it);
-        if (m_callback_index != npos && m_callback_index >= idx) {
-            --m_callback_index;
+        if (m_callback_index != npos) {
+            if (m_callback_index >= idx)
+                --m_callback_index;
+            --m_callback_count;
         }
 
         old = std::move(*it);
@@ -373,7 +375,8 @@ template<typename Fn>
 void CollectionNotifier::for_each_callback(Fn&& fn)
 {
     std::unique_lock<std::mutex> callback_lock(m_callback_mutex);
-    for (++m_callback_index; m_callback_index < m_callbacks.size(); ++m_callback_index) {
+    m_callback_count = m_callbacks.size();
+    for (++m_callback_index; m_callback_index < m_callback_count; ++m_callback_index) {
         fn(callback_lock, m_callbacks[m_callback_index]);
         if (!callback_lock.owns_lock())
             callback_lock.lock();

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -237,6 +237,10 @@ private:
     // Iteration variable for looping over callbacks
     // remove_callback() updates this when needed
     size_t m_callback_index = -1;
+    // During callback iteration, the number of callbacks present at the
+    // beginning of iteration which have not been removed.
+    // Used to avoid calling callbacks registered during iteration.
+    size_t m_callback_count = -1;
 
     template<typename Fn>
     void for_each_callback(Fn&& fn);


### PR DESCRIPTION
The previous behavior of sending the initial notification immediately would result in notifications being lost if the background worker ran at exactly the wrong time. Fixing this turned out to be complicated and sending the initial notification immediately was inconsistent with the normal behavior, so just don't.

The newly added test is a simplification of what the java permissions code is doing that results in https://github.com/realm/realm-java/issues/5413, and without these changes is called once with `table->get_int(0, 0) == 0`, and then is not called again when the realm is advanced to the version with it set to 5.