### PR TITLE
Expose the ability to set the multiplex identity

### DIFF
--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -727,6 +727,7 @@ void SyncSession::create_sync_session()
     session_config.verify_servers_ssl_certificate = m_config.client_validate_ssl;
     session_config.ssl_trust_certificate_path = m_config.ssl_trust_certificate_path;
     session_config.ssl_verify_callback = m_config.ssl_verify_callback;
+    session_config.multiplex_ident = m_multiplex_identity;
     m_session = m_client.make_session(m_realm_path, std::move(session_config));
 
     // The next time we get a token, call `bind()` instead of `refresh()`.
@@ -897,6 +898,11 @@ void SyncSession::override_server(std::string address, int port)
     m_state->override_server(lock, *this, std::move(address), port);
 }
 #endif
+
+void SyncSession::set_multiplex_identifier(std::string multiplex_identity)
+{
+    m_multiplex_identity = std::move(multiplex_identity);
+}
 
 SyncSession::PublicState SyncSession::state() const
 {

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -138,6 +138,15 @@ public:
     // Give the `SyncSession` an administrator token, and ask it to immediately `bind()` the session.
     void bind_with_admin_token(std::string admin_token, std::string server_url);
 
+    // Set the multiplex identifier used for this session. Sessions with different identifiers are
+    // never multiplexed into a single connection, even if they are connecting to the same host.
+    // The value of the token is otherwise treated as an opaque token.
+    //
+    // Has no effect if session multiplexing is not enabled (see SyncManager::enable_session_multiplexing())
+    // or if called after the Sync session is created. In particular, changing the multiplex identity will
+    // not make the session reconnect.
+    void set_multiplex_identifier(std::string multiplex_identity);
+
     // Inform the sync session that it should close.
     void close();
 
@@ -345,6 +354,8 @@ private:
 
     // The fully-resolved URL of this Realm, including the server and the path.
     util::Optional<std::string> m_server_url;
+
+    std::string m_multiplex_identity;
 
     class ExternalReference;
     std::weak_ptr<ExternalReference> m_external_reference;


### PR DESCRIPTION
Used by https://github.com/realm/realm-js/pull/1499 to make the GN work with multiple backend shards.

I don't think there's any meaningful way to test this at the objectstore level.