### PR TITLE
Fix upload progress reporting

### DIFF
--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -27,7 +27,6 @@
 #include <realm/sync/client.hpp>
 #include <realm/sync/protocol.hpp>
 
-
 using namespace realm;
 using namespace realm::_impl;
 using namespace realm::_impl::sync_session_states;
@@ -602,63 +601,7 @@ void SyncSession::cancel_pending_waits()
 void SyncSession::handle_progress_update(uint64_t downloaded, uint64_t downloadable,
                                          uint64_t uploaded, uint64_t uploadable, bool is_fresh)
 {
-    std::vector<std::function<void()>> invocations;
-    {
-        std::lock_guard<std::mutex> lock(m_progress_notifier_mutex);
-        m_current_progress = Progress{uploadable, downloadable, uploaded, downloaded};
-        m_latest_progress_data_is_fresh = is_fresh;
-
-        for (auto it = m_notifiers.begin(); it != m_notifiers.end();) {
-            auto& package = it->second;
-            package.update(*m_current_progress, is_fresh);
-
-            bool should_delete = false;
-            invocations.emplace_back(package.create_invocation(*m_current_progress, should_delete));
-
-            it = (should_delete ? m_notifiers.erase(it) : std::next(it));
-        }
-    }
-    // Run the notifiers only after we've released the lock.
-    for (auto& invocation : invocations) {
-        invocation();
-    }
-}
-
-void SyncSession::NotifierPackage::update(const Progress& current_progress, bool data_is_fresh)
-{
-    if (is_streaming || captured_transferrable || !data_is_fresh)
-        return;
-
-    captured_transferrable = direction == NotifierType::download ? current_progress.downloadable
-                                                                 : current_progress.uploadable;
-}
-
-// PRECONDITION: `update()` must first be called on the same package.
-std::function<void()> SyncSession::NotifierPackage::create_invocation(const Progress& current_progress,
-                                                                      bool& is_expired) const
-{
-    // It's possible for a non-streaming notifier to not yet have fresh transferrable bytes data.
-    // In that case, we don't call it at all.
-    // NOTE: `update()` is always called before `create_invocation()`, and will
-    // set `captured_transferrable` on the notifier package if fresh data has
-    // been received and the package is for a non-streaming notifier.
-    if (!is_streaming && !captured_transferrable)
-        return [](){ };
-
-    bool is_download = direction == NotifierType::download;
-    uint64_t transferred = is_download ? current_progress.downloaded : current_progress.uploaded;
-    uint64_t transferrable;
-    if (is_streaming) {
-        transferrable = is_download ? current_progress.downloadable : current_progress.uploadable;
-    } else {
-        transferrable = *captured_transferrable;
-    }
-    // A notifier is expired if at least as many bytes have been transferred
-    // as were originally considered transferrable.
-    is_expired = !is_streaming && transferred >= *captured_transferrable;
-    return [=, package=*this](){
-        package.notifier(transferred, transferrable);
-    };
+    m_notifier.update(downloaded, downloadable, uploaded, uploadable, is_fresh);
 }
 
 void SyncSession::create_sync_session()
