### PR TITLE
Fix two use-after-move issues flagged in sync-related code

### DIFF
--- a/src/sync/sync_permission.cpp
+++ b/src/sync/sync_permission.cpp
@@ -341,9 +341,8 @@ SharedRealm Permissions::management_realm(std::shared_ptr<SyncUser> user, const 
         }},
     };
     config.schema_version = 0;
-    const std::string path = config.path;
     auto shared_realm = Realm::get_shared_realm(std::move(config));
-    user->register_management_session(path);
+    user->register_management_session(shared_realm->config().path);
     return shared_realm;
 }
 
@@ -364,8 +363,7 @@ SharedRealm Permissions::permission_realm(std::shared_ptr<SyncUser> user, const 
         }}
     };
     config.schema_version = 0;
-    const std::string path = config.path;
     auto shared_realm = Realm::get_shared_realm(std::move(config));
-    user->register_permission_session(path);
+    user->register_permission_session(shared_realm->config().path);
     return shared_realm;
 }

--- a/src/sync/sync_permission.cpp
+++ b/src/sync/sync_permission.cpp
@@ -341,8 +341,9 @@ SharedRealm Permissions::management_realm(std::shared_ptr<SyncUser> user, const 
         }},
     };
     config.schema_version = 0;
+    const std::string path = config.path;
     auto shared_realm = Realm::get_shared_realm(std::move(config));
-    user->register_management_session(config.path);
+    user->register_management_session(path);
     return shared_realm;
 }
 
@@ -363,7 +364,8 @@ SharedRealm Permissions::permission_realm(std::shared_ptr<SyncUser> user, const 
         }}
     };
     config.schema_version = 0;
+    const std::string path = config.path;
     auto shared_realm = Realm::get_shared_realm(std::move(config));
-    user->register_permission_session(config.path);
+    user->register_permission_session(path);
     return shared_realm;
 }


### PR DESCRIPTION
It seems these are somewhat more serious than those from #577. Without these fixes, a user's internal permissions and management Realms will continue syncing even if the user logs out.