### PR TITLE
Replace the partial sync API

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,6 +91,7 @@ set(INCLUDE_DIRS
 if(REALM_ENABLE_SYNC)
     list(APPEND HEADERS
         sync/partial_sync.hpp
+        sync/subscription_state.hpp
         sync/sync_config.hpp
         sync/sync_manager.hpp
         sync/sync_permission.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,7 +99,8 @@ if(REALM_ENABLE_SYNC)
         sync/sync_user.hpp
         sync/impl/sync_client.hpp
         sync/impl/sync_file.hpp
-        sync/impl/sync_metadata.hpp)
+        sync/impl/sync_metadata.hpp
+        sync/impl/work_queue.hpp)
     list(APPEND SOURCES
         sync/partial_sync.cpp
         sync/sync_config.cpp
@@ -108,7 +109,8 @@ if(REALM_ENABLE_SYNC)
         sync/sync_session.cpp
         sync/sync_user.cpp
         sync/impl/sync_file.cpp
-        sync/impl/sync_metadata.cpp)
+        sync/impl/sync_metadata.cpp
+        sync/impl/work_queue.cpp)
     if(APPLE)
         list(APPEND SOURCES
             sync/impl/apple/network_reachability_observer.cpp

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -233,7 +233,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
                 throw RealmFileException(RealmFileException::Kind::AccessError, get_path(), ex.code().message(), "");
             }
         }
-        m_weak_realm_notifiers.emplace_back(realm, m_config.cache);
+        m_weak_realm_notifiers.emplace_back(realm, realm->config().cache);
     }
 
     if (realm->config().sync_config)

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -28,6 +28,7 @@
 #include "schema.hpp"
 
 #if REALM_ENABLE_SYNC
+#include "sync/impl/work_queue.hpp"
 #include "sync/sync_config.hpp"
 #include "sync/sync_manager.hpp"
 #include "sync/sync_session.hpp"
@@ -298,7 +299,12 @@ void RealmCoordinator::advance_schema_cache(uint64_t previous, uint64_t next)
     m_schema_transaction_version_max = std::max(next, m_schema_transaction_version_max);
 }
 