@@ -785,34 +728,12 @@ bool SyncSession::wait_for_download_completion(std::function<void(std::error_cod
 uint64_t SyncSession::register_progress_notifier(std::function<SyncProgressNotifierCallback> notifier,
                                                  NotifierType direction, bool is_streaming)
 {
-    std::function<void()> invocation;
-    uint64_t token_value = 0;
-    {
-        std::lock_guard<std::mutex> lock(m_progress_notifier_mutex);
-        token_value = m_progress_notifier_token++;
-        NotifierPackage package{std::move(notifier), is_streaming, direction};
-        if (!m_current_progress) {
-            // Simply register the package, since we have no data yet.
-            m_notifiers.emplace(token_value, std::move(package));
-            return token_value;
-        }
-        package.update(*m_current_progress, m_latest_progress_data_is_fresh);
-        bool skip_registration = false;
-        invocation = package.create_invocation(*m_current_progress, skip_registration);
-        if (skip_registration) {
-            token_value = 0;
-        } else {
-            m_notifiers.emplace(token_value, std::move(package));
-        }
-    }
-    invocation();
-    return token_value;
+    return m_notifier.register_callback(std::move(notifier), direction == NotifierType::download, is_streaming);
 }
 
 void SyncSession::unregister_progress_notifier(uint64_t token)
 {
-    std::lock_guard<std::mutex> lock(m_progress_notifier_mutex);
-    m_notifiers.erase(token);
+    m_notifier.unregister_callback(token);
 }
 
 void SyncSession::refresh_access_token(std::string access_token, util::Optional<std::string> server_url)
@@ -898,4 +819,96 @@ void SyncSession::did_drop_external_reference()
         return;
 
     m_state->close(lock, *this);
+}
+
+uint64_t SyncProgressNotifier::register_callback(std::function<SyncProgressNotifierCallback> notifier,
+                                                 bool is_download, bool is_streaming)
+{
+    std::function<void()> invocation;
+    uint64_t token_value = 0;
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        token_value = m_progress_notifier_token++;
+        NotifierPackage package{std::move(notifier), is_streaming, is_download};
+        if (!m_current_progress) {
+            // Simply register the package, since we have no data yet.
+            m_packages.emplace(token_value, std::move(package));
+            return token_value;
+        }
+        package.update(*m_current_progress, m_latest_progress_data_is_fresh);
+        bool skip_registration = false;
+        invocation = package.create_invocation(*m_current_progress, skip_registration);
+        if (skip_registration) {
+            token_value = 0;
+        } else {
+            m_packages.emplace(token_value, std::move(package));
+        }
+    }
+    invocation();
+    return token_value;
+}
+
+void SyncProgressNotifier::unregister_callback(uint64_t token)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_packages.erase(token);
+}
+
+void SyncProgressNotifier::update(uint64_t downloaded, uint64_t downloadable,
+                                  uint64_t uploaded, uint64_t uploadable, bool is_fresh)
+{
+    std::vector<std::function<void()>> invocations;
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_current_progress = Progress{uploadable, downloadable, uploaded, downloaded};
+        m_latest_progress_data_is_fresh = is_fresh;
+
+        for (auto it = m_packages.begin(); it != m_packages.end();) {
+            auto& package = it->second;
+            package.update(*m_current_progress, is_fresh);
+
+            bool should_delete = false;
+            invocations.emplace_back(package.create_invocation(*m_current_progress, should_delete));
+
+            it = (should_delete ? m_packages.erase(it) : std::next(it));
+        }
+    }
+    // Run the notifiers only after we've released the lock.
+    for (auto& invocation : invocations) {
+        invocation();
+    }
+}
+
+void SyncProgressNotifier::NotifierPackage::update(const Progress& current_progress, bool data_is_fresh)
+{
+    if (is_streaming || captured_transferrable || !data_is_fresh)
+        return;
+
+    captured_transferrable = is_download ? current_progress.downloadable : current_progress.uploadable;
+}
+
+// PRECONDITION: `update()` must first be called on the same package.
+std::function<void()> SyncProgressNotifier::NotifierPackage::create_invocation(const Progress& current_progress, bool& is_expired) const
+{
+    // It's possible for a non-streaming notifier to not yet have fresh transferrable bytes data.
+    // In that case, we don't call it at all.
+    // NOTE: `update()` is always called before `create_invocation()`, and will
+    // set `captured_transferrable` on the notifier package if fresh data has
+    // been received and the package is for a non-streaming notifier.
+    if (!is_streaming && !captured_transferrable)
+        return [](){ };
+
+    uint64_t transferred = is_download ? current_progress.downloaded : current_progress.uploaded;
+    uint64_t transferrable;
+    if (is_streaming) {
+        transferrable = is_download ? current_progress.downloadable : current_progress.uploadable;
+    } else {
+        transferrable = *captured_transferrable;
+    }
+    // A notifier is expired if at least as many bytes have been transferred
+    // as were originally considered transferrable.
+    is_expired = !is_streaming && transferred >= *captured_transferrable;
+    return [=, package=*this](){
+        package.notifier(transferred, transferrable);
+    };
 }

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -55,7 +55,12 @@ using SyncProgressNotifierCallback = void(uint64_t transferred_bytes, uint64_t t
 namespace _impl {
 class SyncProgressNotifier {
 public:
-    uint64_t register_callback(std::function<SyncProgressNotifierCallback>, bool is_download, bool is_streaming);
+    enum class NotifierType {
+        upload, download
+    };
+
+    uint64_t register_callback(std::function<SyncProgressNotifierCallback>,
+                               NotifierType direction, bool is_streaming);
     void unregister_callback(uint64_t);
 
     void set_local_version(uint64_t);
@@ -136,9 +141,7 @@ public:
     // Works the same way as `wait_for_upload_completion()`.
     bool wait_for_download_completion(std::function<void(std::error_code)> callback);
 
-    enum class NotifierType {
-        upload, download
-    };
+    using NotifierType = _impl::SyncProgressNotifier::NotifierType;
     // Register a notifier that updates the app regarding progress.
     //
     // If `m_current_progress` is populated when this method is called, the notifier

--- a/tests/sync/session/progress_notifications.cpp
+++ b/tests/sync/session/progress_notifications.cpp
@@ -18,209 +18,165 @@
 
 #include "catch.hpp"
 
-#include "sync/session/session_util.hpp"
-
-#include "util/event_loop.hpp"
+#include "sync/sync_session.hpp"
 
 #include <realm/util/scope_exit.hpp>
 
-namespace {
+using namespace realm;
 
-void wait_for_session_to_activate(SyncSession& session)
-{
-    EventLoop::main().run_until([&] { return sessions_are_active(session); });
-    // Wait for uploads and downloads
-    std::atomic<bool> download_did_complete(false);
-    std::atomic<bool> upload_did_complete(false);
-    session.wait_for_download_completion([&](auto) { download_did_complete = true; });
-    session.wait_for_upload_completion([&](auto) { upload_did_complete = true; });
-    EventLoop::main().run_until([&] { return download_did_complete.load() && upload_did_complete.load(); });
-}
-
-}
-
-// FIXME: break this up into smaller discrete test cases
 TEST_CASE("progress notification", "[sync]") {
-    if (!EventLoop::has_implementation())
-        return;
-
-    const std::string dummy_auth_url = "https://realm.example.org";
-
-    SyncServer server;
-    // Disable file-related functionality and metadata functionality for testing purposes.
-    SyncManager::shared().configure_file_system(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
-    auto user = SyncManager::shared().get_user({ "user", dummy_auth_url }, "not_a_real_token");
+    _impl::SyncProgressNotifier progress;
+    progress.update(0, 0, 0, 0);
 
     SECTION("runs at least once (initially when registered)") {
-        auto user = SyncManager::shared().get_user({ "user-test-sync-1", dummy_auth_url }, "not_a_real_token");
-        auto session = sync_session(server, user, "/test-sync-progress-1",
-                                    [](const auto&, const auto&) { return s_test_token; },
-                                    [](auto, auto) { },
-                                    SyncSessionStopPolicy::AfterChangesUploaded);
-        wait_for_session_to_activate(*session);
-
-        std::atomic<bool> callback_was_called(false);
+        bool callback_was_called = false;
 
         SECTION("for upload notifications, with no data transfer ongoing") {
-            session->register_progress_notifier([&](auto, auto) {
-                callback_was_called = true;
-            }, SyncSession::NotifierType::upload, false);
-            EventLoop::main().run_until([&] { return callback_was_called.load(); });
+            progress.register_callback([&](auto, auto) { callback_was_called = true; }, false, false);
+            REQUIRE(callback_was_called);
         }
 
         SECTION("for download notifications, with no data transfer ongoing") {
-            session->register_progress_notifier([&](auto, auto) {
-                callback_was_called = true;
-            }, SyncSession::NotifierType::download, false);
-            EventLoop::main().run_until([&] { return callback_was_called.load(); });
+            progress.register_callback([&](auto, auto) { callback_was_called = true; }, true, false);
         }
 
         SECTION("can register another notifier while in the initial notification without deadlock") {
-            std::atomic<uint64_t> counter(0);
-            session->register_progress_notifier([&](auto, auto) {
+            int counter = 0;
+            progress.register_callback([&](auto, auto) {
                 counter++;
-                session->register_progress_notifier([&](auto, auto) {
+                progress.register_callback([&](auto, auto) {
                     counter++;
-                }, SyncSession::NotifierType::upload, false);
-            }, SyncSession::NotifierType::download, false);
-            EventLoop::main().run_until([&] { return counter.load() == 2; });
+                }, false, false);
+            }, true, false);
+            REQUIRE(counter == 2);
         }
     }
 
     SECTION("properly runs for streaming notifiers") {
-        auto user = SyncManager::shared().get_user({ "user-test-sync-2", dummy_auth_url }, "not_a_real_token");
-        auto session = sync_session(server, user, "/test-sync-progress-2",
-                                    [](const auto&, const auto&) { return s_test_token; },
-                                    [](auto, auto) { },
-                                    SyncSessionStopPolicy::AfterChangesUploaded);
-        wait_for_session_to_activate(*session);
-
-        std::atomic<bool> callback_was_called(false);
-        std::atomic<uint64_t> transferred(0);
-        std::atomic<uint64_t> transferrable(0);
+        bool callback_was_called = false;
+        uint64_t transferred = 0;
+        uint64_t transferrable = 0;
         uint64_t current_transferred = 0;
         uint64_t current_transferrable = 0;
 
         SECTION("for upload notifications") {
-            session->register_progress_notifier([&](auto xferred, auto xferable) {
+            progress.register_callback([&](auto xferred, auto xferable) {
                 transferred = xferred;
                 transferrable = xferable;
                 callback_was_called = true;
-            }, SyncSession::NotifierType::upload, true);
-            // Wait for the initial callback.
-            EventLoop::main().run_until([&] { return callback_was_called.load(); });
+            }, false, true);
+            REQUIRE(callback_was_called);
 
             // Now manually call the notifier handler a few times.
             callback_was_called = false;
             current_transferred = 60;
             current_transferrable = 912;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, 25, 26, current_transferred, current_transferrable);
-            CHECK(callback_was_called.load());
-            CHECK(transferred.load() == current_transferred);
-            CHECK(transferrable.load() == current_transferrable);
+            progress.update(25, 26, current_transferred, current_transferrable);
+            CHECK(callback_was_called);
+            CHECK(transferred == current_transferred);
+            CHECK(transferrable == current_transferrable);
 
             // Second callback
             callback_was_called = false;
             current_transferred = 79;
             current_transferrable = 1021;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, 68, 191, current_transferred, current_transferrable);
-            CHECK(callback_was_called.load());
-            CHECK(transferred.load() == current_transferred);
-            CHECK(transferrable.load() == current_transferrable);
+            progress.update(68, 191, current_transferred, current_transferrable);
+            CHECK(callback_was_called);
+            CHECK(transferred == current_transferred);
+            CHECK(transferrable == current_transferrable);
 
             // Third callback
             callback_was_called = false;
             current_transferred = 150;
             current_transferrable = 1228;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, 199, 591, current_transferred, current_transferrable);
-            CHECK(callback_was_called.load());
-            CHECK(transferred.load() == current_transferred);
-            CHECK(transferrable.load() == current_transferrable);
+            progress.update(199, 591, current_transferred, current_transferrable);
+            CHECK(callback_was_called);
+            CHECK(transferred == current_transferred);
+            CHECK(transferrable == current_transferrable);
         }
 
         SECTION("for download notifications") {
-            session->register_progress_notifier([&](auto xferred, auto xferable) {
+            progress.register_callback([&](auto xferred, auto xferable) {
                 transferred = xferred;
                 transferrable = xferable;
                 callback_was_called = true;
-            }, SyncSession::NotifierType::download, true);
-            // Wait for the initial callback.
-            EventLoop::main().run_until([&] { return callback_was_called.load(); });
+            }, true, true);
+            REQUIRE(callback_was_called);
 
             // Now manually call the notifier handler a few times.
             callback_was_called = false;
             current_transferred = 60;
             current_transferrable = 912;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_transferred, current_transferrable, 25, 26);
-            CHECK(callback_was_called.load());
-            CHECK(transferred.load() == current_transferred);
-            CHECK(transferrable.load() == current_transferrable);
+            progress.update(current_transferred, current_transferrable, 25, 26);
+            CHECK(callback_was_called);
+            CHECK(transferred == current_transferred);
+            CHECK(transferrable == current_transferrable);
 
             // Second callback
             callback_was_called = false;
             current_transferred = 79;
             current_transferrable = 1021;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_transferred, current_transferrable, 68, 191);
-            CHECK(callback_was_called.load());
-            CHECK(transferred.load() == current_transferred);
-            CHECK(transferrable.load() == current_transferrable);
+            progress.update(current_transferred, current_transferrable, 68, 191);
+            CHECK(callback_was_called);
+            CHECK(transferred == current_transferred);
+            CHECK(transferrable == current_transferrable);
 
             // Third callback
             callback_was_called = false;
             current_transferred = 150;
             current_transferrable = 1228;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_transferred, current_transferrable, 199, 591);
-            CHECK(callback_was_called.load());
-            CHECK(transferred.load() == current_transferred);
-            CHECK(transferrable.load() == current_transferrable);
+            progress.update(current_transferred, current_transferrable, 199, 591);
+            CHECK(callback_was_called);
+            CHECK(transferred == current_transferred);
+            CHECK(transferrable == current_transferrable);
         }
 
         SECTION("token unregistration works") {
-            uint64_t token = session->register_progress_notifier([&](auto xferred, auto xferable) {
+            uint64_t token = progress.register_callback([&](auto xferred, auto xferable) {
                 transferred = xferred;
                 transferrable = xferable;
                 callback_was_called = true;
-            }, SyncSession::NotifierType::download, true);
-            // Wait for the initial callback.
-            EventLoop::main().run_until([&] { return callback_was_called.load(); });
+            }, true, true);
+            REQUIRE(callback_was_called);
 
             // Now manually call the notifier handler a few times.
             callback_was_called = false;
             current_transferred = 60;
             current_transferrable = 912;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_transferred, current_transferrable, 25, 26);
