### PR TITLE
Don't treat unknown system errors as being fatal to the sync session.

### DIFF
--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -633,7 +633,6 @@ void SyncSession::handle_error(SyncError error)
     } else {
         // Unrecognized error code.
         error.is_unrecognized_by_client = true;
-        next_state = NextStateAfterError::error;
     }
     switch (next_state) {
         case NextStateAfterError::none:

--- a/tests/sync/session/session.cpp
+++ b/tests/sync/session/session.cpp
@@ -344,6 +344,13 @@ TEST_CASE("sync: error handling", "[sync]") {
     EventLoop::main().run_until([&] { return sessions_are_active(*session); });
     REQUIRE(!session->is_in_error_state());
 
+    SECTION("Doesn't treat unknown system errors as being fatal") {
+        std::error_code code = std::error_code{EBADF, std::generic_category()};
+        SyncSession::OnlyForTesting::handle_error(*session, {code, "Not a real error message", false});
+        CHECK(!sessions_are_inactive(*session));
+        CHECK(!session->is_in_error_state());
+    }
+
     SECTION("Properly handles a client reset error") {
         int code = 0;
         util::Optional<SyncError> final_error;


### PR DESCRIPTION
Fixes https://github.com/realm/realm-sync/issues/1857.