### PR TITLE
Make sync_file more windows-friendly

### DIFF
--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -44,6 +44,14 @@ namespace realm {
 
 namespace {
 
+#ifdef _WIN32
+    char separator = '\\';
+    char alternateSeparator = '/';
+#else
+    char separator = '/';
+    char alternateSeparator = '\\';
+#endif
+
 uint8_t value_of_hex_digit(char hex_digit)
 {
     if (hex_digit >= '0' && hex_digit <= '9') {
@@ -124,26 +132,28 @@ std::string make_raw_string(const std::string& percent_encoded_string)
     return buffer;
 }
 
-std::string file_path_by_appending_component(const std::string& path, const std::string& component, FilePathType path_type)
+std::string file_path_by_appending_component(std::string path, std::string component, FilePathType path_type)
 {
-    // FIXME: Does this have to be changed to accomodate Windows platforms?
+    std::replace(path.begin(), path.end(), alternateSeparator, separator);
+    std::replace(component.begin(), component.end(), alternateSeparator, separator);
+
     std::string buffer;
     buffer.reserve(2 + path.length() + component.length());
     buffer.append(path);
     std::string terminal = "";
-    if (path_type == FilePathType::Directory && component[component.length() - 1] != '/') {
-        terminal = "/";
+    if (path_type == FilePathType::Directory && component[component.length() - 1] != separator) {
+        terminal = std::string(1, separator);
     }
     char path_last = path[path.length() - 1];
     char component_first = component[0];
-    if (path_last == '/' && component_first == '/') {
+    if (path_last == separator && component_first == separator) {
         buffer.append(component.substr(1));
         buffer.append(terminal);
-    } else if (path_last == '/' || component_first == '/') {
+    } else if (path_last == separator || component_first == separator) {
         buffer.append(component);
         buffer.append(terminal);
     } else {
-        buffer.append("/");
+        buffer.append(std::string(1, separator));
         buffer.append(component);
         buffer.append(terminal);
     }

--- a/src/sync/impl/sync_file.hpp
+++ b/src/sync/impl/sync_file.hpp
@@ -42,8 +42,8 @@ std::string make_percent_encoded_string(const std::string& raw_string);
 std::string make_raw_string(const std::string& percent_encoded_string);
 
 /// Given a file path and a path component, return a new path created by appending the component to the path.
-std::string file_path_by_appending_component(const std::string& path,
-                                             const std::string& component,
+std::string file_path_by_appending_component(std::string path,
+                                             std::string component,
                                              FilePathType path_type=FilePathType::File);
 
 /// Given a file path and an extension, append the extension to the path.


### PR DESCRIPTION
Otherwise, it'll generate paths like `C:\jenkins\workspace\realm_realm-dotnet_PR-1672\D/realm-object-server/io.realm.object-server-recovered-realms/recovered_realm-20180109-170844-XXa07412`