### PR TITLE
Fix an edge case that would result in errors not being delivered

### DIFF
--- a/src/collection_notifications.cpp
+++ b/src/collection_notifications.cpp
@@ -23,7 +23,7 @@
 using namespace realm;
 using namespace realm::_impl;
 
-NotificationToken::NotificationToken(std::shared_ptr<_impl::CollectionNotifier> notifier, size_t token)
+NotificationToken::NotificationToken(std::shared_ptr<_impl::CollectionNotifier> notifier, uint64_t token)
 : m_notifier(std::move(notifier)), m_token(token)
 {
 }

--- a/src/collection_notifications.hpp
+++ b/src/collection_notifications.hpp
@@ -35,7 +35,7 @@ namespace _impl {
 // A token which keeps an asynchronous query alive
 struct NotificationToken {
     NotificationToken() = default;
-    NotificationToken(std::shared_ptr<_impl::CollectionNotifier> notifier, size_t token);
+    NotificationToken(std::shared_ptr<_impl::CollectionNotifier> notifier, uint64_t token);
     ~NotificationToken();
 
     NotificationToken(NotificationToken&&);
@@ -48,7 +48,7 @@ struct NotificationToken {
 
 private:
     util::AtomicSharedPtr<_impl::CollectionNotifier> m_notifier;
-    size_t m_token;
+    uint64_t m_token;
 };
 
 struct CollectionChangeSet {

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -118,13 +118,13 @@ public:
     // Add a callback to be called each time the collection changes
     // This can only be called from the target collection's thread
     // Returns a token which can be passed to remove_callback()
-    size_t add_callback(CollectionChangeCallback callback);
+    uint64_t add_callback(CollectionChangeCallback callback);
     // Remove a previously added token. The token is no longer valid after
     // calling this function and must not be used again. This function can be
     // called from any thread.
-    void remove_callback(size_t token);
+    void remove_callback(uint64_t token);
 
-    void suppress_next_notification(size_t token);
+    void suppress_next_notification(uint64_t token);
 
     // ------------------------------------------------------------------------
     // API for RealmCoordinator to manage running things and calling callbacks
@@ -218,7 +218,7 @@ private:
         CollectionChangeCallback fn;
         CollectionChangeBuilder accumulated_changes;
         CollectionChangeSet changes_to_deliver;
-        size_t token;
+        uint64_t token;
         bool initial_delivered;
         bool skip_next;
     };
@@ -242,10 +242,12 @@ private:
     // Used to avoid calling callbacks registered during iteration.
     size_t m_callback_count = -1;
 
+    uint64_t m_next_token = 0;
+
     template<typename Fn>
     void for_each_callback(Fn&& fn);
 
-    std::vector<Callback>::iterator find_callback(size_t token);
+    std::vector<Callback>::iterator find_callback(uint64_t token);
 };
 
 // A smart pointer to a CollectionNotifier that unregisters the notifier when


### PR DESCRIPTION
Reusing notifier tokens resulted in deregistering a token created before errors were delivered actually removing a callback registered after errors were delivered.

Unlikely that this has ever actually been a problem for anyone, but there's really no reason to be reusing tokens and this makes the code simpler.