### PR TITLE
Extend notification system to support partially synced results

### DIFF
--- a/src/collection_notifications.hpp
+++ b/src/collection_notifications.hpp
@@ -88,10 +88,24 @@ struct CollectionChangeSet {
     // Per-column version of `modifications`
     std::vector<IndexSet> columns;
 
+    // Any potential error message from partial sync for the new collection
+    // This is only set if partial_sync_new_status_code is -1
+    std::string partial_sync_error_message;
+
+    /// Partial sync status codes:
+    // int8_t::min() -> Undefined
+    // -2            -> Not a partial Realm
+    // -1            -> Error occurred while processing the subscription.
+    // 0             -> Subscription created locally, but not processed by the server yet.
+    // 1             -> Subscription successfully processed by the server.
+    int8_t partial_sync_old_status_code;
+    int8_t partial_sync_new_status_code;
+
     bool empty() const noexcept
     {
         return deletions.empty() && insertions.empty() && modifications.empty()
-            && modifications_new.empty() && moves.empty();
+            && modifications_new.empty() && moves.empty()
+            && partial_sync_old_status_code == partial_sync_new_status_code;
     }
 };
 

--- a/src/collection_notifications.hpp
+++ b/src/collection_notifications.hpp
@@ -88,10 +88,6 @@ struct CollectionChangeSet {
     // Per-column version of `modifications`
     std::vector<IndexSet> columns;
 
-    // Any potential error message from partial sync for the new collection
-    // This is only set if partial_sync_new_status_code is -1
-    std::string partial_sync_error_message;
-
     /// Partial sync status codes:
     // int8_t::min() -> Undefined
     // -2            -> Not a partial Realm
@@ -100,6 +96,10 @@ struct CollectionChangeSet {
     // 1             -> Subscription successfully processed by the server.
     int8_t partial_sync_old_status_code;
     int8_t partial_sync_new_status_code;
+
+    // Any potential error message from partial sync for the new collection
+    // This is only set if partial_sync_new_status_code is -1
+    std::string partial_sync_error_message;
 
     bool empty() const noexcept
     {

--- a/src/collection_notifications.hpp
+++ b/src/collection_notifications.hpp
@@ -101,6 +101,8 @@ struct CollectionChangeSet {
     // This is only set if partial_sync_new_status_code is -1
     std::string partial_sync_error_message;
 
+    // Returns `true` iff this change set is "empty", i.e. no changes of interest
+    // can be reported.
     bool empty() const noexcept
     {
         return deletions.empty() && insertions.empty() && modifications.empty()

--- a/src/impl/collection_change_builder.cpp
+++ b/src/impl/collection_change_builder.cpp
@@ -504,6 +504,21 @@ void CollectionChangeBuilder::move_column(size_t from, size_t to)
         std::rotate(begin(columns) + to, begin(columns) + from, begin(columns) + from + 1);
 }
 
+void CollectionChangeBuilder::old_partial_sync_status_code(int8_t code)
+{
+    this->partial_sync_old_status_code = code;
+}
+
+void CollectionChangeBuilder::new_partial_sync_status_code(int8_t code)
+{
+    this->partial_sync_new_status_code = code;
+}
+
+void CollectionChangeBuilder::new_partial_sync_error_message(std::string error)
+{
+    this->partial_sync_error_message = error;
+}
+
 namespace {
 struct RowInfo {
     size_t row_index;

--- a/src/impl/collection_change_builder.cpp
+++ b/src/impl/collection_change_builder.cpp
@@ -58,6 +58,11 @@ void CollectionChangeBuilder::merge(CollectionChangeBuilder&& c)
         return;
     }
 
+    // Always override partial sync codes/status
+    m_partial_sync_old_status_code = c.partial_sync_old_status_code;
+    m_partial_sync_new_status_code = c.partial_sync_new_status_code;
+    m_partial_sync_error_message = c.partial_sync_error_message;
+
     verify();
     c.verify();
 
@@ -517,17 +522,17 @@ void CollectionChangeBuilder::move_column(size_t from, size_t to)
 
 void CollectionChangeBuilder::old_partial_sync_status_code(int8_t code)
 {
-    this->partial_sync_old_status_code = code;
+    m_partial_sync_old_status_code = code;
 }
 
 void CollectionChangeBuilder::new_partial_sync_status_code(int8_t code)
 {
-    this->partial_sync_new_status_code = code;
+    m_partial_sync_new_status_code = code;
 }
 
-void CollectionChangeBuilder::new_partial_sync_error_message(std::string error)
+void CollectionChangeBuilder::partial_sync_error_message(std::string error)
 {
-    this->partial_sync_error_message = error;
+    m_partial_sync_error_message = error;
 }
 
 namespace {
@@ -909,8 +914,8 @@ CollectionChangeSet CollectionChangeBuilder::finalize() &&
         std::move(modifications),
         std::move(moves),
         std::move(columns),
-        std::move(partial_sync_old_status_code),
-        std::move(partial_sync_new_status_code),
-        std::move(partial_sync_error_message)
+        std::move(m_partial_sync_old_status_code),
+        std::move(m_partial_sync_new_status_code),
+        std::move(m_partial_sync_error_message)
     };
 }

--- a/src/impl/collection_change_builder.cpp
+++ b/src/impl/collection_change_builder.cpp
@@ -29,8 +29,19 @@ using namespace realm::_impl;
 CollectionChangeBuilder::CollectionChangeBuilder(IndexSet deletions,
                                                  IndexSet insertions,
                                                  IndexSet modifications,
-                                                 std::vector<Move> moves)
-: CollectionChangeSet({std::move(deletions), std::move(insertions), std::move(modifications), {}, std::move(moves)})
+                                                 std::vector<Move> moves,
+                                                 int8_t partial_sync_old_status_code,
+                                                 int8_t partial_sync_new_status_code,
+                                                 std::string partial_sync_error_message)
+: CollectionChangeSet({std::move(deletions),
+                       std::move(insertions),
+                       std::move(modifications),
+                       {},
+                       std::move(moves),
+                       {},
+                       partial_sync_old_status_code,
+                       partial_sync_new_status_code,
+                       partial_sync_error_message})
 {
     for (auto&& move : this->moves) {
         this->deletions.add(move.from);
@@ -897,6 +908,9 @@ CollectionChangeSet CollectionChangeBuilder::finalize() &&
         std::move(modifications_in_old),
         std::move(modifications),
         std::move(moves),
-        std::move(columns)
+        std::move(columns),
+        std::move(partial_sync_old_status_code),
+        std::move(partial_sync_new_status_code),
+        std::move(partial_sync_error_message)
     };
 }

--- a/src/impl/collection_change_builder.hpp
+++ b/src/impl/collection_change_builder.hpp
@@ -40,7 +40,7 @@ public:
                             std::vector<Move> moves = {},
                             int8_t partial_sync_old_status_code = -2,
                             int8_t partial_sync_new_status_code = -2,
-                            std::string partial_sync_error_message = nullptr);
+                            std::string partial_sync_error_message = "");
 
     // Calculate where rows need to be inserted or deleted from old_rows to turn
     // it into new_rows, and check all matching rows for modifications
@@ -54,6 +54,8 @@ public:
 
     // generic operations {
     CollectionChangeSet finalize() &&;
+
+    // Merge input change set into this one.
     void merge(CollectionChangeBuilder&&);
 
     void insert(size_t ndx, size_t count=1, bool track_moves=true);
@@ -80,13 +82,17 @@ public:
     void insert_column(size_t ndx);
     void move_column(size_t from, size_t to);
 
+    // partial sync
     void old_partial_sync_status_code(int8_t code);
     void new_partial_sync_status_code(int8_t code);
-    void new_partial_sync_error_message(std::string error);
+    void partial_sync_error_message(std::string error);
 
 private:
     std::unordered_map<size_t, size_t> m_move_mapping;
     bool m_track_columns = true;
+    int8_t m_partial_sync_old_status_code;
+    int8_t m_partial_sync_new_status_code;
+    std::string m_partial_sync_error_message;
 
     template<typename Func>
     void for_each_col(Func&& f);

--- a/src/impl/collection_change_builder.hpp
+++ b/src/impl/collection_change_builder.hpp
@@ -37,7 +37,10 @@ public:
     CollectionChangeBuilder(IndexSet deletions = {},
                             IndexSet insertions = {},
                             IndexSet modification = {},
-                            std::vector<Move> moves = {});
+                            std::vector<Move> moves = {},
+                            int8_t partial_sync_old_status_code = -2,
+                            int8_t partial_sync_new_status_code = -2,
+                            std::string partial_sync_error_message = nullptr);
 
     // Calculate where rows need to be inserted or deleted from old_rows to turn
     // it into new_rows, and check all matching rows for modifications