-            CHECK(callback_was_called.load());
-            CHECK(transferred.load() == current_transferred);
-            CHECK(transferrable.load() == current_transferrable);
+            progress.update(current_transferred, current_transferrable, 25, 26);
+            CHECK(callback_was_called);
+            CHECK(transferred == current_transferred);
+            CHECK(transferrable == current_transferrable);
 
             // Unregister
-            session->unregister_progress_notifier(token);
+            progress.unregister_callback(token);
 
             // Second callback: should not actually do anything.
             callback_was_called = false;
             current_transferred = 150;
             current_transferrable = 1228;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_transferred, current_transferrable, 199, 591);
-            CHECK(!callback_was_called.load());
+            progress.update(current_transferred, current_transferrable, 199, 591);
+            CHECK(!callback_was_called);
         }
 
         SECTION("for multiple notifiers") {
-            session->register_progress_notifier([&](auto xferred, auto xferable) {
+            progress.register_callback([&](auto xferred, auto xferable) {
                 transferred = xferred;
                 transferrable = xferable;
                 callback_was_called = true;
-            }, SyncSession::NotifierType::download, true);
+            }, true, true);
+            REQUIRE(callback_was_called);
+
             // Register a second notifier.
-            std::atomic<bool> callback_was_called_2(false);
-            std::atomic<uint64_t> transferred_2(0);
-            std::atomic<uint64_t> transferrable_2(0);
-            session->register_progress_notifier([&](auto xferred, auto xferable) {
+            bool callback_was_called_2 = false;
+            uint64_t transferred_2 = 0;
+            uint64_t transferrable_2 = 0;
+            progress.register_callback([&](auto xferred, auto xferable) {
                 transferred_2 = xferred;
                 transferrable_2 = xferable;
                 callback_was_called_2 = true;
-            }, SyncSession::NotifierType::upload, true);
-            // Wait for the initial callback.
-            EventLoop::main().run_until([&] { return callback_was_called.load() && callback_was_called_2.load(); });
+            }, false, true);
+            REQUIRE(callback_was_called_2);
 
             // Now manually call the notifier handler a few times.
             callback_was_called = false;
@@ -229,13 +185,13 @@ TEST_CASE("progress notification", "[sync]") {
             uint64_t current_uploadable = 201;
             uint64_t current_downloaded = 68;
             uint64_t current_downloadable = 182;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_downloaded, current_downloadable, current_uploaded, current_uploadable);
-            CHECK(callback_was_called.load());
-            CHECK(transferred.load() == current_downloaded);
-            CHECK(transferrable.load() == current_downloadable);
-            CHECK(callback_was_called_2.load());
-            CHECK(transferred_2.load() == current_uploaded);
-            CHECK(transferrable_2.load() == current_uploadable);
+            progress.update(current_downloaded, current_downloadable, current_uploaded, current_uploadable);
+            CHECK(callback_was_called);
+            CHECK(transferred == current_downloaded);
+            CHECK(transferrable == current_downloadable);
+            CHECK(callback_was_called_2);
+            CHECK(transferred_2 == current_uploaded);
+            CHECK(transferrable_2 == current_uploadable);
 
             // Second callback
             callback_was_called = false;
@@ -244,27 +200,20 @@ TEST_CASE("progress notification", "[sync]") {
             current_uploadable = 329;
             current_downloaded = 76;
             current_downloadable = 191;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_downloaded, current_downloadable, current_uploaded, current_uploadable);
-            CHECK(callback_was_called.load());
-            CHECK(transferred.load() == current_downloaded);
-            CHECK(transferrable.load() == current_downloadable);
-            CHECK(callback_was_called_2.load());
-            CHECK(transferred_2.load() == current_uploaded);
-            CHECK(transferrable_2.load() == current_uploadable);
+            progress.update(current_downloaded, current_downloadable, current_uploaded, current_uploadable);
+            CHECK(callback_was_called);
+            CHECK(transferred == current_downloaded);
+            CHECK(transferrable == current_downloadable);
+            CHECK(callback_was_called_2);
+            CHECK(transferred_2 == current_uploaded);
+            CHECK(transferrable_2 == current_uploadable);
         }
     }
 
     SECTION("properly runs for non-streaming notifiers") {
-        auto user = SyncManager::shared().get_user({ "user-test-sync-3", dummy_auth_url }, "not_a_real_token");
-        auto session = sync_session(server, user, "/test-sync-progress-3",
-                                    [](const auto&, const auto&) { return s_test_token; },
-                                    [](auto, auto) { },
-                                    SyncSessionStopPolicy::AfterChangesUploaded);
-        wait_for_session_to_activate(*session);
-
-        std::atomic<bool> callback_was_called(false);
-        std::atomic<uint64_t> transferred(0);
-        std::atomic<uint64_t> transferrable(0);
+        bool callback_was_called = false;
+        uint64_t transferred = 0;
+        uint64_t transferrable = 0;
         uint64_t current_transferred = 0;
         uint64_t current_transferrable = 0;
 
@@ -273,40 +222,40 @@ TEST_CASE("progress notification", "[sync]") {
             current_transferred = 60;
             current_transferrable = 501;
             const uint64_t original_transferrable = current_transferrable;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, 21, 26, current_transferred, current_transferrable);
+            progress.update(21, 26, current_transferred, current_transferrable);
 
-            session->register_progress_notifier([&](auto xferred, auto xferable) {
+            progress.register_callback([&](auto xferred, auto xferable) {
                 transferred = xferred;
                 transferrable = xferable;
                 callback_was_called = true;
-            }, SyncSession::NotifierType::upload, false);
+            }, false, false);
             // Wait for the initial callback.
-            EventLoop::main().run_until([&] { return callback_was_called.load(); });
+            REQUIRE(callback_was_called);
 
             // Now manually call the notifier handler a few times.
             callback_was_called = false;
             current_transferred = 66;
             current_transferrable = 582;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, 25, 26, current_transferred, current_transferrable);