-RealmCoordinator::RealmCoordinator() = default;
+RealmCoordinator::RealmCoordinator()
+#if REALM_ENABLE_SYNC
+: m_partial_sync_work_queue(std::make_unique<partial_sync::WorkQueue>())
+#endif
+{
+}
 
 RealmCoordinator::~RealmCoordinator()
 {
@@ -890,3 +896,10 @@ void RealmCoordinator::set_transaction_callback(std::function<void(VersionID, Ve
     create_sync_session();
     m_transaction_callback = std::move(fn);
 }
+
+#if REALM_ENABLE_SYNC
+partial_sync::WorkQueue& RealmCoordinator::partial_sync_work_queue()
+{
+    return *m_partial_sync_work_queue;
+}
+#endif

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -38,6 +38,10 @@ class CollectionNotifier;
 class ExternalCommitHelper;
 class WeakRealmNotifier;
 
+namespace partial_sync {
+class WorkQueue;
+}
+
 // RealmCoordinator manages the weak cache of Realm instances and communication
 // between per-thread Realm instances for a given file
 class RealmCoordinator : public std::enable_shared_from_this<RealmCoordinator> {
@@ -137,6 +141,11 @@ public:
     template<typename Pred>
     std::unique_lock<std::mutex> wait_for_notifiers(Pred&& wait_predicate);
 
+#if REALM_ENABLE_SYNC
+    // A work queue that can be used to perform background work related to partial sync.
+    partial_sync::WorkQueue& partial_sync_work_queue();
+#endif
+
 private:
     Realm::Config m_config;
 
@@ -170,7 +179,10 @@ private:
     std::unique_ptr<_impl::ExternalCommitHelper> m_notifier;
     std::function<void(VersionID, VersionID)> m_transaction_callback;
 
+#if REALM_ENABLE_SYNC
     std::shared_ptr<SyncSession> m_sync_session;
+    std::unique_ptr<partial_sync::WorkQueue> m_partial_sync_work_queue;
+#endif
 
     // must be called with m_notifier_mutex locked
     void pin_version(VersionID version);

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -53,7 +53,7 @@ public:
     // set the schema version without any checks
     // and the tables for the schema version and the primary key are created if they don't exist
     // NOTE: must be performed within a write transaction
-    static void set_schema_version(Group& group, uint64_t version);
+    static void set_schema_version(Group& group, uint64_t version, bool partial_realm = false);
 
     // check if all of the changes in the list can be applied automatically, or
     // throw if any of them require a schema version bump and migration function
@@ -85,7 +85,8 @@ public:
     static void apply_schema_changes(Group& group, uint64_t schema_version,
                                      Schema& target_schema, uint64_t target_schema_version,
                                      SchemaMode mode, std::vector<SchemaChange> const& changes,
-                                     std::function<void()> migration_function={});
+                                     std::function<void()> migration_function={}, 
+                                     bool partial_realm = false);
 
     static void apply_additive_changes(Group&, std::vector<SchemaChange> const&, bool update_indexes);
 

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -51,9 +51,9 @@ typedef std::weak_ptr<Realm> WeakRealm;
 namespace _impl {
     class AnyHandover;
     class CollectionNotifier;
+    class PartialSyncHelper;
     class RealmCoordinator;
     class RealmFriend;
-    struct RowHandover;
 }
 
 // How to handle update_schema() being called on a file which has
@@ -314,11 +314,11 @@ public:
     // without making it public to everyone
     class Internal {
         friend class _impl::CollectionNotifier;
+        friend class _impl::PartialSyncHelper;
         friend class _impl::RealmCoordinator;
         friend class ThreadSafeReferenceBase;
         friend class GlobalNotifier;
         friend class TestHelper;
-        friend struct _impl::RowHandover;
 
         // ResultsNotifier and ListNotifier need access to the SharedGroup
         // to be able to call the handover functions, which are not very wrappable

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -53,6 +53,7 @@ namespace _impl {
     class CollectionNotifier;
     class RealmCoordinator;
     class RealmFriend;
+    struct RowHandover;
 }
 
 // How to handle update_schema() being called on a file which has
@@ -317,6 +318,7 @@ public:
         friend class ThreadSafeReferenceBase;
         friend class GlobalNotifier;
         friend class TestHelper;
+        friend struct _impl::RowHandover;
 
         // ResultsNotifier and ListNotifier need access to the SharedGroup
         // to be able to call the handover functions, which are not very wrappable

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -248,6 +248,9 @@ public:
     Schema const& schema() const { return m_schema; }
     uint64_t schema_version() const { return m_schema_version; }
 
+    // Returns `true` if this Realm is a Partially synchronized Realm.
+    bool is_partial() const noexcept;
+
     void begin_transaction();
     void commit_transaction();
     void cancel_transaction();

--- a/src/sync/impl/work_queue.cpp
+++ b/src/sync/impl/work_queue.cpp
@@ -1,0 +1,80 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2018 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "sync/impl/work_queue.hpp"
+
+#include <chrono>
+
+namespace realm {
+namespace _impl {
+namespace partial_sync {
+
+WorkQueue::~WorkQueue()
+{
+    {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        m_stopping = true;
+    }
+    m_cv.notify_one();
+
+    if (m_thread.joinable())
+        m_thread.join();
+}
+
+void WorkQueue::enqueue(std::function<void()> function)
+{
+    {
+        std::unique_lock<std::mutex> lock(m_mutex);
+        m_queue.push_back(std::move(function));
+
+        if (m_stopped)
+            create_thread();
+    }
+    m_cv.notify_one();
+}
+
+void WorkQueue::create_thread()
+{
+    if (m_thread.joinable())
+        m_thread.join();
+
+    m_thread = std::thread([this] {
+        std::vector<std::function<void()>> queue;
+
+        std::unique_lock<std::mutex> lock(m_mutex);
+        while (!m_stopping &&
+               m_cv.wait_for(lock, std::chrono::milliseconds(500),
+                             [&] { return !m_queue.empty() || m_stopping; })) {
+
+            swap(queue, m_queue);
+
+            lock.unlock();
+            for (auto& f : queue)
+                f();
+            queue.clear();
+            lock.lock();
+        }
+
+        m_stopped = true;
+    });
+    m_stopped = false;
+}
+
+} // namespace partial_sync
+} // namespace _impl
+} // namespace realm

--- a/src/sync/impl/work_queue.hpp
+++ b/src/sync/impl/work_queue.hpp
@@ -1,0 +1,52 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2018 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_OS_PARTIAL_SYNC_WORK_QUEUE
+#define REALM_OS_PARTIAL_SYNC_WORK_QUEUE
+
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace realm {
+namespace _impl {
+namespace partial_sync {
+
+class WorkQueue {
+public:
+    ~WorkQueue();
+    void enqueue(std::function<void()> function);
+
+private:
+    void create_thread();
+
+    std::mutex m_mutex;
+    std::condition_variable m_cv;
+    std::vector<std::function<void()>> m_queue;
+    std::thread m_thread;
+    bool m_stopping = false;
+    bool m_stopped = true;
+};
+
+
+} // namespace partial_sync
+} // namespace _impl
+} // namespace realm
+
+#endif // REALM_OS_PARTIAL_SYNC_WORK_QUEUE

--- a/src/sync/partial_sync.cpp
+++ b/src/sync/partial_sync.cpp
@@ -485,8 +485,13 @@ void unsubscribe(Subscription& subscription)
         }
 
         case SubscriptionState::Error:
+            // We encountered an error when creating the subscription. There's nothing to remove, so just
+            // mark the subscription as removed.
+            subscription.m_notifier->finished_unsubscribing();
+            break;
+
         case SubscriptionState::Invalidated:
-            // Nothing to do. We either failed to create the subscription, or have already removed it.
+            // Nothing to do. We have already removed the subscription.
             break;
 
         case SubscriptionState::Pending:

--- a/src/sync/partial_sync.cpp
+++ b/src/sync/partial_sync.cpp
@@ -369,6 +369,9 @@ util::Optional<Object> Subscription::result_set_object() const
 
 SubscriptionState Subscription::status() const
 {
+    if (!m_notifier->subscription_completed())
+        return SubscriptionState::Creating;
+
     if (m_notifier->error())
         return SubscriptionState::Error;
 
@@ -378,7 +381,9 @@ SubscriptionState Subscription::status() const
         return (SubscriptionState)value;
     }
 
-    return SubscriptionState::Uninitialized;
+    // We may not have an object even if the subscription has completed if the completion callback fired
+    // but the result sets callback is yet to fire.
+    return SubscriptionState::Creating;
 }
 
 std::exception_ptr Subscription::error() const

--- a/src/sync/partial_sync.cpp
+++ b/src/sync/partial_sync.cpp
@@ -267,7 +267,7 @@ struct Subscription::Notifier : public _impl::CollectionNotifier {
         }
 
         // Trigger processing of change notifications.
-        m_coordinator->on_change();
+        m_coordinator->wake_up_notifier_worker();
     }
 
     std::exception_ptr error() const

