### PR TITLE
Testing that sort/distinct orderings are applied to partial sync

### DIFF
--- a/src/sync/partial_sync.cpp
+++ b/src/sync/partial_sync.cpp
@@ -482,7 +482,7 @@ Subscription subscribe(Results const& results, util::Optional<std::string> user_
         throw std::logic_error("A partial sync query can only be registered in a partially synced Realm");
 
     auto query = results.get_query().get_description(); // Throws if the query cannot be serialized.
-    //query += " " + results.get_descriptor_ordering().get_description(results.get_query().get_table());
+    query += " " + results.get_descriptor_ordering().get_description(results.get_query().get_table());
 
     std::string name = user_provided_name ? std::move(*user_provided_name)
                                           : default_name_for_query(query, results.get_object_type());

--- a/src/sync/partial_sync.cpp
+++ b/src/sync/partial_sync.cpp
@@ -482,6 +482,8 @@ Subscription subscribe(Results const& results, util::Optional<std::string> user_
         throw std::logic_error("A partial sync query can only be registered in a partially synced Realm");
 
     auto query = results.get_query().get_description(); // Throws if the query cannot be serialized.
+    //query += " " + results.get_descriptor_ordering().get_description(results.get_query().get_table());
+
     std::string name = user_provided_name ? std::move(*user_provided_name)
                                           : default_name_for_query(query, results.get_object_type());
 

--- a/tests/sync/partial_sync.cpp
+++ b/tests/sync/partial_sync.cpp
@@ -258,6 +258,32 @@ TEST_CASE("Partial sync", "[sync]") {
         });
     }
 
+    SECTION("works when sort and distinct are applied") {
+        auto realm = Realm::get_shared_realm(partial_config);
+        auto table = ObjectStore::table_for_object_type(realm->read_group(), "object_b");
+        bool ascending = true;
+        bool descending = false;
+
+        {
+            Results partial_conditions(realm, *table);
+            partial_conditions = partial_conditions.sort({{"number", ascending}}).distinct({"string"});
+            subscribe_and_wait(partial_conditions, util::none, [](Results results, std::exception_ptr) {
+                REQUIRE(results.size() == 2);
+                REQUIRE(results_contains(results, {3, "meela", "orange"}));
+                REQUIRE(results_contains(results, {4, "jyaku", "kiwi"}));
+            });
+        }
+        {
+            Results partial_conditions(realm, *table);
+            partial_conditions = partial_conditions.sort({{"number", descending}}).distinct({"string"});
+            subscribe_and_wait(partial_conditions, util::none, [](Results results, std::exception_ptr) {
+                REQUIRE(results.size() == 2);
+                REQUIRE(results_contains(results, {6, "meela", "kiwi"}));
+                REQUIRE(results_contains(results, {7, "jyaku", "orange"}));
+            });
+        }
+    }
+
     SECTION("works when queries are made on different properties") {
         subscribe_and_wait("string = \"jyaku\"", partial_config, "object_b", util::none, [](Results results, std::exception_ptr) {
             REQUIRE(results.size() == 2);

--- a/tests/sync/partial_sync.cpp
+++ b/tests/sync/partial_sync.cpp
@@ -258,30 +258,46 @@ TEST_CASE("Partial sync", "[sync]") {
         });
     }
 
-    SECTION("works when sort and distinct are applied") {
+    SECTION("works when sort ascending and distinct are applied") {
         auto realm = Realm::get_shared_realm(partial_config);
         auto table = ObjectStore::table_for_object_type(realm->read_group(), "object_b");
         bool ascending = true;
-        bool descending = false;
-
-        {
-            Results partial_conditions(realm, *table);
-            partial_conditions = partial_conditions.sort({{"number", ascending}}).distinct({"string"});
-            subscribe_and_wait(partial_conditions, util::none, [](Results results, std::exception_ptr) {
+        Results partial_conditions(realm, *table);
+        partial_conditions = partial_conditions.sort({{"number", ascending}}).distinct({"string"});
+        partial_sync::Subscription subscription = subscribe_and_wait(partial_conditions, util::none, [](Results results, std::exception_ptr) {
                 REQUIRE(results.size() == 2);
                 REQUIRE(results_contains(results, {3, "meela", "orange"}));
                 REQUIRE(results_contains(results, {4, "jyaku", "kiwi"}));
-            });
-        }
-        {
-            Results partial_conditions(realm, *table);
-            partial_conditions = partial_conditions.sort({{"number", descending}}).distinct({"string"});
-            subscribe_and_wait(partial_conditions, util::none, [](Results results, std::exception_ptr) {
-                REQUIRE(results.size() == 2);
-                REQUIRE(results_contains(results, {6, "meela", "kiwi"}));
-                REQUIRE(results_contains(results, {7, "jyaku", "orange"}));
-            });
-        }
+        });
+        auto partial_realm = Realm::get_shared_realm(partial_config);
+        auto partial_table = ObjectStore::table_for_object_type(partial_realm->read_group(), "object_b");
+        REQUIRE(partial_table);
+        REQUIRE(partial_table->size() == 2);
+        Results partial_results(partial_realm, *partial_table);
+        REQUIRE(partial_results.size() == 2);
+        REQUIRE(results_contains(partial_results, {3, "meela", "orange"}));
+        REQUIRE(results_contains(partial_results, {4, "jyaku", "kiwi"}));
+    }
+
+    SECTION("works when sort descending and distinct are applied") {
+        auto realm = Realm::get_shared_realm(partial_config);
+        auto table = ObjectStore::table_for_object_type(realm->read_group(), "object_b");
+        bool ascending = false;
+        Results partial_conditions(realm, *table);
+        partial_conditions = partial_conditions.sort({{"number", ascending}}).distinct({"string"});
+        subscribe_and_wait(partial_conditions, util::none, [](Results results, std::exception_ptr) {
+            REQUIRE(results.size() == 2);
+            REQUIRE(results_contains(results, {6, "meela", "kiwi"}));
+            REQUIRE(results_contains(results, {7, "jyaku", "orange"}));
+        });
+        auto partial_realm = Realm::get_shared_realm(partial_config);
+        auto partial_table = ObjectStore::table_for_object_type(partial_realm->read_group(), "object_b");
+        REQUIRE(partial_table);
+        REQUIRE(partial_table->size() == 2);
+        Results partial_results(partial_realm, *partial_table);
+        REQUIRE(partial_results.size() == 2);
+        REQUIRE(results_contains(partial_results, {6, "meela", "kiwi"}));
+        REQUIRE(results_contains(partial_results, {7, "jyaku", "orange"}));
     }
 
     SECTION("works when queries are made on different properties") {


### PR DESCRIPTION
The description of sort/distinct needs to be serialised from the descriptor orderings that are stored in the Results class.

The strange thing is that the added test actually works with the changes commented out. Am I missing something here? How can I test this change?