### PR TITLE
Remove bind_with_admin_token() and use the normal refresh flow

### DIFF
--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -87,9 +87,6 @@ struct SyncSession::State {
                                       SyncSession&, std::string,
                                       const util::Optional<std::string>&) const { }
 
-    virtual void bind_with_admin_token(std::unique_lock<std::mutex>&,
-                                       SyncSession&, const std::string&, const std::string&) const { }
-
     // Returns true iff the lock is still locked when the method returns.
     virtual bool access_token_expired(std::unique_lock<std::mutex>&, SyncSession&) const { return true; }
 
@@ -343,14 +340,6 @@ struct sync_session_states::Dying : public SyncSession::State {
         return false;
     }
 
-    void bind_with_admin_token(std::unique_lock<std::mutex>& lock, SyncSession& session,
-                               const std::string& admin_token,
-                               const std::string& server_url) const override
-    {
-        session.advance_state(lock, waiting_for_access_token);
-        session.m_state->refresh_access_token(lock, session, admin_token, server_url);
-    }
-
     void log_out(std::unique_lock<std::mutex>& lock, SyncSession& session) const override
     {
         session.advance_state(lock, inactive);
@@ -383,14 +372,6 @@ struct sync_session_states::Inactive : public SyncSession::State {
         session.m_completion_wait_packages.clear();
         session.m_session = nullptr;
         session.unregister(lock);
-    }
-
-    void bind_with_admin_token(std::unique_lock<std::mutex>& lock, SyncSession& session,
-                               const std::string& admin_token,
-                               const std::string& server_url) const override
-    {
-        session.advance_state(lock, waiting_for_access_token);
-        session.m_state->refresh_access_token(lock, session, admin_token, server_url);
     }
 
     bool revive_if_needed(std::unique_lock<std::mutex>& lock, SyncSession& session) const override
@@ -847,12 +828,6 @@ void SyncSession::refresh_access_token(std::string access_token, util::Optional<
         return;
     }
     m_state->refresh_access_token(lock, *this, std::move(access_token), server_url);
-}
-
-void SyncSession::bind_with_admin_token(std::string admin_token, std::string server_url)
-{
-    std::unique_lock<std::mutex> lock(m_state_mutex);
-    m_state->bind_with_admin_token(lock, *this, admin_token, server_url);
 }
 
 void SyncSession::override_server(std::string address, int port)

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -135,9 +135,6 @@ public:
     // FIXME: we need an API to allow the binding to tell sync that the access token fetch failed
     // or was cancelled, and cannot be retried.
 
-    // Give the `SyncSession` an administrator token, and ask it to immediately `bind()` the session.
-    void bind_with_admin_token(std::string admin_token, std::string server_url);
-
     // Set the multiplex identifier used for this session. Sessions with different identifiers are
     // never multiplexed into a single connection, even if they are connecting to the same host.
     // The value of the token is otherwise treated as an opaque token.

--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -220,13 +220,8 @@ void SyncUser::register_session(std::shared_ptr<SyncSession> session)
         case State::Active:
             // Immediately ask the session to come online.
             m_sessions[path] = session;
-            // FIXME: `SyncUser`s shouldn't even wrap admin tokens; the bindings should do that.
-            if (m_token_type == TokenType::Admin) {
-                session->bind_with_admin_token(m_refresh_token, session->config().realm_url());
-            } else {
-                lock.unlock();
-                session->revive_if_needed();
-            }
+            lock.unlock();
+            session->revive_if_needed();
             break;
         case State::LoggedOut:
             m_waiting_sessions[path] = session;


### PR DESCRIPTION
When session multiplexing is enabled we need to perform a token refresh even with admin token users so that ROS knows that we're accessing a new Realm (as it can't just automatically detect that from the fact that we've opened a new connection).

All bindings need to be updated to support this, but bindings which do not support multiplexing (i.e. everything but JS) can simply "refresh" the token on the session without talking to the server. Cocoa doesn't support admin token users at all, so it doesn't need any updates.

Object store part of the fix for https://github.com/realm/realm-object-server-private/issues/836.