### PR TITLE
Fix the build with GCC 4.9

### DIFF
--- a/src/sync/sync_config.hpp
+++ b/src/sync/sync_config.hpp
@@ -64,6 +64,13 @@ struct SyncError {
     /// to expose these errors so that users can do something about them.
     bool is_unrecognized_by_client = false;
 
+    SyncError(std::error_code error_code, std::string message, bool is_fatal)
+        : error_code(std::move(error_code))
+        , message(std::move(message))
+        , is_fatal(is_fatal)
+    {
+    }
+
     static constexpr const char c_original_file_path_key[] = "ORIGINAL_FILE_PATH";
     static constexpr const char c_recovery_file_path_key[] = "RECOVERY_FILE_PATH";
 


### PR DESCRIPTION
Add a constructor to `SyncError` since GCC 4.9 doesn't like brace initialization with non-static data member initializers.