### PR TITLE
Enhance GenericEventLoop abstraction

### DIFF
--- a/src/util/generic/event_loop_signal.hpp
+++ b/src/util/generic/event_loop_signal.hpp
@@ -17,42 +17,36 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #include <utility>
+#include <functional>
+#include <memory>
 
 namespace realm {
 namespace util {
 
-using GenericEventLoop = void*;
-using EventLoopPostHandler = void(const void* user_data);
+    struct GenericEventLoop {
+    public:
+        virtual void post(std::function<void()>) = 0;
+        virtual ~GenericEventLoop() = default;
+        static void set_event_loop_factory(std::function<std::unique_ptr<GenericEventLoop>()>);
+        static std::unique_ptr<GenericEventLoop> get();
+    };
 
-extern GenericEventLoop (*s_get_eventloop)();
+    template<typename Callback>
+    class EventLoopSignal {
+    public:
+        EventLoopSignal(Callback&& callback)
+                : m_callback(std::move(callback))
+                , m_eventloop(GenericEventLoop::get())
+        { }
 
-extern void (*s_post_on_eventloop)(GenericEventLoop, EventLoopPostHandler*, void* user_data);
-
-extern void (*s_release_eventloop)(GenericEventLoop);
-
-template<typename Callback>
-class EventLoopSignal {
-public:
-    EventLoopSignal(Callback&& callback)
-    : m_callback(std::move(callback))
-    , m_eventloop(s_get_eventloop())
-    { }
-
-    void notify() {
-        s_post_on_eventloop(m_eventloop, &on_post, this);
-    }
-
-    ~EventLoopSignal() {
-        s_release_eventloop(m_eventloop);
-    }
-private:
-    static void on_post(const void* user_data) {
-        reinterpret_cast<const EventLoopSignal<Callback>*>(user_data)->m_callback();
-    }
-
-    const Callback m_callback;
-    const GenericEventLoop m_eventloop;
-};
+        void notify()
+        {
+            m_eventloop->post(m_callback);
+        }
+    private:
+        Callback m_callback;
+        std::unique_ptr<GenericEventLoop> m_eventloop;
+    };
 
 } // namespace util
 } // namespace realm


### PR DESCRIPTION
This is a much nicer event loop abstraction that allows us to not be forced to use opaque pointers or rely on extern DATA symbols.

Functionality in realm-dotnet-server relies on this.