### PR TITLE
Don't ignore unrecognized sync errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ MinSizeRel/
 
 # Visual Studio
 /.vs
+
+# Linters
+compile_commands.json

--- a/src/sync/sync_config.hpp
+++ b/src/sync/sync_config.hpp
@@ -59,6 +59,10 @@ struct SyncError {
     std::string message;
     bool is_fatal;
     std::unordered_map<std::string, std::string> user_info;
+    /// The sync server may send down an error that the client does not recognize,
+    /// whether because of a version mismatch or an oversight. It is still valuable
+    /// to expose these errors so that users can do something about them.
+    bool is_unrecognized_by_client = false;
 
     static constexpr const char c_original_file_path_key[] = "ORIGINAL_FILE_PATH";
     static constexpr const char c_recovery_file_path_key[] = "RECOVERY_FILE_PATH";

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -625,8 +625,9 @@ void SyncSession::handle_error(SyncError error)
                 break;
         }
     } else {
-        // Unrecognized error code; just ignore it.
-        return;
+        // Unrecognized error code.
+        error.is_unrecognized_by_client = true;
+        next_state = NextStateAfterError::error;
     }
     switch (next_state) {
         case NextStateAfterError::none:


### PR DESCRIPTION
The sync error handler was silently ignoring unrecognized errors. This change flags such errors as unrecognized and passes them to bindings, giving bindings the option to handle them further (e.g. present them to users).