### PR TITLE
Fix some use-after-move errors

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -225,8 +225,9 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
     }
 
     if (!realm) {
+        bool should_initialize_notifier = !config.immutable() && config.automatic_change_notifications;
         realm = Realm::make_shared_realm(std::move(config), shared_from_this());
-        if (!config.immutable() && !m_notifier && config.automatic_change_notifications) {
+        if (!m_notifier && should_initialize_notifier) {
             try {
                 m_notifier = std::make_unique<ExternalCommitHelper>(*this);
             }

--- a/src/index_set.cpp
+++ b/src/index_set.cpp
@@ -80,7 +80,7 @@ void ChunkedRangeVector::push_back(value_type value)
         range.end = value.second;
     }
     else {
-        m_data.push_back({{ value }, value.first, value.second, value.second - value.first});
+        m_data.push_back({{value}, value.first, value.second, value.second - value.first});
     }
     verify();
 }

--- a/src/index_set.cpp
+++ b/src/index_set.cpp
@@ -80,7 +80,7 @@ void ChunkedRangeVector::push_back(value_type value)
         range.end = value.second;
     }
     else {
-        m_data.push_back({{std::move(value)}, value.first, value.second, value.second - value.first});
+        m_data.push_back({{ value }, value.first, value.second, value.second - value.first});
     }
     verify();
 }


### PR DESCRIPTION
`clang-tidy` uncovered a few issues.