--- a/src/impl/collection_change_builder.hpp
+++ b/src/impl/collection_change_builder.hpp
@@ -77,6 +77,10 @@ public:
     void insert_column(size_t ndx);
     void move_column(size_t from, size_t to);
 
+    void old_partial_sync_status_code(int8_t code);
+    void new_partial_sync_status_code(int8_t code);
+    void new_partial_sync_error_message(std::string error);
+
 private:
     std::unordered_map<size_t, size_t> m_move_mapping;
     bool m_track_columns = true;

--- a/src/impl/collection_notifier.cpp
+++ b/src/impl/collection_notifier.cpp
@@ -187,7 +187,7 @@ uint64_t CollectionNotifier::add_callback(CollectionChangeCallback callback)
     std::lock_guard<std::mutex> lock(m_callback_mutex);
     auto token = m_next_token++;
     // TODO Detect partial sync enabled here or not, if not 0 should be -2
-    m_callbacks.push_back({std::move(callback), {}, {}, token, false, false, 0, nullptr});
+    m_callbacks.push_back({std::move(callback), {}, {}, token, false, false});
     if (m_callback_index == npos) { // Don't need to wake up if we're already sending notifications
         Realm::Internal::get_coordinator(*m_realm).wake_up_notifier_worker();
         m_have_callbacks = true;

--- a/src/impl/collection_notifier.cpp
+++ b/src/impl/collection_notifier.cpp
@@ -182,7 +182,8 @@ uint64_t CollectionNotifier::add_callback(CollectionChangeCallback callback)
 
     std::lock_guard<std::mutex> lock(m_callback_mutex);
     auto token = m_next_token++;
-    m_callbacks.push_back({std::move(callback), {}, {}, token, false, false});
+    // TODO Detect partial sync enabled here or not, if not 0 should be -2
+    m_callbacks.push_back({std::move(callback), {}, {}, token, false, false, 0, nullptr});
     if (m_callback_index == npos) { // Don't need to wake up if we're already sending notifications
         Realm::Internal::get_coordinator(*m_realm).wake_up_notifier_worker();
         m_have_callbacks = true;

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -194,8 +194,9 @@ protected:
     void set_table(Table const& table);
     std::unique_lock<std::mutex> lock_target();
     SharedGroup& source_shared_group();
-
     std::function<bool (size_t)> get_modification_checker(TransactionChangeInfo const&, Table const&);
+    bool m_partial_sync_enabled = true;
+    std::shared_ptr<Realm> m_realm;
 
 private:
     virtual void do_attach_to(SharedGroup&) = 0;
@@ -205,12 +206,10 @@ private:
     virtual bool prepare_to_deliver() { return true; }
 
     mutable std::mutex m_realm_mutex;
-    std::shared_ptr<Realm> m_realm;
 
     VersionID m_sg_version;
     SharedGroup* m_sg = nullptr;
 
-    bool m_partial_sync_enabled = true;
     bool m_has_run = false;
     bool m_error = false;
     std::vector<DeepChangeChecker::RelatedTable> m_related_tables;
@@ -222,8 +221,6 @@ private:
         uint64_t token;
         bool initial_delivered;
         bool skip_next;
-        int partial_sync_status_code;   // -2 means partial sync is not enabled, -1 error has happened, 0 not processed, 1 processed
-        int partial_sync_error_message; // error message, only relevant if status_code is -1
     };
 
     // Currently registered callbacks and a mutex which must always be held

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -164,6 +164,8 @@ public:
     bool is_alive() const noexcept;
 
     // precondition: RealmCoordinator::m_notifier_mutex is locked *or* is called on worker thread
+    // Returns `true` if this is not the first time the notification is running, `false` if this
+    // is the initial notification.
     bool has_run() const noexcept { return m_has_run; }
 
     // Attach the handed-over query to `sg`. Must not be already attached to a SharedGroup.
@@ -197,6 +199,7 @@ protected:
     std::function<bool (size_t)> get_modification_checker(TransactionChangeInfo const&, Table const&);
     bool m_partial_sync_enabled = true;
     std::shared_ptr<Realm> m_realm;
+    SharedGroup* m_sg = nullptr;
 
 private:
     virtual void do_attach_to(SharedGroup&) = 0;
@@ -208,7 +211,6 @@ private:
     mutable std::mutex m_realm_mutex;
 
     VersionID m_sg_version;
-    SharedGroup* m_sg = nullptr;
 
     bool m_has_run = false;
     bool m_error = false;

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -210,6 +210,7 @@ private:
     VersionID m_sg_version;
     SharedGroup* m_sg = nullptr;
 
+    bool m_partial_sync_enabled = true;
     bool m_has_run = false;
     bool m_error = false;
     std::vector<DeepChangeChecker::RelatedTable> m_related_tables;
@@ -221,6 +222,8 @@ private:
         uint64_t token;
         bool initial_delivered;
         bool skip_next;
+        int partial_sync_status_code;   // -2 means partial sync is not enabled, -1 error has happened, 0 not processed, 1 processed
+        int partial_sync_error_message; // error message, only relevant if status_code is -1
     };
 
     // Currently registered callbacks and a mutex which must always be held
