### PR TITLE
Add an `apply_ordering` method to `Results`

### DIFF
--- a/src/results.cpp
+++ b/src/results.cpp
@@ -612,6 +612,24 @@ Results Results::filter(Query&& q) const
     return Results(m_realm, get_query().and_query(std::move(q)), m_descriptor_ordering);
 }
 
+Results Results::apply_ordering(DescriptorOrdering&& ordering)
+{
+    DescriptorOrdering new_order = m_descriptor_ordering;
+    for (size_t i = 0; i < ordering.size(); ++i) {
+        const CommonDescriptor* desc = ordering[i];
+        if (const SortDescriptor* sort = dynamic_cast<const SortDescriptor*>(desc)) {
+            new_order.append_sort(*sort);
+            continue;
+        }
+        if (const DistinctDescriptor* distinct = dynamic_cast<const DistinctDescriptor*>(desc)) {
+            new_order.append_distinct(*distinct);
+            continue;
+        }
+        REALM_COMPILER_HINT_UNREACHABLE();
+    }
+    return Results(m_realm, get_query(), std::move(new_order));
+}
+
 Results Results::distinct(DistinctDescriptor&& uniqueness) const
 {
     DescriptorOrdering new_order = m_descriptor_ordering;

--- a/src/results.cpp
+++ b/src/results.cpp
@@ -618,11 +618,11 @@ Results Results::apply_ordering(DescriptorOrdering&& ordering)
     for (size_t i = 0; i < ordering.size(); ++i) {
         const CommonDescriptor* desc = ordering[i];
         if (const SortDescriptor* sort = dynamic_cast<const SortDescriptor*>(desc)) {
-            new_order.append_sort(*sort);
+            new_order.append_sort(std::move(*sort));
             continue;
         }
         if (const DistinctDescriptor* distinct = dynamic_cast<const DistinctDescriptor*>(desc)) {
-            new_order.append_distinct(*distinct);
+            new_order.append_distinct(std::move(*distinct));
             continue;
         }
         REALM_COMPILER_HINT_UNREACHABLE();

--- a/src/results.hpp
+++ b/src/results.hpp
@@ -120,6 +120,9 @@ public:
     Results distinct(DistinctDescriptor&& uniqueness) const;
     Results distinct(std::vector<std::string> const& keypaths) const;
 
+    // Create a new Results by adding sort and distinct combinations
+    Results apply_ordering(DescriptorOrdering&& ordering);
+
     // Return a snapshot of this Results that never updates to reflect changes in the underlying data.
     Results snapshot() const &;
     Results snapshot() &&;

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -2318,6 +2318,21 @@ TEST_CASE("results: distinct") {
         REQUIRE(unique.get(2).get_int(2) == 8);
     }
 
+    SECTION("Single integer via apply_ordering") {
+        DescriptorOrdering ordering;
+        ordering.append_sort(SortDescriptor(results.get_tableview().get_parent(), {{0}}));
+        ordering.append_distinct(DistinctDescriptor(results.get_tableview().get_parent(), {{0}}));
+        Results unique = results.apply_ordering(std::move(ordering));
+        // unique:
+        //  0, Foo_0, 10
+        //  1, Foo_1,  9
+        //  2, Foo_2,  8
+        REQUIRE(unique.size() == 3);
+        REQUIRE(unique.get(0).get_int(2) == 10);
+        REQUIRE(unique.get(1).get_int(2) == 9);
+        REQUIRE(unique.get(2).get_int(2) == 8);
+    }
+
     SECTION("Single string property") {
         Results unique = results.distinct(SortDescriptor(results.get_tableview().get_parent(), {{1}}));
         // unique:


### PR DESCRIPTION
This is a more generic method which will help the js binding easily integrate the parsed sort/distinct descriptors.