### PR TITLE
Mask off extra bits set in computed privileges

### DIFF
--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -137,6 +137,7 @@ enum class SchemaMode : uint8_t {
 
 enum class ComputedPrivileges : uint8_t {
     None = 0,
+
     Read = (1 << 0),
     Update = (1 << 1),
     Delete = (1 << 2),
@@ -144,6 +145,10 @@ enum class ComputedPrivileges : uint8_t {
     Query = (1 << 4),
     Create = (1 << 5),
     ModifySchema = (1 << 6),
+
+    AllRealm = Read | Update | SetPermissions | ModifySchema,
+    AllClass = Read | Update | Create | Query | SetPermissions,
+    AllObject = Read | Update | Delete | SetPermissions,
     All = (1 << 7) - 1
 };
 

--- a/tests/sync/permission.cpp
+++ b/tests/sync/permission.cpp
@@ -134,9 +134,9 @@ TEST_CASE("Object-level Permissions") {
             auto r = Realm::get_shared_realm(config);
             auto& table = create_object(r);
 
-            CHECK(r->get_privileges() == ComputedPrivileges::All);
-            CHECK(r->get_privileges("object") == ComputedPrivileges::All);
-            CHECK(r->get_privileges(table[0]) == ComputedPrivileges::All);
+            CHECK(r->get_privileges() == ComputedPrivileges::AllRealm);
+            CHECK(r->get_privileges("object") == ComputedPrivileges::AllClass);
+            CHECK(r->get_privileges(table[0]) == ComputedPrivileges::AllObject);
         }
     }
 
@@ -145,9 +145,9 @@ TEST_CASE("Object-level Permissions") {
             auto r = Realm::get_shared_realm(config);
             auto& table = create_object(r);
 
-            CHECK(r->get_privileges() == ComputedPrivileges::All);
-            CHECK(r->get_privileges("object") == ComputedPrivileges::All);
-            CHECK(r->get_privileges(table[0]) == ComputedPrivileges::All);
+            CHECK(r->get_privileges() == ComputedPrivileges::AllRealm);
+            CHECK(r->get_privileges("object") == ComputedPrivileges::AllClass);
+            CHECK(r->get_privileges(table[0]) == ComputedPrivileges::AllObject);
         }
     }
 
@@ -158,9 +158,9 @@ TEST_CASE("Object-level Permissions") {
             auto r = Realm::get_shared_realm(config);
             auto& table = create_object(r);
 
-            CHECK(r->get_privileges() == ComputedPrivileges::All);
-            CHECK(r->get_privileges("object") == ComputedPrivileges::All);
-            CHECK(r->get_privileges(table[0]) == ComputedPrivileges::All);
+            CHECK(r->get_privileges() == ComputedPrivileges::AllRealm);
+            CHECK(r->get_privileges("object") == ComputedPrivileges::AllClass);
+            CHECK(r->get_privileges(table[0]) == ComputedPrivileges::AllObject);
         }
 
         SECTION("continue to permit all operations after syncing locally-created data") {
@@ -173,9 +173,9 @@ TEST_CASE("Object-level Permissions") {
             wait_for_upload(*r);
             wait_for_download(*r);
 
-            CHECK(r->get_privileges() == ComputedPrivileges::All);
-            CHECK(r->get_privileges("object") == ComputedPrivileges::All);
-            CHECK(r->get_privileges(table[0]) == ComputedPrivileges::All);
+            CHECK(r->get_privileges() == ComputedPrivileges::AllRealm);
+            CHECK(r->get_privileges("object") == ComputedPrivileges::AllClass);
+            CHECK(r->get_privileges(table[0]) == ComputedPrivileges::AllObject);
         }
 
         SECTION("permit all operations on a downloaded Realm created as a non-partial Realm when logged in as an admin") {
@@ -192,9 +192,9 @@ TEST_CASE("Object-level Permissions") {
             wait_for_download(*r);
             subscribe_to_all(r);
 
-            CHECK(r->get_privileges() == ComputedPrivileges::All);
-            CHECK(r->get_privileges("object") == ComputedPrivileges::All);
-            CHECK(r->get_privileges(r->read_group().get_table("class_object")->get(0)) == ComputedPrivileges::All);
+            CHECK(r->get_privileges() == ComputedPrivileges::AllRealm);
+            CHECK(r->get_privileges("object") == ComputedPrivileges::AllClass);
+            CHECK(r->get_privileges(r->read_group().get_table("class_object")->get(0)) == ComputedPrivileges::AllObject);
         }
 
         SECTION("permit nothing on pre-existing types in a downloaded Realm created as a non-partial Realm") {
@@ -215,7 +215,7 @@ TEST_CASE("Object-level Permissions") {
             // should have no objects as we don't have read permission
             CHECK(r->read_group().get_table("class_object")->size() == 0);
 
-            CHECK(r->get_privileges() == ComputedPrivileges::All);
+            CHECK(r->get_privileges() == ComputedPrivileges::AllRealm);
             CHECK(r->get_privileges("object") == ComputedPrivileges::None);
         }
     }


### PR DESCRIPTION
PermissionsCache can return values with unused bits set. This is normally harmless, but it has confusing results when the bitmask is dumped into a Swift OptionSet.