### PR TITLE
Remove SyncSession's Error state entirely

### DIFF
--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -42,7 +42,6 @@ struct WaitingForAccessToken;
 struct Active;
 struct Dying;
 struct Inactive;
-struct Error;
 }
 }
 
@@ -60,13 +59,14 @@ public:
         Active,
         Dying,
         Inactive,
+
+        // FIXME: This state no longer exists. This should be removed.
         Error,
     };
     PublicState state() const;
 
-    bool is_in_error_state() const {
-        return state() == PublicState::Error;
-    }
+    // FIXME: The error state no longer exists. This should be removed.
+    bool is_in_error_state() const { return false; }
 
     // The on-disk path of the Realm file backing the Realm this `SyncSession` represents.
     std::string const& path() const { return m_realm_path; }
@@ -242,7 +242,6 @@ private:
     friend struct _impl::sync_session_states::Active;
     friend struct _impl::sync_session_states::Dying;
     friend struct _impl::sync_session_states::Inactive;
-    friend struct _impl::sync_session_states::Error;
 
     friend class realm::SyncManager;
     // Called by SyncManager {
@@ -260,6 +259,7 @@ private:
     SyncSession(_impl::SyncClient&, std::string realm_path, SyncConfig);
 
     void handle_error(SyncError);
+    void cancel_pending_waits();
     enum class ShouldBackup { yes, no };
     void update_error_and_mark_file_for_deletion(SyncError&, ShouldBackup);
     static std::string get_recovery_file_path();

--- a/tests/sync/session/progress_notifications.cpp
+++ b/tests/sync/session/progress_notifications.cpp
@@ -59,7 +59,6 @@ TEST_CASE("progress notification", "[sync]") {
                                     SyncSessionStopPolicy::AfterChangesUploaded);
         wait_for_session_to_activate(*session);
 
-        REQUIRE(!session->is_in_error_state());
         std::atomic<bool> callback_was_called(false);
 
         SECTION("for upload notifications, with no data transfer ongoing") {
@@ -96,7 +95,6 @@ TEST_CASE("progress notification", "[sync]") {
                                     SyncSessionStopPolicy::AfterChangesUploaded);
         wait_for_session_to_activate(*session);
 
-        REQUIRE(!session->is_in_error_state());
         std::atomic<bool> callback_was_called(false);
         std::atomic<uint64_t> transferred(0);
         std::atomic<uint64_t> transferrable(0);
@@ -264,7 +262,6 @@ TEST_CASE("progress notification", "[sync]") {
                                     SyncSessionStopPolicy::AfterChangesUploaded);
         wait_for_session_to_activate(*session);
 
-        REQUIRE(!session->is_in_error_state());
         std::atomic<bool> callback_was_called(false);
         std::atomic<uint64_t> transferred(0);
         std::atomic<uint64_t> transferrable(0);

--- a/tests/sync/session/wait_for_completion.cpp
+++ b/tests/sync/session/wait_for_completion.cpp
@@ -126,17 +126,6 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
         EventLoop::main().run_until([&] { return error_count > 0; });
         REQUIRE(handler_called == true);
     }
-
-    SECTION("properly rejects any callbacks when session is errored") {
-        auto user = SyncManager::shared().get_user({ "user-async-wait-download-5", dummy_auth_url }, "not_a_real_token");
-        std::atomic<int> error_count(0);
-        auto session = sync_session(server, user, "/test",
-                                    [](const auto&, const auto&) { return "this is not a valid access token"; },
-                                    [&](auto, auto) { ++error_count; });
-
-        EventLoop::main().run_until([&] { return error_count > 0; });
-        REQUIRE(!session->wait_for_download_completion([](auto) { }));
-    }
 }
 
 TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
@@ -237,16 +226,5 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
         SyncSession::OnlyForTesting::handle_error(*session, {code, "Not a real error message", true});
         EventLoop::main().run_until([&] { return error_count > 0; });
         REQUIRE(handler_called == true);
-    }
-
-    SECTION("properly rejects any callbacks when session is errored") {
-        auto user = SyncManager::shared().get_user({ "user-async-wait-upload-5", dummy_auth_url }, "not_a_real_token");
-        std::atomic<int> error_count(0);
-        auto session = sync_session(server, user, "/test",
-                                    [](const auto&, const auto&) { return "this is not a valid access token"; },
-                                    [&](auto, auto) { ++error_count; });
-
-        EventLoop::main().run_until([&] { return error_count > 0; });
-        REQUIRE(!session->wait_for_upload_completion([](auto) { }));
     }
 }


### PR DESCRIPTION
Fixes one part of realm/realm-sync#1857. An alternative, more invasive, approach to #613.