### PR TITLE
rename update_tableview to evaluate_query_if_needed and expose it to public

### DIFF
--- a/src/results.cpp
+++ b/src/results.cpp
@@ -138,7 +138,7 @@ size_t Results::size()
                 return m_query.count();
             REALM_FALLTHROUGH;
         case Mode::TableView:
-            update_tableview();
+            evaluate_query_if_needed();
             return m_table_view.size();
     }
     REALM_COMPILER_HINT_UNREACHABLE();
@@ -201,7 +201,7 @@ util::Optional<T> Results::try_get(size_t row_ndx)
             REALM_FALLTHROUGH;
         case Mode::Query:
         case Mode::TableView:
-            update_tableview();
+            evaluate_query_if_needed();
             if (row_ndx >= m_table_view.size())
                 break;
             if (m_update_policy == UpdatePolicy::Never && !m_table_view.is_row_attached(row_ndx))
@@ -230,7 +230,7 @@ util::Optional<T> Results::last()
 {
     validate_read();
     if (m_mode == Mode::Query)
-        update_tableview(); // avoid running the query twice (for size() and for get())
+        evaluate_query_if_needed(); // avoid running the query twice (for size() and for get())
     return try_get<T>(size() - 1);
 }
 
@@ -241,13 +241,13 @@ bool Results::update_linkview()
     if (!m_descriptor_ordering.is_empty()) {
         m_query = get_query();
         m_mode = Mode::Query;
-        update_tableview();
+        evaluate_query_if_needed();
         return false;
     }
     return true;
 }
 
-void Results::update_tableview(bool wants_notifications)
+void Results::evaluate_query_if_needed(bool wants_notifications)
 {
     if (m_update_policy == UpdatePolicy::Never) {
         REALM_ASSERT(m_mode == Mode::TableView);
@@ -312,7 +312,7 @@ size_t Results::index_of(RowExpr const& row)
             REALM_FALLTHROUGH;
         case Mode::Query:
         case Mode::TableView:
-            update_tableview();
+            evaluate_query_if_needed();
             return m_table_view.find_by_source_ndx(row.get_index());
     }
     REALM_COMPILER_HINT_UNREACHABLE();
@@ -331,7 +331,7 @@ size_t Results::index_of(T const& value)
             REALM_UNREACHABLE();
         case Mode::Query:
         case Mode::TableView:
-            update_tableview();
+            evaluate_query_if_needed();
             return m_table_view.find_first(0, value);
     }
     REALM_COMPILER_HINT_UNREACHABLE();
@@ -363,7 +363,7 @@ void Results::prepare_for_aggregate(size_t column, const char* name)
             REALM_FALLTHROUGH;
         case Mode::Query:
         case Mode::TableView:
-            update_tableview();
+            evaluate_query_if_needed();
             break;
         default:
             REALM_COMPILER_HINT_UNREACHABLE();
@@ -453,7 +453,7 @@ void Results::clear()
             // clearing it is actually significantly faster
         case Mode::TableView:
             validate_write();
-            update_tableview();
+            evaluate_query_if_needed();
 
             switch (m_update_policy) {
                 case UpdatePolicy::Auto:
@@ -533,7 +533,7 @@ TableView Results::get_tableview()
             REALM_FALLTHROUGH;
         case Mode::Query:
         case Mode::TableView:
-            update_tableview();
+            evaluate_query_if_needed();
             return m_table_view;
         case Mode::Table:
             return m_table->where().find_all();
@@ -672,7 +672,7 @@ Results Results::snapshot() &&
             REALM_FALLTHROUGH;
         case Mode::Query:
         case Mode::TableView:
-            update_tableview(false);
+            evaluate_query_if_needed(false);
             m_notifier.reset();
             m_update_policy = UpdatePolicy::Never;
             return std::move(*this);

--- a/src/results.hpp
+++ b/src/results.hpp
@@ -209,6 +209,11 @@ public:
     template<typename Context, typename T>
     size_t index_of(Context&, T value);
 
+    // Execute the query immediately if needed. When the relevant query is slow, size()
+    // may cost similar time compared with creating the tableview. Use this function to
+    // avoid running the query twice for size() and other accessors.
+    void evaluate_query_if_needed(bool wants_notifications = true);
+
 private:
     enum class UpdatePolicy {
         Auto,  // Update automatically to reflect changes in the underlying data.
@@ -230,7 +235,6 @@ private:
     bool m_has_used_table_view = false;
     bool m_wants_background_updates = true;
 
-    void update_tableview(bool wants_notifications = true);
     bool update_linkview();
 
     void validate_read() const;


### PR DESCRIPTION
The orignal purpose of not creating TableView in size() is to make the
call faster if the query has not been executed before. But in the real
usecases, users always try to call accessors after the size() which
makes the query gets executed twice. See java issue
https://github.com/realm/realm-java/issues/5328
https://github.com/realm/realm-java/issues/5387

With this change, there would be no difference if the query has been
evaluated before.

It will be faster if:
- Calling Results::size() multiple times in the same event loop.
- Calling any accessors after Results::size().

It will be slower if:
- Calling Results::size() at the first time.