### PR TITLE
Configure target aliases and exports

### DIFF
--- a/CMake/realmobjectstore-config.cmake.in
+++ b/CMake/realmobjectstore-config.cmake.in
@@ -1,0 +1,18 @@
+include(CMakeFindDependencyMacro)
+
+set(REALM_URL "http://static.realm.io/downloads/sync/@DEP_REALM_SYNC_VERSION@/@realm-sync_FILE_NAME@.tar.gz")
+
+message(STATUS "Downloading Realm Sync...")
+file(DOWNLOAD "${REALM_URL}" "${CMAKE_BINARY_DIR}/@realm-sync_FILE_NAME@.tar.gz")
+
+message(STATUS "Uncompressing Realm Sync...")
+file(MAKE_DIRECTORY "${CMAKE_BINARY_DIR}/@realm-sync_FILE_NAME@")
+execute_process(
+    COMMAND ${CMAKE_COMMAND} -E tar xfz "${CMAKE_BINARY_DIR}/@realm-sync_FILE_NAME@.tar.gz"
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}/@realm-sync_FILE_NAME@"
+)
+
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}/@realm-sync_FILE_NAME@")
+find_dependency(RealmSync REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/realmobjectstore-targets.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,23 @@ if(NOT CMAKE_XCODE_ATTRIBUTE_SUPPORTED_PLATFORMS MATCHES "iphoneos"
     add_subdirectory(tests)
 endif()
 
+install(FILES LICENSE DESTINATION doc/realmobjectstore)
+
+# Configure the realmobjectstore-config.cmake file
+get_package_file_name(realm-sync ${DEP_REALM_SYNC_VERSION})
+configure_file(CMake/realmobjectstore-config.cmake.in "${RealmObjectStore_BINARY_DIR}/realmobjectstore-config.cmake" @ONLY)
+
+# Make the project importable from the build directory
+export(EXPORT realm-object-store NAMESPACE RealmObjectStore:: FILE realmobjectstore-targets.cmake)
+
+# Make the project importable from the install directory
+install(EXPORT realm-object-store FILE realmobjectstore-targets.cmake NAMESPACE RealmObjectStore:: DESTINATION lib/cmake/realmobjectstore)
+install(
+    FILES
+        "${RealmObjectStore_BINARY_DIR}/realmobjectstore-config.cmake"
+    DESTINATION lib/cmake/realmobjectstore
+)
+
 # CPack
 get_package_file_name(realm-object-store "v${DEP_VERSION}")
 set(CPACK_GENERATOR TGZ)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -143,12 +143,17 @@ target_include_directories(ObjectStore
        $<BUILD_INTERFACE:${RealmObjectStore_SOURCE_DIR}/src>
        $<INSTALL_INTERFACE:include> 
 )
+target_include_directories(ObjectStore
+    PRIVATE
+        ${RealmObjectStore_SOURCE_DIR}/external/pegtl
+)
 target_link_libraries(ObjectStore
     PUBLIC
         $<IF:$<BOOL:${REALM_ENABLE_SYNC}>,RealmSync::Sync,Realm::Core>
-        Pegtl
         $<$<BOOL:${UV_LIBRARY}>:${UV_LIBRARY}>
 )
+
+add_library(RealmObjectStore::ObjectStore ALIAS ObjectStore)
 
 install(TARGETS ObjectStore EXPORT realm-object-store
     RUNTIME DESTINATION bin


### PR DESCRIPTION
I removed the `Pegtl` target because it kept being included in the interface link libraries list even after I moved it to private linking. It's a header-only library that's only used inside `src/parser/parser.cpp`.