@@ -239,7 +242,7 @@ private:
     size_t m_callback_index = -1;
     // The number of callbacks which were present when the notifier was packaged
     // for delivery which are still present.
-    // Updated by packaged_for_delivery and removd_callback(), and used in
+    // Updated by packaged_for_delivery and  removd_callback(), and used in
     // for_each_callback() to avoid calling callbacks registered during delivery.
     size_t m_callback_count = -1;
 

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -178,6 +178,8 @@ private:
     void set_config(const Realm::Config&);
     void create_sync_session();
 
+    // Run CollectionNotifiers on the advanced Realm.
+    // This will trigger all registered collection callbacks.
     void run_async_notifiers();
     void open_helper_shared_group();
     void advance_helper_shared_group_to_latest();

--- a/src/impl/results_notifier.cpp
+++ b/src/impl/results_notifier.cpp
@@ -18,7 +18,12 @@
 
 #include "impl/results_notifier.hpp"
 
+#include "object_store.hpp"
+#include "object_schema.hpp"
 #include "shared_realm.hpp"
+#include <realm/query_expression.hpp>
+#include "impl/object_accessor_impl.hpp"
+
 #include <sstream>
 
 using namespace realm;
@@ -186,16 +191,15 @@ void ResultsNotifier::run()
     int8_t partial_sync_status_code = (m_partial_sync_enabled) ? 0 : -2;
     std::string partial_sync_error_message = nullptr;
     if (m_partial_sync_enabled) {
-        bool cancel = false;
-        m_realm->begin_transaction();
+        m_realm->begin_transaction(); // TODO What happens if notifications are triggered due to beginning a write transaction
 
         // TODO: Determine how to create key. Right now we just used the serialized query (are there any
         // disadvantages to that?). Would it make sense to hash it (to keep it short), but then we need
         // to handle hash collisions as well.
-        std::string key = m_query.get_description();
+        std::string key = "SELECT * FROM XXX"; // Awaiting a release with m_query.get_description();
 
         // TODO: It might change how the query is serialized. See https://realmio.slack.com/archives/C80PLGQ8Z/p1511797410000188
-        std::string serialized_query = m_query.get_description();
+        std::string serialized_query = "SELECT * FROM XXX"; // Awaiting a release with m_query.get_description();
 
         // Check current state and create subscription if needed. Throw in an error is found:
         TableRef table = ObjectStore::table_for_object_type(m_realm->read_group(), "__ResultSet");
@@ -203,36 +207,42 @@ void ResultsNotifier::run()
         size_t query_idx = table->get_descriptor()->get_column_index("query");
         size_t status_idx = table->get_descriptor()->get_column_index("status");
         size_t error_idx = table->get_descriptor()->get_column_index("error_message");
-        auto results = Results(realm, *table).filter(table->column<StringData>(col_idx).equal(key));
+        Results results(m_realm, *table);
+        auto query = table->column<StringData>(name_idx).equal(key);
+        results = results.filter(std::move(query));
         if (results.size() > 0) {
             // Subscription with that ID already exist. Verify that we are not trying to reuse an
             // existing name for a different query.
             REALM_ASSERT(results.size() == 1);
             auto obj = results.get(0);
-            if (obj.get_string(query_idx) != serialized_query)) {
+            if (obj.get_string(query_idx) != serialized_query) {
                 std::stringstream ss;
                 ss << "Subscription cannot be created as another subscription already exists with the same name. ";
                 ss << "Name: " << key << ". ";
                 ss << "Existing query: " << obj.get_string(query_idx) << ". ";
                 ss << "New query: " << serialized_query << ".";
-                m_realm->cancel_transaction();
-                throw new std::logic_error(ss.str());
-            };
 
-            partial_sync_status_code = (int8_t) obj->get_int(status_idx);
-            partial_sync_error_message = obj->get_string(error_idx);
+                partial_sync_status_code = -1; // TODO Is overloading -1 this way acceptable?
+                partial_sync_error_message = ss.str();
+
+            } else {
+                partial_sync_status_code = (int8_t) obj.get_int(status_idx);
+                partial_sync_error_message = obj.get_string(error_idx);
+            }
+            m_realm->cancel_transaction();
 
         } else {
             auto props = AnyDict{
-           O     {"name", key},
+                {"name", key},
                 {"query", serialized_query}
             };
-            Object::create<util::Any>(context, m_realm, m_realm->schema().find("__ResultSet"), std::move(props), false);
+            CppContext context;
+            Object::create<util::Any>(context, m_realm, *m_realm->schema().find("__ResultSet"), std::move(props), false);
             partial_sync_status_code = 0;
             partial_sync_error_message = "";
+            m_realm->commit_transaction();
         }
 