--- a/src/sync/partial_sync.cpp
+++ b/src/sync/partial_sync.cpp
@@ -312,7 +312,7 @@ Subscription subscribe(Results const& results, util::Optional<std::string> user_
     if (!sync_config || !sync_config->is_partial)
         throw std::logic_error("A partial sync query can only be registered in a partially synced Realm");
 
-    auto query = results.get_query().get_description();
+    auto query = results.get_query().get_description(); // Throws if the query cannot be serialized.
     std::string name = user_provided_name ? std::move(*user_provided_name) : default_name_for_query(query,results.get_object_type());
 
     Subscription subscription(name, results.get_object_type(), realm);

--- a/src/sync/partial_sync.cpp
+++ b/src/sync/partial_sync.cpp
@@ -367,7 +367,7 @@ util::Optional<Object> Subscription::result_set_object() const
     return util::none;
 }
 
-SubscriptionState Subscription::status() const
+SubscriptionState Subscription::state() const
 {
     if (!m_notifier->subscription_completed())
         return SubscriptionState::Creating;

--- a/src/sync/partial_sync.hpp
+++ b/src/sync/partial_sync.hpp
@@ -19,6 +19,7 @@
 #ifndef REALM_OS_PARTIAL_SYNC_HPP
 #define REALM_OS_PARTIAL_SYNC_HPP
 
+#include "object_schema.hpp"
 #include "results.hpp"
 
 #include <realm/util/optional.hpp>
@@ -61,7 +62,7 @@ private:
 
     void error_occurred(std::exception_ptr);
 
-    std::unique_ptr<ObjectSchema> m_object_schema;
+    ObjectSchema m_object_schema;
 
     mutable Results m_result_sets;
 

--- a/src/sync/partial_sync.hpp
+++ b/src/sync/partial_sync.hpp
@@ -70,9 +70,11 @@ private:
     _impl::CollectionNotifier::Handle<Notifier> m_notifier;
 
     friend Subscription subscribe(Results const&, util::Optional<std::string>);
+    friend void unsubscribe(Subscription&);
 };
 