-            CHECK(callback_was_called.load());
-            CHECK(transferred.load() == current_transferred);
-            CHECK(transferrable.load() == original_transferrable);
+            progress.update(25, 26, current_transferred, current_transferrable);
+            CHECK(callback_was_called);
+            CHECK(transferred == current_transferred);
+            CHECK(transferrable == original_transferrable);
 
             // Second callback
             callback_was_called = false;
             current_transferred = original_transferrable + 100;
             current_transferrable = 1021;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, 68, 191, current_transferred, current_transferrable);
-            CHECK(callback_was_called.load());
-            CHECK(transferred.load() == current_transferred);
-            CHECK(transferrable.load() == original_transferrable);
+            progress.update(68, 191, current_transferred, current_transferrable);
+            CHECK(callback_was_called);
+            CHECK(transferred == current_transferred);
+            CHECK(transferrable == original_transferrable);
 
             // The notifier should be unregistered at this point, and not fire.
             callback_was_called = false;
             current_transferred = original_transferrable + 250;
             current_transferrable = 1228;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, 199, 591, current_transferred, current_transferrable);
-            CHECK(!callback_was_called.load());
+            progress.update(199, 591, current_transferred, current_transferrable);
+            CHECK(!callback_was_called);
         }
 
         SECTION("for download notifications") {
@@ -314,40 +263,40 @@ TEST_CASE("progress notification", "[sync]") {
             current_transferred = 60;
             current_transferrable = 501;
             const uint64_t original_transferrable = current_transferrable;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_transferred, current_transferrable, 21, 26);
+            progress.update(current_transferred, current_transferrable, 21, 26);
 
-            session->register_progress_notifier([&](auto xferred, auto xferable) {
+            progress.register_callback([&](auto xferred, auto xferable) {
                 transferred = xferred;
                 transferrable = xferable;
                 callback_was_called = true;
-            }, SyncSession::NotifierType::download, false);
+            }, true, false);
             // Wait for the initial callback.
-            EventLoop::main().run_until([&] { return callback_was_called.load(); });
+            REQUIRE(callback_was_called);
 
             // Now manually call the notifier handler a few times.
             callback_was_called = false;
             current_transferred = 66;
             current_transferrable = 582;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_transferred, current_transferrable, 25, 26);