-        m_realm->commit_transaction();
     }
 
     // m_query->sync_view_if_needed(); // No longer needed, begin_transaction will do this
@@ -252,8 +262,8 @@ void ResultsNotifier::run()
 
     // Set partial sync properties
     // TODO SHould we do this inside calculate_changes()?
-    m_changes->new_partial_sync_status_code = partial_sync_status_code;
-    m_changes->new_partial_sync_error_message = partial_sync_error_message;
+    m_changes.new_partial_sync_status_code(partial_sync_status_code);
+    m_changes.new_partial_sync_error_message(partial_sync_error_message);
 }
 
 void ResultsNotifier::do_prepare_handover(SharedGroup& sg)

--- a/src/impl/results_notifier.hpp
+++ b/src/impl/results_notifier.hpp
@@ -61,6 +61,7 @@ private:
     // The changeset calculated during run() and delivered in do_prepare_handover()
     CollectionChangeBuilder m_changes;
     TransactionChangeInfo* m_info = nullptr;
+    int8_t m_previous_partial_sync_status_code;
 
     bool need_to_run();
     void calculate_changes();

--- a/src/impl/weak_realm_notifier.hpp
+++ b/src/impl/weak_realm_notifier.hpp
@@ -57,6 +57,7 @@ public:
     // Is this a WeakRealmNotifier for the given Realm instance?
     bool is_for_realm(Realm* realm) const { return realm == m_realm_key; }
 