-Subscription subscribe(Results const& results, util::Optional<std::string> name);
+Subscription subscribe(Results const&, util::Optional<std::string> name);
+void unsubscribe(Subscription&);
 
 // Deprecated
 void register_query(std::shared_ptr<Realm>, const std::string &object_class, const std::string &query,

--- a/src/sync/partial_sync.hpp
+++ b/src/sync/partial_sync.hpp
@@ -36,35 +36,37 @@ class Realm;
 namespace partial_sync {
 enum class SubscriptionState : int8_t;
 
+struct SubscriptionNotificationToken {
+    NotificationToken subscription_token;
+    NotificationToken error_token;
+};
+
 class Subscription {
 public:
     ~Subscription();
     Subscription(Subscription&&);
     Subscription& operator=(Subscription&&);
 
-    Subscription(Subscription const&) = delete;
-    Subscription& operator=(Subscription const&) = delete;
-
     SubscriptionState status() const;
     util::Optional<std::string> error_message() const;
 
     Results results() const;
 
-    NotificationToken add_notification_callback(std::function<void()> callback);
+    SubscriptionNotificationToken add_notification_callback(std::function<void()> callback);
 
 private:
     Subscription(std::string name, std::string object_type, std::shared_ptr<Realm>);
 
     util::Optional<Object> result_set_object() const;
 
-    void error_occurred();
+    void error_occurred(std::exception_ptr);
 
     std::unique_ptr<ObjectSchema> m_object_schema;
 
     mutable Results m_result_sets;
 
     struct ErrorNotifier;
-    std::shared_ptr<ErrorNotifier> m_error_notifier;
+    _impl::CollectionNotifier::Handle<ErrorNotifier> m_error_notifier;
 
     friend Subscription subscribe(Results const&, util::Optional<std::string>);
 };

--- a/src/sync/partial_sync.hpp
+++ b/src/sync/partial_sync.hpp
@@ -48,7 +48,7 @@ public:
     Subscription(Subscription&&);
     Subscription& operator=(Subscription&&);
 
-    SubscriptionState status() const;
+    SubscriptionState state() const;
     std::exception_ptr error() const;
 
     Results results() const;

--- a/src/sync/partial_sync.hpp
+++ b/src/sync/partial_sync.hpp
@@ -73,7 +73,21 @@ private:
     friend void unsubscribe(Subscription&);
 };
 
+/// Create a partial sync subscription from the query associated with the `Results`.
+///
+/// The subscription is created asynchronously.
+///
+/// State changes, including runtime errors, are communicated via notifications
+/// registered on the resulting `Subscription` object.
+///
+/// Programming errors, such as attempting to create a subscription in that is not
+/// partially synced, or subscribing to an unsupported query, will throw an exception.
 Subscription subscribe(Results const&, util::Optional<std::string> name);
+
+/// Remove a partial sync subscription.
+///
+/// The operation is performed asynchronously. Completion will be indicated by the
+/// `Subscription` transitioning to the `Invalidated` state.
 void unsubscribe(Subscription&);
 
 // Deprecated

--- a/src/sync/partial_sync.hpp
+++ b/src/sync/partial_sync.hpp
@@ -74,8 +74,6 @@ private:
 
 Subscription subscribe(Results const& results, util::Optional<std::string> name);
 
-void reset_for_testing();
-
 // Deprecated
 void register_query(std::shared_ptr<Realm>, const std::string &object_class, const std::string &query,
 					std::function<void (Results, std::exception_ptr)>);

--- a/src/sync/partial_sync.hpp
+++ b/src/sync/partial_sync.hpp
@@ -37,8 +37,8 @@ namespace partial_sync {
 enum class SubscriptionState : int8_t;
 
 struct SubscriptionNotificationToken {
-    NotificationToken subscription_token;
-    NotificationToken error_token;
+    NotificationToken registration_token;
+    NotificationToken result_sets_token;
 };
 
 class Subscription {
@@ -48,7 +48,7 @@ public:
     Subscription& operator=(Subscription&&);
 
     SubscriptionState status() const;
-    util::Optional<std::string> error_message() const;
+    std::exception_ptr error() const;
 
     Results results() const;
 
@@ -65,8 +65,8 @@ private:
 
     mutable Results m_result_sets;
 
-    struct ErrorNotifier;
-    _impl::CollectionNotifier::Handle<ErrorNotifier> m_error_notifier;
+    struct Notifier;
+    _impl::CollectionNotifier::Handle<Notifier> m_notifier;
 
     friend Subscription subscribe(Results const&, util::Optional<std::string>);
 };

--- a/src/sync/subscription_state.hpp
+++ b/src/sync/subscription_state.hpp
@@ -1,0 +1,37 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2018 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_OS_SUBSCRIPTION_STATE_HPP
+#define REALM_OS_SUBSCRIPTION_STATE_HPP
+
+#include <cstdint>
+
+namespace realm {
+namespace partial_sync {
+
+// Enum describing the various states a partial sync subscription can have.
+enum class SubscriptionState : int8_t {
+    Error = -1,             // An error occurred with the partial sync subscription..
+    Uninitialized = 0,      // The subscription was created, but has not yet been processed by the sync server.
+    Initialized = 1         // The subscription has been initialized successfully and is syncing data to the device.
+};
+
+}
+}
+
+#endif // REALM_OS_SUBSCRIPTION_STATE_HPP

--- a/src/sync/subscription_state.hpp
+++ b/src/sync/subscription_state.hpp
@@ -26,10 +26,11 @@ namespace partial_sync {
 
 // Enum describing the various states a partial sync subscription can have.
 enum class SubscriptionState : int8_t {
-    Error = -1,    // An error occurred while creating or processing the partial sync subscription.
-    Creating = 2,  // The subscription is being created.
-    Pending = 0,   // The subscription was created, but has not yet been processed by the sync server.
-    Complete = 1,  // The subscription has been processed by the sync server and data is being synced to the device.
+    Error = -1,      // An error occurred while creating or processing the partial sync subscription.
+    Creating = 2,    // The subscription is being created.
+    Pending = 0,     // The subscription was created, but has not yet been processed by the sync server.
+    Complete = 1,    // The subscription has been processed by the sync server and data is being synced to the device.
+    Invalidated = 3, // The subscription has been removed.
 };
 
 }

--- a/src/sync/subscription_state.hpp
+++ b/src/sync/subscription_state.hpp
@@ -26,9 +26,10 @@ namespace partial_sync {
 
 // Enum describing the various states a partial sync subscription can have.
 enum class SubscriptionState : int8_t {
-    Error = -1,             // An error occurred with the partial sync subscription..
-    Uninitialized = 0,      // The subscription was created, but has not yet been processed by the sync server.
-    Initialized = 1         // The subscription has been initialized successfully and is syncing data to the device.
+    Error = -1,    // An error occurred while creating or processing the partial sync subscription.
+    Creating = 2,  // The subscription is being created.
+    Pending = 0,   // The subscription was created, but has not yet been processed by the sync server.
+    Complete = 1,  // The subscription has been processed by the sync server and data is being synced to the device.
 };
 
 }

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -21,7 +21,6 @@
 #include "sync/impl/sync_client.hpp"
 #include "sync/impl/sync_file.hpp"
 #include "sync/impl/sync_metadata.hpp"
-#include "sync/partial_sync.hpp"
 #include "sync/sync_session.hpp"
 #include "sync/sync_user.hpp"
 
@@ -196,8 +195,6 @@ bool SyncManager::run_file_action(const SyncFileActionMetadata& md)
 
 void SyncManager::reset_for_testing()
 {
-    partial_sync::reset_for_testing();
-
     std::lock_guard<std::mutex> lock(m_file_system_mutex);
     m_file_manager = nullptr;
     m_metadata_manager = nullptr;

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -21,6 +21,7 @@
 #include "sync/impl/sync_client.hpp"
 #include "sync/impl/sync_file.hpp"
 #include "sync/impl/sync_metadata.hpp"
+#include "sync/partial_sync.hpp"
 #include "sync/sync_session.hpp"
 #include "sync/sync_user.hpp"
 
@@ -212,6 +213,8 @@ void SyncManager::reset_for_testing()
         // Stop the client. This will abort any uploads that inactive sessions are waiting for.
         if (m_sync_client)
             m_sync_client->stop();
+
+        partial_sync::reset_for_testing();
 
         {
             std::lock_guard<std::mutex> lock(m_session_mutex);

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -196,6 +196,8 @@ bool SyncManager::run_file_action(const SyncFileActionMetadata& md)
 
 void SyncManager::reset_for_testing()
 {
+    partial_sync::reset_for_testing();
+
     std::lock_guard<std::mutex> lock(m_file_system_mutex);
     m_file_manager = nullptr;
     m_metadata_manager = nullptr;
@@ -213,8 +215,6 @@ void SyncManager::reset_for_testing()
         // Stop the client. This will abort any uploads that inactive sessions are waiting for.
         if (m_sync_client)
             m_sync_client->stop();
-
-        partial_sync::reset_for_testing();
 
         {
             std::lock_guard<std::mutex> lock(m_session_mutex);

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -36,6 +36,7 @@ class SyncUser;
 namespace _impl {
 class RealmCoordinator;
 struct SyncClient;
+class WriteTransactionNotifyingSync;
 
 namespace sync_session_states {
 struct WaitingForAccessToken;
@@ -106,7 +107,8 @@ private:
 
     std::unordered_map<uint64_t, NotifierPackage> m_packages;
 };
-}
+
+} // namespace _impl
 
 class SyncSession : public std::enable_shared_from_this<SyncSession> {
 public:
@@ -242,6 +244,7 @@ public:
     // without making it public to everyone
     class Internal {
         friend class _impl::RealmCoordinator;
+        friend class _impl::WriteTransactionNotifyingSync;
 
         static void set_sync_transact_callback(SyncSession& session,
                                                std::function<SyncSessionTransactCallback> callback)

--- a/tests/sync/partial_sync.cpp
+++ b/tests/sync/partial_sync.cpp
@@ -136,7 +136,7 @@ void run_query(Results results, util::Optional<std::string> name,
     std::atomic<bool> partial_sync_done(false);
     std::exception_ptr exception;
     auto token = subscription.add_notification_callback([&] {
-        switch (subscription.status()) {
+        switch (subscription.state()) {
             case partial_sync::SubscriptionState::Creating:
             case partial_sync::SubscriptionState::Pending:
                 // Ignore these. They're temporary states.
@@ -149,7 +149,7 @@ void run_query(Results results, util::Optional<std::string> name,
                 partial_sync_done = true;
                 break;
             default:
-                throw std::logic_error(util::format("Unexpected state: %1", static_cast<uint8_t>(subscription.status())));
+                throw std::logic_error(util::format("Unexpected state: %1", static_cast<uint8_t>(subscription.state())));
         }
     });
     EventLoop::main().run_until([&] { return partial_sync_done.load(); });

--- a/tests/sync/partial_sync.cpp
+++ b/tests/sync/partial_sync.cpp
@@ -137,14 +137,15 @@ void run_query(Results results, util::Optional<std::string> name,
     std::exception_ptr exception;
     auto token = subscription.add_notification_callback([&] {
         switch (subscription.status()) {
-            case partial_sync::SubscriptionState::Uninitialized:
-                // Ignore this, temporary state
+            case partial_sync::SubscriptionState::Creating:
+            case partial_sync::SubscriptionState::Pending:
+                // Ignore these. They're temporary states.
                 break;
             case partial_sync::SubscriptionState::Error:
                 exception = subscription.error();
                 partial_sync_done = true;
                 break;
-            case partial_sync::SubscriptionState::Initialized:
+            case partial_sync::SubscriptionState::Complete:
                 partial_sync_done = true;
                 break;
             default:

--- a/tests/sync/partial_sync.cpp
+++ b/tests/sync/partial_sync.cpp
@@ -143,7 +143,7 @@ partial_sync::Subscription subscribe_and_wait(Results results, util::Optional<st
 {
     auto subscription = partial_sync::subscribe(results, name);
 
-    std::atomic<bool> partial_sync_done(false);
+    bool partial_sync_done = false;
     std::exception_ptr exception;
     auto token = subscription.add_notification_callback([&] {
         switch (subscription.state()) {
@@ -163,7 +163,7 @@ partial_sync::Subscription subscribe_and_wait(Results results, util::Optional<st
                 throw std::logic_error(util::format("Unexpected state: %1", static_cast<uint8_t>(subscription.state())));
         }
     });
-    EventLoop::main().run_until([&] { return partial_sync_done.load(); });
+    EventLoop::main().run_until([&] { return partial_sync_done; });
     check(std::move(results), std::move(exception));
     return subscription;
 }
@@ -318,7 +318,7 @@ TEST_CASE("Partial sync", "[sync]") {
     SECTION("unnamed query can be unsubscribed while in creating state") {
         auto subscription = subscription_with_query("number > 1", partial_config, "object_a", util::none);
 
-        std::atomic<bool> partial_sync_done(false);
+        bool partial_sync_done = false;
         auto token = subscription.add_notification_callback([&] {
             using SubscriptionState = partial_sync::SubscriptionState;
 
@@ -337,13 +337,13 @@ TEST_CASE("Partial sync", "[sync]") {
                     break;
             }
         });
-        EventLoop::main().run_until([&] { return partial_sync_done.load(); });
+        EventLoop::main().run_until([&] { return partial_sync_done; });
     }
 
     SECTION("unnamed query can be unsubscribed while in pending state") {
         auto subscription = subscription_with_query("number > 1", partial_config, "object_a", util::none);
 
-        std::atomic<bool> partial_sync_done(false);
+        bool partial_sync_done = false;
         auto token = subscription.add_notification_callback([&] {
             using SubscriptionState = partial_sync::SubscriptionState;
 
@@ -362,13 +362,13 @@ TEST_CASE("Partial sync", "[sync]") {
                     break;
             }
         });
-        EventLoop::main().run_until([&] { return partial_sync_done.load(); });
+        EventLoop::main().run_until([&] { return partial_sync_done; });
     }
 
     SECTION("unnamed query can be unsubscribed while in complete state") {
         auto subscription = subscription_with_query("number > 1", partial_config, "object_a", util::none);
 
-        std::atomic<bool> partial_sync_done(false);
+        bool partial_sync_done = false;
         auto token = subscription.add_notification_callback([&] {
             using SubscriptionState = partial_sync::SubscriptionState;
 
@@ -387,14 +387,14 @@ TEST_CASE("Partial sync", "[sync]") {
                     break;
             }
         });
-        EventLoop::main().run_until([&] { return partial_sync_done.load(); });
+        EventLoop::main().run_until([&] { return partial_sync_done; });
     }
 
     SECTION("unnamed query can be unsubscribed while in invalidated state") {
         auto subscription = subscription_with_query("number > 1", partial_config, "object_a", util::none);
         partial_sync::unsubscribe(subscription);
 
-        std::atomic<bool> partial_sync_done(false);
+        bool partial_sync_done = false;
         auto token = subscription.add_notification_callback([&] {
             using SubscriptionState = partial_sync::SubscriptionState;
 
@@ -412,14 +412,14 @@ TEST_CASE("Partial sync", "[sync]") {
                     break;
             }
         });
-        EventLoop::main().run_until([&] { return partial_sync_done.load(); });
+        EventLoop::main().run_until([&] { return partial_sync_done; });
     }
 
     SECTION("unnamed query can be unsubscribed while in error state") {
         auto subscription_1 = subscription_with_query("number != 1", partial_config, "object_a", "query"s);
         auto subscription_2 = subscription_with_query("number > 1", partial_config, "object_a", "query"s);
 
-        std::atomic<bool> partial_sync_done(false);
+        bool partial_sync_done = false;
         auto token = subscription_2.add_notification_callback([&] {
             using SubscriptionState = partial_sync::SubscriptionState;
 
@@ -438,7 +438,7 @@ TEST_CASE("Partial sync", "[sync]") {
                     break;
             }
         });
-        EventLoop::main().run_until([&] { return partial_sync_done.load(); });
+        EventLoop::main().run_until([&] { return partial_sync_done; });
     }
 }
 


### PR DESCRIPTION
This replaces the partial sync API introduced in #547 with one that supports named queries, and that allows subscribing to an existing `Results` so bindings can build queries using their high-level APIs. It supersedes @cmelchior's PR in #610 based on discussions on Slack about the difficulty of adapting that implementation to Cocoa's API.

Not yet supported:
 - [x] Unsubscribing (this may come in a later PR?)

Remaining work needed here:
 - [x] Further tests around subscription naming.

Things to further evaluate:
 - [x] Is the locking in `Subscription::Notifier` correct? There's a comment on `ResultsNotifier::do_add_required_change_info` that outlines what's safe to access when, but I've not thought too hard about how that relates to this code.
 - [x] Should `Subscription::Notifier` be where the error / subscription completed state is stored, or should it be storing it on the `Subscription` as part of delivering the notification?

I'm flagging this for review despite their being some work remaining so I can start getting feedback.