### PR TITLE
Use the error handler from the config in SyncSession

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -105,9 +105,6 @@ void RealmCoordinator::create_sync_session()
                 self->m_notifier->notify_others();
         }
     });
-    if (m_config.sync_config->error_handler) {
-        SyncSession::Internal::set_error_handler(*m_sync_session, m_config.sync_config->error_handler);
-    }
 #endif
 }
 

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -627,8 +627,8 @@ void SyncSession::handle_error(SyncError error)
             break;
         }
     }
-    if (m_error_handler) {
-        m_error_handler(shared_from_this(), std::move(error));
+    if (m_config.error_handler) {
+        m_config.error_handler(shared_from_this(), std::move(error));
     }
 }
 
@@ -757,11 +757,6 @@ void SyncSession::create_sync_session()
 void SyncSession::set_sync_transact_callback(std::function<sync::Session::SyncTransactCallback> callback)
 {
     m_sync_transact_callback = std::move(callback);
-}
-
-void SyncSession::set_error_handler(std::function<SyncSessionErrorHandler> handler)
-{
-    m_error_handler = std::move(handler);
 }
 
 void SyncSession::advance_state(std::unique_lock<std::mutex>& lock, const State& state)

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -200,11 +200,6 @@ public:
             session.set_sync_transact_callback(std::move(callback));
         }
 
-        static void set_error_handler(SyncSession& session, std::function<SyncSessionErrorHandler> callback)
-        {
-            session.set_error_handler(std::move(callback));
-        }
-
         static void nonsync_transact_notify(SyncSession& session, VersionID::version_type version)
         {
             session.nonsync_transact_notify(version);
@@ -266,7 +261,6 @@ private:
     void handle_progress_update(uint64_t, uint64_t, uint64_t, uint64_t, bool);
 
     void set_sync_transact_callback(std::function<SyncSessionTransactCallback>);
-    void set_error_handler(std::function<SyncSessionErrorHandler>);
     void nonsync_transact_notify(VersionID::version_type);
 
     void advance_state(std::unique_lock<std::mutex>& lock, const State&);
@@ -276,7 +270,6 @@ private:
     void did_drop_external_reference();
 
     std::function<SyncSessionTransactCallback> m_sync_transact_callback;
-    std::function<SyncSessionErrorHandler> m_error_handler;
 
     // How many bytes are uploadable or downloadable.
     struct Progress {


### PR DESCRIPTION
This removes the need to go through RealmCoordinator to set the error handler and is just generally simpler with seemingly no downside.