### PR TITLE
Exposing get_number_of_versions

### DIFF
--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -690,6 +690,10 @@ bool Realm::compact()
     return m_shared_group->compact();
 }
 
+int64_t Realm::get_number_of_versions() {
+    return static_cast<int64_t>(m_shared_group->get_number_of_versions());
+}
+
 void Realm::write_copy(StringData path, BinaryData key)
 {
     if (key.data() && key.size() != 64) {

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -269,6 +269,8 @@ public:
     void write_copy(StringData path, BinaryData encryption_key);
     OwnedBinaryData write_copy();
 
+    int64_t get_number_of_versions();
+
     void verify_thread() const;
     void verify_in_write() const;
     void verify_open() const;

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -1297,10 +1297,8 @@ TEST_CASE("SharedRealm: compact on launch") {
             auto r2 = Realm::get_shared_realm(config);
             r2->begin_transaction();
             auto table = r2->read_group().get_table("class_object");
-            size_t count = 1000;
-            table->add_empty_row(count);
-            for (size_t i = 0; i < count; ++i)
-                table->set_string(0, i, util::format("Foo_%1", i % 10).c_str());
+            table->add_empty_row();
+            table->set_string(0, 0, "Foo");
             r2->commit_transaction();
             REQUIRE(r2->get_number_of_versions() == 2);
         }).join();


### PR DESCRIPTION
We have a customer with large Realm files, and we need to understand why. 