### PR TITLE
Make it difficult to create permission Users not in the "everyone" role

### DIFF
--- a/src/object.cpp
+++ b/src/object.cpp
@@ -91,3 +91,20 @@ Property const& Object::property_for_name(StringData prop_name) const
     }
     return *prop;
 }
+
+#if REALM_ENABLE_SYNC
+void Object::ensure_user_in_everyone_role()
+{
+    auto role_table = m_realm->read_group().get_table("class___Role");
+    if (!role_table)
+        return;
+    size_t ndx = role_table->find_first_string(role_table->get_column_index("name"), "everyone");
+    if (ndx == npos)
+        return;
+    auto users = role_table->get_linklist(role_table->get_column_index("members"), ndx);
+    if (users->find(m_row.get_index()) != not_found)
+        return;
+
+    users->add(m_row.get_index());
+}
+#endif

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -53,6 +53,8 @@ public:
 
     NotificationToken add_notification_callback(CollectionChangeCallback callback) &;
 
+    void ensure_user_in_everyone_role();
+
     // The following functions require an accessor context which converts from
     // the binding's native data types to the core data types. See CppContext
     // for a reference implementation of such a context.

--- a/src/object_accessor.hpp
+++ b/src/object_accessor.hpp
@@ -280,6 +280,10 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
         if (v)
             object.set_property_value_impl(ctx, prop, *v, try_update, is_default);
     }
+#if REALM_ENABLE_SYNC
+    if (realm->is_partial() && object_schema.name == "__User")
+        object.ensure_user_in_everyone_role();
+#endif
     return object;
 }
 


### PR DESCRIPTION
Special-casing a single type like this is pretty gross, but doing it at higher layers wasn't really any better, and making it easy to accidentally have users that aren't a member of "everyone" is a pretty big footgun.