### PR TITLE
Fix more problems with adding callbacks from within callbacks

### DIFF
--- a/src/impl/collection_notifier.cpp
+++ b/src/impl/collection_notifier.cpp
@@ -335,7 +335,7 @@ void CollectionNotifier::deliver_error(std::exception_ptr error)
     m_error = true;
 
     m_callback_count = m_callbacks.size();
-    for_each_callback([&](auto& lock, auto& callback) {
+    for_each_callback([this, &error](auto& lock, auto& callback) {
         // acquire a local reference to the callback so that removing the
         // callback from within it can't result in a dangling pointer
         auto cb = std::move(callback.fn);
@@ -344,7 +344,7 @@ void CollectionNotifier::deliver_error(std::exception_ptr error)
         cb.error(error);
 
         // We never want to call the callback again after this, so just remove it
-        remove_callback(token);
+        this->remove_callback(token);
     });
 }
 

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -237,9 +237,10 @@ private:
     // Iteration variable for looping over callbacks
     // remove_callback() updates this when needed
     size_t m_callback_index = -1;
-    // During callback iteration, the number of callbacks present at the
-    // beginning of iteration which have not been removed.
-    // Used to avoid calling callbacks registered during iteration.
+    // The number of callbacks which were present when the notifier was packaged
+    // for delivery which are still present.
+    // Updated by packaged_for_delivery and removd_callback(), and used in
+    // for_each_callback() to avoid calling callbacks registered during delivery.
     size_t m_callback_count = -1;
 
     uint64_t m_next_token = 0;

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -279,6 +279,61 @@ TEST_CASE("notifications: async delivery") {
         REQUIRE(called);
     }
 
+    SECTION("notifications are delivered on the next cycle when a new callback is added from within a callback") {
+        auto results2 = results;
+        auto results3 = results;
+        NotificationToken token2, token3, token4;
+
+        bool called = false;
+        auto check = [&](Results& outer, Results& inner) {
+            token2 = outer.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+                token2 = {};
+                token3 = inner.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+                    called = true;
+                });
+            });
+
+            advance_and_notify(*r);
+            REQUIRE_FALSE(called);
+            advance_and_notify(*r);
+            REQUIRE(called);
+        };
+
+        SECTION("same Results") {
+            check(results, results);
+        }
+
+        SECTION("Results which has never had a notifier") {
+            check(results, results2);
+        }
+
+        SECTION("Results which used to have callbacks but no longer does") {
+            SECTION("notifier before active") {
+                token3 = results2.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+                    token3 = {};
+                });
+                check(results3, results2);
+            }
+            SECTION("notifier after active") {
+                token3 = results2.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+                    token3 = {};
+                });
+                check(results, results2);
+            }
+        }
+
+        SECTION("Results which already has callbacks") {
+            SECTION("notifier before active") {
+                token4 = results2.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) { });
+                check(results3, results2);
+            }
+            SECTION("notifier after active") {
+                token4 = results2.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) { });
+                check(results, results2);
+            }
+        }
+    }
+
     SECTION("remote changes made before adding a callback from within a callback are not reported") {
         NotificationToken token2, token3;
         bool called = false;
@@ -1021,10 +1076,26 @@ TEST_CASE("notifications: async error handling") {
             REQUIRE(called);
         }
 
-        SECTION("adding another callback from within an error callback") {
+        SECTION("adding another callback from within an error callback defers delivery") {
             NotificationToken token2;
             token = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
                 token2 = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr err) {
+                    REQUIRE(err);
+                    REQUIRE_FALSE(called);
+                    called = true;
+                });
+            });
+            advance_and_notify(*r);
+            REQUIRE(!called);
+            advance_and_notify(*r);
+            REQUIRE(called);
+        }
+
+        SECTION("adding a callback to a different collection from within the error callback defers delivery") {
+            auto results2 = results;
+            NotificationToken token2;
+            token = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+                token2 = results2.add_notification_callback([&](CollectionChangeSet, std::exception_ptr err) {
                     REQUIRE(err);
                     REQUIRE_FALSE(called);
                     called = true;
@@ -1053,7 +1124,7 @@ TEST_CASE("notifications: async error handling") {
             REQUIRE(called);
         }
 
-        SECTION("adding another callback does not send the error again") {
+        SECTION("adding another callback only sends the error to the new one") {
             bool called = false;
             auto token = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr err) {
                 REQUIRE(err);

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -1020,6 +1020,21 @@ TEST_CASE("notifications: async error handling") {
             advance_and_notify(*r);
             REQUIRE(called);
         }
+
+        SECTION("adding another callback from within an error callback") {
+            NotificationToken token2;
+            token = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+                token2 = results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr err) {
+                    REQUIRE(err);
+                    REQUIRE_FALSE(called);
+                    called = true;
+                });
+            });
+            advance_and_notify(*r);
+            REQUIRE(!called);
+            advance_and_notify(*r);
+            REQUIRE(called);
+        }
     }
 
     SECTION("error when opening the executor SG") {


### PR DESCRIPTION
The initial notification for callbacks added within a callback for a *different* collection also need to be deferred for the same reason as when it's the same collection.