### PR TITLE
Expose an option to enable sync multiplexing

### DIFF
--- a/src/sync/impl/sync_client.hpp
+++ b/src/sync/impl/sync_client.hpp
@@ -39,10 +39,8 @@ namespace _impl {
 using ReconnectMode = sync::Client::ReconnectMode;
 
 struct SyncClient {
-    sync::Client client;
-
-    SyncClient(std::unique_ptr<util::Logger> logger, ReconnectMode reconnect_mode = ReconnectMode::normal)
-        : client(make_client(*logger, reconnect_mode)) // Throws
+    SyncClient(std::unique_ptr<util::Logger> logger, ReconnectMode reconnect_mode, bool multiplex_sessions)
+        : m_client(make_client(*logger, reconnect_mode, multiplex_sessions)) // Throws
         , m_logger(std::move(logger))
         , m_thread([this] {
             if (g_binding_callback_thread_observer) {
@@ -51,14 +49,14 @@ struct SyncClient {
                     g_binding_callback_thread_observer->will_destroy_thread();
                 });
                 try {
-                    client.run(); // Throws
+                    m_client.run(); // Throws
                 }
                 catch (std::exception const& e) {
                     g_binding_callback_thread_observer->handle_error(e);
                 }
             }
             else {
-                client.run(); // Throws
+                m_client.run(); // Throws
             }
         }) // Throws
 #if NETWORK_REACHABILITY_AVAILABLE
@@ -76,15 +74,21 @@ struct SyncClient {
 #endif
 
     void cancel_reconnect_delay() {
-        client.cancel_reconnect_delay();
+        m_client.cancel_reconnect_delay();
     }
 
     void stop()
     {
-        client.stop();
+        m_client.stop();
         if (m_thread.joinable())
             m_thread.join();
     }
+
+    std::unique_ptr<sync::Session> make_session(std::string path, sync::Session::Config config)
+    {
+        return std::make_unique<sync::Session>(m_client, std::move(path), std::move(config));
+    }
+
 
     ~SyncClient()
     {
@@ -92,14 +96,16 @@ struct SyncClient {
     }
 
 private:
-    static sync::Client make_client(util::Logger& logger, ReconnectMode reconnect_mode)
+    static sync::Client make_client(util::Logger& logger, ReconnectMode reconnect_mode, bool multiplex_sessions)
     {
         sync::Client::Config config;
         config.logger = &logger;
         config.reconnect_mode = std::move(reconnect_mode);
+        config.one_connection_per_session = !multiplex_sessions;
         return sync::Client(std::move(config)); // Throws
     }
 
+    sync::Client m_client;
     const std::unique_ptr<util::Logger> m_logger;
     std::thread m_thread;
 #if NETWORK_REACHABILITY_AVAILABLE

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -489,11 +489,11 @@ void SyncManager::unregister_session(const std::string& path)
     m_sessions.erase(path);
 }
 
-void SyncManager::enable_connection_multiplexing()
+void SyncManager::enable_session_multiplexing()
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     if (m_sync_client)
-        throw std::logic_error("Cannot enable connection multiplexing after creating the sync client");
+        throw std::logic_error("Cannot enable session multiplexing after creating the sync client");
     m_multiplex_sessions = true;
 }
 

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -235,6 +235,7 @@ void SyncManager::reset_for_testing()
         m_log_level = util::Logger::Level::info;
         m_logger_factory = nullptr;
         m_client_reconnect_mode = ReconnectMode::normal;
+        m_multiplex_sessions = false;
     }
 }
 
@@ -488,6 +489,14 @@ void SyncManager::unregister_session(const std::string& path)
     m_sessions.erase(path);
 }
 
+void SyncManager::enable_connection_multiplexing()
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    if (m_sync_client)
+        throw std::logic_error("Cannot enable connection multiplexing after creating the sync client");
+    m_multiplex_sessions = true;
+}
+
 SyncClient& SyncManager::get_sync_client() const
 {
     std::lock_guard<std::mutex> lock(m_mutex);
@@ -509,8 +518,7 @@ std::unique_ptr<SyncClient> SyncManager::create_sync_client() const
         stderr_logger->set_level_threshold(m_log_level);
         logger = std::move(stderr_logger);
     }
-    return std::make_unique<SyncClient>(std::move(logger),
-                                        m_client_reconnect_mode);
+    return std::make_unique<SyncClient>(std::move(logger), m_client_reconnect_mode, m_multiplex_sessions);
 }
 
 std::string SyncManager::client_uuid() const

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -78,11 +78,12 @@ public:
     // The metadata and file management subsystems must also have already been configured.
     bool immediately_run_file_actions(const std::string& original_name);
 
-    // Use a single connection for all sync sessions rather than one per session.
+    // Use a single connection for all sync sessions for each host/port rather
+    // than one per session.
     // This must be called before any sync sessions are created, cannot be
     // disabled afterwards, and currently is incompatible with using a load
     // balancer or automatic failover.
-    void enable_connection_multiplexing();
+    void enable_session_multiplexing();
 
     void set_log_level(util::Logger::Level) noexcept;
     void set_logger_factory(SyncLoggerFactory&) noexcept;

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -78,6 +78,12 @@ public:
     // The metadata and file management subsystems must also have already been configured.
     bool immediately_run_file_actions(const std::string& original_name);
 
+    // Use a single connection for all sync sessions rather than one per session.
+    // This must be called before any sync sessions are created, cannot be
+    // disabled afterwards, and currently is incompatible with using a load
+    // balancer or automatic failover.
+    void enable_connection_multiplexing();
+
     void set_log_level(util::Logger::Level) noexcept;
     void set_logger_factory(SyncLoggerFactory&) noexcept;
 
@@ -183,6 +189,7 @@ private:
     std::unordered_map<std::string, std::shared_ptr<SyncUser>> m_admin_token_users;
 
     mutable std::unique_ptr<_impl::SyncClient> m_sync_client;
+    bool m_multiplex_sessions = false;
 
     // Protects m_file_manager and m_metadata_manager
     mutable std::mutex m_file_system_mutex;

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -718,7 +718,7 @@ void SyncSession::create_sync_session()
     session_config.verify_servers_ssl_certificate = m_config.client_validate_ssl;
     session_config.ssl_trust_certificate_path = m_config.ssl_trust_certificate_path;
     session_config.ssl_verify_callback = m_config.ssl_verify_callback;
-    m_session = std::make_unique<sync::Session>(m_client.client, m_realm_path, session_config);
+    m_session = m_client.make_session(m_realm_path, std::move(session_config));
 
     // The next time we get a token, call `bind()` instead of `refresh()`.
     m_session_has_been_bound = false;


### PR DESCRIPTION
This is disabled by default as it doesn't work with load balancing, but the GN really needs it.

Since the option to disable multiplexing was originally just there for tests the API for this is pretty awkward, but we can sort that out later.

I'm not really sure how to usefully test this at the objectstore layer, but I have verified that it achieves the desired end result (by calling this function the GN is able to open >10k realms rather than hitting the open file limit at 1500).