-            CHECK(callback_was_called.load());
-            CHECK(transferred.load() == current_transferred);
-            CHECK(transferrable.load() == original_transferrable);
+            progress.update(current_transferred, current_transferrable, 25, 26);
+            CHECK(callback_was_called);
+            CHECK(transferred == current_transferred);
+            CHECK(transferrable == original_transferrable);
 
             // Second callback
             callback_was_called = false;
             current_transferred = original_transferrable + 100;
             current_transferrable = 1021;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_transferred, current_transferrable, 68, 191);
-            CHECK(callback_was_called.load());
-            CHECK(transferred.load() == current_transferred);
-            CHECK(transferrable.load() == original_transferrable);
+            progress.update(current_transferred, current_transferrable, 68, 191);
+            CHECK(callback_was_called);
+            CHECK(transferred == current_transferred);
+            CHECK(transferrable == original_transferrable);
 
             // The notifier should be unregistered at this point, and not fire.
             callback_was_called = false;
             current_transferred = original_transferrable + 250;
             current_transferrable = 1228;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_transferred, current_transferrable, 199, 591);
-            CHECK(!callback_was_called.load());
+            progress.update(current_transferred, current_transferrable, 199, 591);
+            CHECK(!callback_was_called);
         }
 
         SECTION("token unregistration works") {
@@ -355,34 +304,34 @@ TEST_CASE("progress notification", "[sync]") {
             current_transferred = 60;
             current_transferrable = 501;
             const uint64_t original_transferrable = current_transferrable;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, 21, 26, current_transferred, current_transferrable);
+            progress.update(21, 26, current_transferred, current_transferrable);
 
-            uint64_t token = session->register_progress_notifier([&](auto xferred, auto xferable) {
+            uint64_t token = progress.register_callback([&](auto xferred, auto xferable) {
                 transferred = xferred;
                 transferrable = xferable;
                 callback_was_called = true;
-            }, SyncSession::NotifierType::upload, false);
+            }, false, false);
             // Wait for the initial callback.
-            EventLoop::main().run_until([&] { return callback_was_called.load(); });
+            REQUIRE(callback_was_called);
 
             // Now manually call the notifier handler a few times.
             callback_was_called = false;
             current_transferred = 66;
             current_transferrable = 912;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, 25, 26, current_transferred, current_transferrable);
