### PR TITLE
Fix crashes when a Realm is closed from within a notification callback

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -878,6 +878,8 @@ void RealmCoordinator::process_available_async(Realm& realm)
 
     bool in_read = realm.is_in_read_transaction();
     auto& sg = Realm::Internal::get_shared_group(realm);
+    if (!sg) // i.e. the Realm was closed in a callback above
+        return;
     auto version = sg->get_version_of_current_transaction();
     auto package = [&](auto& notifier) {
         return !(notifier->has_run() && (!in_read || notifier->version() == version) && notifier->package_for_delivery());

--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -779,18 +779,18 @@ void advance_with_notifications(BindingContext* context, const std::unique_ptr<S
         auto new_version = sg->get_version_of_current_transaction();
         if (context && old_version != new_version)
             context->did_change({}, {});
-        // did_change() could close the Realm. Just return if it does.
-        if (!sg)
+        if (!sg) // did_change() could close the Realm. Just return if it does.
             return;
-
         if (context)
             context->will_send_notifications();
+        if (!sg) // will_send_notifications() could close the Realm. Just return if it does.
+            return;
         // did_change() can change the read version, and if it does we can't
         // deliver notifiers
         if (new_version == sg->get_version_of_current_transaction())
             notifiers.deliver(*sg);
         notifiers.after_advance();
-        if (context)
+        if (sg && context)
             context->did_send_notifications();
         return;
     }


### PR DESCRIPTION
#634 added some more places where Realms can be closed while we're in the middle of doing things and need to exit early if so.