+    // Notify the Realm that it has been updated.
     void notify();
 
 private:

--- a/src/sync/partial_sync.cpp
+++ b/src/sync/partial_sync.cpp
@@ -58,6 +58,70 @@ void update_schema(Group& group, Property matches_property)
 
 } // unnamed namespace
 
+/**
+
+bool subscribe_query(std::shared_ptr<Realm> realm, std::string id = nullptr, Query* query) {
+
+    if (!realm->is_in_transaction())
+        throw std::logic_error("Must be in a write transaction");
+
+    auto sync_config = realm->config().sync_config;
+    if (!sync_config || !sync_config->is_partial)
+        throw std::logic_error("A subscription can only be created for a partially synced Realm.");
+    
+    std::string queryErrorMessage = query->validate();
+    if (queryErrorMessage != "")
+        throw std::logic_error("Invalid query: " + queryErrorMessage);
+
+
+
+
+
+
+
+
+
+    auto matches_property = object_class + "_matches";
+
+    // The object schema must outlive `object` below.
+    std::unique_ptr<ObjectSchema> result_sets_schema;
+    Object raw_object;
+    {
+        realm->begin_transaction();
+        auto cleanup = util::make_scope_exit([&]() noexcept {
+            if (realm->is_in_transaction())
+                realm->cancel_transaction();
+        });
+
+        update_schema(realm->read_group(),
+                      Property(matches_property, PropertyType::Object|PropertyType::Array, object_class));
+
+        result_sets_schema = std::make_unique<ObjectSchema>(realm->read_group(), result_sets_type_name);
+
+        CppContext context;
+        raw_object = Object::create<util::Any>(context, realm, *result_sets_schema,
+                                               AnyDict{
+                                                   {"matches_property", matches_property},
+                                                   {"query", query},
+                                                   {"status", int64_t(0)},
+                                                   {"error_message", std::string()},
+                                                   {"query_parse_counter", int64_t(0)},
+                                               }, false);
+
+        realm->commit_transaction();
+    }
+
+
+    s
+
+
+
+
+
+    return true;
+}
+*/
+
 void register_query(std::shared_ptr<Realm> realm, const std::string &object_class, const std::string &query,
                     std::function<void (Results, std::exception_ptr)> callback)
 {

--- a/src/sync/partial_sync.hpp
+++ b/src/sync/partial_sync.hpp
@@ -19,6 +19,12 @@
 #ifndef REALM_OS_PARTIAL_SYNC_HPP
 #define REALM_OS_PARTIAL_SYNC_HPP
 
+#include "impl/collection_change_builder.hpp"
+#include <realm/group_shared.hpp>
+#include <realm/lang_bind_helper.hpp>
+#include <realm/query.hpp>
+#include <realm/query_expression.hpp>
+
 #include <functional>
 #include <memory>
 #include <string>
@@ -29,23 +35,10 @@ class Realm;
 class Results;
 
 namespace partial_sync {
-/**
-// This method must be called from within a write transaction. It creates a partial Realm
-// subscription for the provided query if one didn't exist already. Providing an ID is optional, but
-// if one isn't provided an automatic (opaque) ID will be generated. This automated ID will be the
-// same, if multiple subscriptions are being made for the same anonymous query (= only the first call
-// to create_subscription will return `true`).
+// This method creates or updates the subscription for a given query and returns the status code after doing so.
+// It can fail immediately (if e.g. name is already being used elsewhere) or later (if query is invalid).
+int8_t create_or_update_subscription(SharedGroup &sg, realm::_impl::CollectionChangeBuilder &changes, Query&, int8_t previous_state);
 
-// This method will return `true` if a subscription was created, `false` if a subscription already
-// existed.
-//
-// This method will throw if any of the following scenarios are encountered:
-// - An Id already exist with another query assigned to it.
-// - Core could not validate the query, i.e. the query should be a valid local query.
-
-
-bool create_subscription(std::shared_ptr<Realm>, std::string id = nullptr, Query* query);
-**/
 void register_query(std::shared_ptr<Realm>, const std::string &object_class,
                     const std::string &query,
                     std::function<void (Results, std::exception_ptr)>);

--- a/src/sync/partial_sync.hpp
+++ b/src/sync/partial_sync.hpp
@@ -29,7 +29,23 @@ class Realm;
 class Results;
 
 namespace partial_sync {
+/**
+// This method must be called from within a write transaction. It creates a partial Realm
+// subscription for the provided query if one didn't exist already. Providing an ID is optional, but
+// if one isn't provided an automatic (opaque) ID will be generated. This automated ID will be the
+// same, if multiple subscriptions are being made for the same anonymous query (= only the first call
+// to create_subscription will return `true`).
 
+// This method will return `true` if a subscription was created, `false` if a subscription already
+// existed.
+//
+// This method will throw if any of the following scenarios are encountered:
+// - An Id already exist with another query assigned to it.
+// - Core could not validate the query, i.e. the query should be a valid local query.
+
+
+bool create_subscription(std::shared_ptr<Realm>, std::string id = nullptr, Query* query);
+**/
 void register_query(std::shared_ptr<Realm>, const std::string &object_class,
                     const std::string &query,
                     std::function<void (Results, std::exception_ptr)>);


### PR DESCRIPTION
Very much WIP (does not compile):

General concept: Extend the `CollectionChangeSet` with information about Partial Sync status and errors and expose them in the general notification system.

 TODO
- [x] Expose Partial Sync error message and state as part of CollectionChange events.
- [ ] Finish refactor moving all partial sync methods to `partial_sync.cpp`
- [ ] Add support for explicitly named results.
- [ ] Add support for updating the schema with *_matches columns for new queries
- [ ] Consider adding support for Realm in collection_notifier.cpp instead of m_sg as it otherwise requires a lot of low-level logic that have unclear rules.
- [ ] Consider adding a status enum instead of int8.
- [x] Find where "old" state is read. We need to read status flag here.
- [ ] Trigger notifications when only partial sync error message is triggered
- [ ] Question: Is it safe to do a write transaction in the notifier?
- [ ] Unit tess

Open questions:
- Tracking initial callback is currently done in bindings, can this move to object store?


