### PR TITLE
Create the sync session in set_transaction_callback()

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -890,5 +890,6 @@ void RealmCoordinator::process_available_async(Realm& realm)
 
 void RealmCoordinator::set_transaction_callback(std::function<void(VersionID, VersionID)> fn)
 {
+    create_sync_session();
     m_transaction_callback = std::move(fn);
 }


### PR DESCRIPTION
If it doesn't already exist.

The global notifier opens and then immediately closes each Realm during startup
purely for the sake of creating the sync session (it used to do more with the
Realms, but hasn't for a long time), and with a large number of Realms this
starts to take a significant amount of time.