### PR TITLE
Improve sync config

### DIFF
--- a/src/sync/sync_config.hpp
+++ b/src/sync/sync_config.hpp
@@ -124,31 +124,12 @@ struct SyncConfig {
     // This will differ from `reference_realm_url` when partial sync is being used.
     std::string realm_url() const;
 
-    SyncConfig(std::shared_ptr<SyncUser> user, std::string reference_realm_url,
-               SyncSessionStopPolicy stop_policy,
-               std::function<SyncBindSessionHandler> bind_session_handler,
-               std::function<SyncSessionErrorHandler> error_handler = nullptr,
-               std::shared_ptr<ChangesetTransformer> transformer = nullptr,
-               util::Optional<std::array<char, 64>> realm_encryption_key = util::none,
-               bool client_validate_ssl = true, 
-               util::Optional<std::string> ssl_trust_certificate_path = util::none, 
-               std::function<realm::sync::Session::SSLVerifyCallback> ssl_verify_callback = nullptr,
-               bool is_partial = false,
-               util::Optional<std::string> custom_partial_sync_identifier = util::none
-        )
-        : user(std::move(user))
-        , reference_realm_url(std::move(reference_realm_url))
-        , stop_policy(stop_policy)
-        , bind_session_handler(std::move(bind_session_handler))
-        , error_handler(std::move(error_handler))
-        , transformer(std::move(transformer))
-        , realm_encryption_key(std::move(realm_encryption_key))
-        , client_validate_ssl(client_validate_ssl)
-        , ssl_trust_certificate_path(std::move(ssl_trust_certificate_path))
-        , ssl_verify_callback(std::move(ssl_verify_callback))
-        , is_partial(is_partial)
-        , custom_partial_sync_identifier(std::move(custom_partial_sync_identifier))
+    SyncConfig(std::shared_ptr<SyncUser> user, std::string reference_realm_url)
+    : user(std::move(user))
+    , reference_realm_url(std::move(reference_realm_url))
     {
+        if (this->reference_realm_url.find("/__partial/") != npos)
+            throw std::invalid_argument("A Realm URL may not contain the reserved string \"/__partial/\".");
     }
 };
 

--- a/src/sync/sync_config.hpp
+++ b/src/sync/sync_config.hpp
@@ -20,6 +20,7 @@
 #define REALM_OS_SYNC_CONFIG_HPP
 
 #include "sync_user.hpp"
+#include "sync_manager.hpp"
 
 #include <realm/util/assert.hpp>
 #include <realm/sync/client.hpp>