-            CHECK(callback_was_called.load());
-            CHECK(transferred.load() == current_transferred);
-            CHECK(transferrable.load() == original_transferrable);
+            progress.update(25, 26, current_transferred, current_transferrable);
+            CHECK(callback_was_called);
+            CHECK(transferred == current_transferred);
+            CHECK(transferrable == original_transferrable);
 
             // Unregister
-            session->unregister_progress_notifier(token);
+            progress.unregister_callback(token);
 
             // Second callback: should not actually do anything.
             callback_was_called = false;
             current_transferred = 67;
             current_transferrable = 1228;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, 199, 591, current_transferred, current_transferrable);
-            CHECK(!callback_was_called.load());
+            progress.update(199, 591, current_transferred, current_transferrable);
+            CHECK(!callback_was_called);
         }
 
         SECTION("for multiple notifiers, different directions") {
@@ -393,24 +342,25 @@ TEST_CASE("progress notification", "[sync]") {
             uint64_t current_downloadable = 182;
             const uint64_t original_uploadable = current_uploadable;
             const uint64_t original_downloadable = current_downloadable;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_downloaded, current_downloadable, current_uploaded, current_uploadable);
+            progress.update(current_downloaded, current_downloadable, current_uploaded, current_uploadable);
 
-            session->register_progress_notifier([&](auto xferred, auto xferable) {
+            progress.register_callback([&](auto xferred, auto xferable) {
                 transferred = xferred;
                 transferrable = xferable;
                 callback_was_called = true;
-            }, SyncSession::NotifierType::upload, false);
+            }, false, false);
+            REQUIRE(callback_was_called);
+
             // Register a second notifier.
-            std::atomic<bool> callback_was_called_2(false);
-            std::atomic<uint64_t> downloaded(0);
-            std::atomic<uint64_t> downloadable(0);
-            session->register_progress_notifier([&](auto xferred, auto xferable) {
+            bool callback_was_called_2 = false;
+            uint64_t downloaded = 0;
+            uint64_t downloadable = 0;
+            progress.register_callback([&](auto xferred, auto xferable) {
                 downloaded = xferred;
                 downloadable = xferable;
                 callback_was_called_2 = true;
-            }, SyncSession::NotifierType::download, false);
-            // Wait for the initial callback.
-            EventLoop::main().run_until([&] { return callback_was_called.load() && callback_was_called_2.load(); });
+            }, true, false);
+            REQUIRE(callback_was_called_2);
 
             // Now manually call the notifier handler a few times.
             callback_was_called = false;
@@ -419,13 +369,13 @@ TEST_CASE("progress notification", "[sync]") {
             current_uploadable = 310;
             current_downloaded = 171;
             current_downloadable = 185;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_downloaded, current_downloadable, current_uploaded, current_uploadable);
-            CHECK(callback_was_called.load());
-            CHECK(transferred.load() == current_uploaded);
-            CHECK(transferrable.load() == original_uploadable);
-            CHECK(callback_was_called_2.load());
-            CHECK(downloaded.load() == current_downloaded);
-            CHECK(downloadable.load() == original_downloadable);
+            progress.update(current_downloaded, current_downloadable, current_uploaded, current_uploadable);
+            CHECK(callback_was_called);
+            CHECK(transferred == current_uploaded);
+            CHECK(transferrable == original_uploadable);
+            CHECK(callback_was_called_2);
+            CHECK(downloaded == current_downloaded);
+            CHECK(downloadable == original_downloadable);
 
             // Second callback, last one for the upload notifier
             callback_was_called = false;
@@ -434,13 +384,13 @@ TEST_CASE("progress notification", "[sync]") {
             current_uploadable = 310;
             current_downloaded = 174;
             current_downloadable = 190;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_downloaded, current_downloadable, current_uploaded, current_uploadable);
-            CHECK(callback_was_called.load());
-            CHECK(transferred.load() == current_uploaded);
-            CHECK(transferrable.load() == original_uploadable);
-            CHECK(callback_was_called_2.load());
-            CHECK(downloaded.load() == current_downloaded);
-            CHECK(downloadable.load() == original_downloadable);
+            progress.update(current_downloaded, current_downloadable, current_uploaded, current_uploadable);
+            CHECK(callback_was_called);
+            CHECK(transferred == current_uploaded);
+            CHECK(transferrable == original_uploadable);
+            CHECK(callback_was_called_2);
+            CHECK(downloaded == current_downloaded);
+            CHECK(downloadable == original_downloadable);
 
             // Third callback, last one for the download notifier
             callback_was_called = false;
@@ -449,11 +399,11 @@ TEST_CASE("progress notification", "[sync]") {
             current_uploadable = 310;
             current_downloaded = 182;
             current_downloadable = 196;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_downloaded, current_downloadable, current_uploaded, current_uploadable);
-            CHECK(!callback_was_called.load());
-            CHECK(callback_was_called_2.load());
-            CHECK(downloaded.load() == current_downloaded);
-            CHECK(downloadable.load() == original_downloadable);
+            progress.update(current_downloaded, current_downloadable, current_uploaded, current_uploadable);
+            CHECK(!callback_was_called);
+            CHECK(callback_was_called_2);
+            CHECK(downloaded == current_downloaded);
+            CHECK(downloadable == original_downloadable);
 
             // Fourth callback, last one for the download notifier
             callback_was_called_2 = false;
@@ -461,9 +411,9 @@ TEST_CASE("progress notification", "[sync]") {
             current_uploadable = 410;
             current_downloaded = 192;
             current_downloadable = 591;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_downloaded, current_downloadable, current_uploaded, current_uploadable);
-            CHECK(!callback_was_called.load());
-            CHECK(!callback_was_called_2.load());;
+            progress.update(current_downloaded, current_downloadable, current_uploaded, current_uploadable);
+            CHECK(!callback_was_called);
+            CHECK(!callback_was_called_2);;
         }
 
         SECTION("for multiple notifiers, same direction") {
@@ -473,14 +423,14 @@ TEST_CASE("progress notification", "[sync]") {
             uint64_t current_downloaded = 68;
             uint64_t current_downloadable = 182;
             const uint64_t original_downloadable = current_downloadable;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_downloaded, current_downloadable, current_uploaded, current_uploadable);
+            progress.update(current_downloaded, current_downloadable, current_uploaded, current_uploadable);
 
-            session->register_progress_notifier([&](auto xferred, auto xferable) {
+            progress.register_callback([&](auto xferred, auto xferable) {
                 transferred = xferred;
                 transferrable = xferable;
                 callback_was_called = true;
-            }, SyncSession::NotifierType::download, false);
-            EventLoop::main().run_until([&] { return callback_was_called.load(); });
+            }, true, false);
+            REQUIRE(callback_was_called);
 
             // Now manually call the notifier handler a few times.
             callback_was_called = false;
@@ -488,23 +438,23 @@ TEST_CASE("progress notification", "[sync]") {
             current_uploadable = 310;
             current_downloaded = 171;
             current_downloadable = 185;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_downloaded, current_downloadable, current_uploaded, current_uploadable);
-            CHECK(callback_was_called.load());
-            CHECK(transferred.load() == current_downloaded);
-            CHECK(transferrable.load() == original_downloadable);
+            progress.update(current_downloaded, current_downloadable, current_uploaded, current_uploadable);
+            CHECK(callback_was_called);
+            CHECK(transferred == current_downloaded);
+            CHECK(transferrable == original_downloadable);
 
             // Register a second notifier.
-            std::atomic<bool> callback_was_called_2(false);
-            std::atomic<uint64_t> downloaded(0);
-            std::atomic<uint64_t> downloadable(0);
+            bool callback_was_called_2 = false;
+            uint64_t downloaded = 0;
+            uint64_t downloadable = 0;
             const uint64_t original_downloadable_2 = current_downloadable;
-            session->register_progress_notifier([&](auto xferred, auto xferable) {
+            progress.register_callback([&](auto xferred, auto xferable) {
                 downloaded = xferred;
                 downloadable = xferable;
                 callback_was_called_2 = true;
-            }, SyncSession::NotifierType::download, false);
+            }, true, false);
             // Wait for the initial callback.
-            EventLoop::main().run_until([&] { return callback_was_called_2.load(); });
+            REQUIRE(callback_was_called_2);
 
             // Second callback, last one for first notifier
             callback_was_called = false;
@@ -513,13 +463,13 @@ TEST_CASE("progress notification", "[sync]") {
             current_uploadable = 310;
             current_downloaded = 182;
             current_downloadable = 190;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_downloaded, current_downloadable, current_uploaded, current_uploadable);
-            CHECK(callback_was_called.load());
-            CHECK(transferred.load() == current_downloaded);
-            CHECK(transferrable.load() == original_downloadable);
-            CHECK(callback_was_called_2.load());
-            CHECK(downloaded.load() == current_downloaded);
-            CHECK(downloadable.load() == original_downloadable_2);
+            progress.update(current_downloaded, current_downloadable, current_uploaded, current_uploadable);
+            CHECK(callback_was_called);
+            CHECK(transferred == current_downloaded);
+            CHECK(transferrable == original_downloadable);
+            CHECK(callback_was_called_2);
+            CHECK(downloaded == current_downloaded);
+            CHECK(downloadable == original_downloadable_2);
 
             // Third callback, last one for second notifier
             callback_was_called = false;
@@ -528,11 +478,11 @@ TEST_CASE("progress notification", "[sync]") {
             current_uploadable = 310;
             current_downloaded = 189;
             current_downloadable = 250;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_downloaded, current_downloadable, current_uploaded, current_uploadable);
-            CHECK(!callback_was_called.load());
-            CHECK(callback_was_called_2.load());
-            CHECK(downloaded.load() == current_downloaded);
-            CHECK(downloadable.load() == original_downloadable_2);
+            progress.update(current_downloaded, current_downloadable, current_uploaded, current_uploadable);
+            CHECK(!callback_was_called);
+            CHECK(callback_was_called_2);
+            CHECK(downloaded == current_downloaded);
+            CHECK(downloadable == original_downloadable_2);
 
             // Fourth callback
             callback_was_called_2 = false;
@@ -540,8 +490,8 @@ TEST_CASE("progress notification", "[sync]") {
             current_uploadable = 310;
             current_downloaded = 201;
             current_downloadable = 289;
-            SyncSession::OnlyForTesting::handle_progress_update(*session, current_downloaded, current_downloadable, current_uploaded, current_uploadable);
-            CHECK(!callback_was_called_2.load());
+            progress.update(current_downloaded, current_downloadable, current_uploaded, current_uploadable);
+            CHECK(!callback_was_called_2);
         }
     }
 }

--- a/tests/sync/session/progress_notifications.cpp
+++ b/tests/sync/session/progress_notifications.cpp
@@ -333,7 +333,7 @@ TEST_CASE("progress notification", "[sync]") {
             CHECK(!callback_was_called);
         }
 
-        SECTION("download notifications are not sent until all a DOWNLOAD message has been received") {
+        SECTION("download notifications are not sent until a DOWNLOAD message has been received") {
             _impl::SyncProgressNotifier progress;
 
             progress.register_callback([&](auto xferred, auto xferable) {


### PR DESCRIPTION
When a non-streaming progress notification is added immediately after a local commit was made, that progress notification could capture the total bytes to upload before that value was actually updated to reflect the newly made transaction, resulting in the notifier completing before the upload actually happened. Fix this by tracking the last seen local transaction version and only capture the uploadable bytes value once the sync progress is for that version or later.

The functional changes are all in the second commit. The first commit extracts the callback management code to a helper class that can be unit tested directly rather than via test helper functions on SyncSession (none of the existing tests were integration tests that meaningfully tested it by doing things via sync).

Fixes https://github.com/realm/realm-sync/issues/1904.