### PR TITLE
[CI] Explicitly select Windows SDK

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,7 +118,7 @@ def doWindowsBuild() {
       getSourceArchive()
 
       bat """
-        "${tool 'cmake'}" .
+        "${tool 'cmake'}" . -DCMAKE_SYSTEM_VERSION="8.1"
         "${tool 'cmake'}" --build . --config Release
         tests\\Release\\tests.exe
       """


### PR DESCRIPTION
Our windows nodes on CI come with a number of Windows SDKs and CMake has trouble selecting the right one.