### PR TITLE
Fetch the client's UUID when configuring the SyncManager's file system support

### DIFF
--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -89,6 +89,8 @@ void SyncManager::configure_file_system(const std::string& base_file_path,
         }
 
         REALM_ASSERT(m_metadata_manager);
+        m_client_uuid = m_metadata_manager->client_uuid();
+
         // Perform any necessary file actions.
         std::vector<SyncFileActionMetadata> completed_actions;
         SyncFileActionMetadataResults file_actions = m_metadata_manager->all_pending_actions();
@@ -196,6 +198,8 @@ void SyncManager::reset_for_testing()
     std::lock_guard<std::mutex> lock(m_file_system_mutex);
     m_file_manager = nullptr;
     m_metadata_manager = nullptr;
+    m_client_uuid = util::none;
+
     {
         // Destroy all the users.
         std::lock_guard<std::mutex> lock(m_user_mutex);
@@ -511,6 +515,6 @@ std::unique_ptr<SyncClient> SyncManager::create_sync_client() const
 
 std::string SyncManager::client_uuid() const
 {
-    REALM_ASSERT(m_metadata_manager);
-    return m_metadata_manager->client_uuid();
+    REALM_ASSERT(m_client_uuid);
+    return *m_client_uuid;
 }

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -200,6 +200,9 @@ private:
     // Sessions remove themselves from this map by calling `unregister_session` once they're
     // inactive and have performed any necessary cleanup work.
     std::unordered_map<std::string, std::shared_ptr<SyncSession>> m_sessions;
+
+    // The unique identifier of this client.
+    util::Optional<std::string> m_client_uuid;
 };
 
 } // namespace realm


### PR DESCRIPTION
This removes the need to open and access a Realm file from within `SyncManager::client_uuid()`, which was problematic as it can be called in the process of opening a Realm file. This is both surprising, and had the potential to cause a deadlock on some platforms.

This fixes the hang I was hitting in #628.