### PR TITLE
 Don't reuse list notifiers which had all callbacks removed

### DIFF
--- a/tests/list.cpp
+++ b/tests/list.cpp
@@ -472,6 +472,27 @@ TEST_CASE("list") {
             advance_and_notify(*r);
             REQUIRE_INDICES(change.deletions, 5);
         }
+
+        // Test case to reproduce part of Java issue https://github.com/realm/realm-java/issues/5507
+        SECTION("changes are sent in initial notification after on_change called (another token has been added and removed)") {
+            auto token = lst.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
+                REQUIRE(false);
+            });
+            token = {}; // The problem doesn't happen without removing token.
+
+            r2->begin_transaction();
+            r2_lv->remove(5);
+            r2->commit_transaction();
+
+            coordinator.on_change(); // The problem doesn't happen without this line.
+
+            token = lst.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
+                change = c;
+            });
+
+            advance_and_notify(*r);
+            REQUIRE_INDICES(change.deletions, 5);
+        }
     }
 
     SECTION("sorted add_notification_block()") {


### PR DESCRIPTION
If a transaction is processed while a notifier has no callbacks, no work is done for that notifier and it gets into an inconsistent state. Adding a new callback to that notifier thus results in incorrect results from the first notification sent due to that the cached state is not properly reinitialized. Work around this for now by just not reusing list notifiers.

This problem does not apply to Results notifiers due to that the changeset in the Initial notification for those is not meaningful.

Fixes #601.