@@ -107,16 +108,16 @@ struct SyncConfig {
     // and will differ from `reference_realm_url` if partial sync is being used.
     // Set this field, but read from `realm_url()`.
     std::string reference_realm_url;
-    SyncSessionStopPolicy stop_policy;
-    std::function<SyncBindSessionHandler> bind_session_handler;
-    std::function<SyncSessionErrorHandler> error_handler;
-    std::shared_ptr<ChangesetTransformer> transformer;
-    util::Optional<std::array<char, 64>> realm_encryption_key;
+    SyncSessionStopPolicy stop_policy = SyncSessionStopPolicy::AfterChangesUploaded;
+    std::function<SyncBindSessionHandler> bind_session_handler = nullptr;
+    std::function<SyncSessionErrorHandler> error_handler = nullptr;
+    std::shared_ptr<ChangesetTransformer> transformer = nullptr;
+    util::Optional<std::array<char, 64>> realm_encryption_key = none;
     bool client_validate_ssl = true;
-    util::Optional<std::string> ssl_trust_certificate_path;
-    std::function<sync::Session::SSLVerifyCallback> ssl_verify_callback;
-    bool is_partial;
-    util::Optional<std::string> custom_partial_sync_identifier;
+    util::Optional<std::string> ssl_trust_certificate_path = none;
+    std::function<sync::Session::SSLVerifyCallback> ssl_verify_callback = nullptr;
+    bool is_partial = false;
+    util::Optional<std::string> custom_partial_sync_identifier = none;
 
     bool validate_sync_history = true;
 

--- a/src/sync/sync_config.hpp
+++ b/src/sync/sync_config.hpp
@@ -112,7 +112,7 @@ struct SyncConfig {
     std::function<SyncSessionErrorHandler> error_handler;
     std::shared_ptr<ChangesetTransformer> transformer;
     util::Optional<std::array<char, 64>> realm_encryption_key;
-    bool client_validate_ssl;
+    bool client_validate_ssl = true;
     util::Optional<std::string> ssl_trust_certificate_path;
     std::function<sync::Session::SSLVerifyCallback> ssl_verify_callback;
     bool is_partial;

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -434,7 +434,7 @@ struct sync_session_states::Error : public SyncSession::State {
         }
         session.m_completion_wait_packages.clear();
         session.m_session = nullptr;
-        session.m_config = { nullptr, "", SyncSessionStopPolicy::Immediately, nullptr };
+        session.m_config = { nullptr, "" };
     }
 
     // Everything else is a no-op when in the error state.

--- a/tests/sync/session/session.cpp
+++ b/tests/sync/session/session.cpp
@@ -43,9 +43,10 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
     if (!EventLoop::has_implementation())
         return;
 
+    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
     const std::string dummy_auth_url = "https://realm.example.org";
-    SyncManager::shared().configure_file_system(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
+    SyncManager::shared().configure_file_system(tmp_dir(), SyncManager::MetadataMode::NoEncryption);
     const std::string realm_base_url = server.base_url();
 
     SECTION("a SyncUser can properly retrieve its owned sessions") {

--- a/tests/sync/session/session.cpp
+++ b/tests/sync/session/session.cpp
@@ -322,9 +322,10 @@ TEST_CASE("SyncSession: close() API", "[sync]") {
 }
 
 TEST_CASE("sync: error handling", "[sync]") {
+    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     using ProtocolError = realm::sync::ProtocolError;
     SyncServer server;
-    SyncManager::shared().configure_file_system(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
+    SyncManager::shared().configure_file_system(tmp_dir(), SyncManager::MetadataMode::NoEncryption);
 
     // Create a valid session.
     std::function<void(std::shared_ptr<SyncSession>, SyncError)> error_handler = [](auto, auto) { };

--- a/tests/sync/session/session_util.hpp
+++ b/tests/sync/session/session_util.hpp
@@ -68,8 +68,8 @@ std::shared_ptr<SyncSession> sync_session_with_bind_handler(SyncServer& server, 
                                                             Realm::Config* out_config=nullptr)
 {
     std::string url = server.base_url() + path;
-    SyncTestFile config({user, url, std::move(stop_policy),
-        std::forward<BindCallback>(bind_callback), std::forward<ErrorHandler>(error_handler)});
+    SyncTestFile config({user, url}, std::move(stop_policy),
+        std::forward<BindCallback>(bind_callback), std::forward<ErrorHandler>(error_handler));
     if (schema) {
         config.schema = *schema;
     }

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -18,6 +18,7 @@
 
 #include "sync_test_utils.hpp"
 
+#include "sync/sync_config.hpp"
 #include "sync/sync_manager.hpp"
 #include "sync/sync_user.hpp"
 #include <realm/util/logger.hpp>
@@ -43,6 +44,13 @@ bool validate_user_in_vector(std::vector<std::shared_ptr<SyncUser>> vector,
     return false;
 }
 
+}
+
+TEST_CASE("sync_config: basic functionality", "[sync") {
+    SECTION("should reject URLs containing \"/__partial/\"") {
+        auto make_bad_config = [] { SyncConfig{nullptr, "realm://example.org:9080/123456/__partial/realm"}; };
+        REQUIRE_THROWS(make_bad_config());
+    }
 }
 
 TEST_CASE("sync_manager: basic properties and APIs", "[sync]") {

--- a/tests/util/test_file.hpp
+++ b/tests/util/test_file.hpp
@@ -106,8 +106,8 @@ struct SyncTestFile : TestFile {
     template<typename BindHandler, typename ErrorHandler>
     SyncTestFile(const realm::SyncConfig& sync_config, 
         realm::SyncSessionStopPolicy stop_policy, 
-        BindHandler bind_handler, 
-        ErrorHandler error_handler)
+        BindHandler&& bind_handler, 
+        ErrorHandler&& error_handler)
     {
         this->sync_config = std::make_shared<realm::SyncConfig>(sync_config);
         this->sync_config->stop_policy = stop_policy;

--- a/tests/util/test_file.hpp
+++ b/tests/util/test_file.hpp
@@ -26,12 +26,15 @@
 #include <realm/util/optional.hpp>
 
 #if REALM_ENABLE_SYNC
+#include "sync/sync_config.hpp"
+
 #include <realm/sync/client.hpp>
 #include <realm/sync/server.hpp>
 
 namespace realm {
 struct SyncConfig;
 class Schema;
+enum class SyncSessionStopPolicy;
 }
 
 // {"identity":"test", "access": ["download", "upload"]}
@@ -100,7 +103,19 @@ private:
 };
 
 struct SyncTestFile : TestFile {
-    SyncTestFile(const realm::SyncConfig&);
+    template<typename BindHandler, typename ErrorHandler>
+    SyncTestFile(const realm::SyncConfig& sync_config, 
+        realm::SyncSessionStopPolicy stop_policy, 
+        BindHandler bind_handler, 
+        ErrorHandler error_handler)
+    {
+        this->sync_config = std::make_shared<realm::SyncConfig>(sync_config);
+        this->sync_config->stop_policy = stop_policy;
+        this->sync_config->bind_session_handler = std::forward<BindHandler>(bind_handler);
+        this->sync_config->error_handler = std::forward<ErrorHandler>(error_handler);
+        schema_mode = realm::SchemaMode::Additive;
+    }
+
     SyncTestFile(SyncServer& server, 
         std::string name="", 
         realm::util::Optional<realm::Schema> realm_schema=none, 


### PR DESCRIPTION
Changes:
- SyncConfig's constructor only takes the two required arguments now; all others must be explicitly set
- SyncConfig now throws an exception if the URL passed in is invalid
- Fixed a broken test case

Fixes #579