### PR TITLE
Improve error reporting when the server reverts schema changes

### DIFF
--- a/src/impl/transact_log_handler.cpp
+++ b/src/impl/transact_log_handler.cpp
@@ -275,7 +275,7 @@ class TransactLogValidationMixin {
     REALM_NOINLINE
     void schema_error()
     {
-        throw std::logic_error("Schema mismatch detected: another process has modified the Realm file's schema in an incompatible way");
+        throw _impl::UnsupportedSchemaChange();
     }
 
 protected:
@@ -810,6 +810,11 @@ void advance_with_notifications(BindingContext* context, const std::unique_ptr<S
 namespace realm {
 namespace _impl {
 
+UnsupportedSchemaChange::UnsupportedSchemaChange()
+: std::logic_error("Schema mismatch detected: another process has modified the Realm file's schema in an incompatible way")
+{
+}
+
 namespace transaction {
 void advance(SharedGroup& sg, BindingContext*, VersionID version)
 {
@@ -863,7 +868,6 @@ void advance(SharedGroup& sg, TransactionChangeInfo& info, VersionID version)
     else {
         LangBindHelper::advance_read(sg, TransactLogObserver(info), version);
     }
-
 }
 
 } // namespace transaction

--- a/src/impl/transact_log_handler.hpp
+++ b/src/impl/transact_log_handler.hpp
@@ -20,9 +20,10 @@
 #define REALM_TRANSACT_LOG_HANDLER_HPP
 
 #include <cstdint>
-#include <realm/version_id.hpp>
-
+#include <stdexcept>
 #include <memory>
+
+#include <realm/version_id.hpp>
 
 namespace realm {
 class BindingContext;
@@ -31,6 +32,10 @@ class SharedGroup;
 namespace _impl {
 class NotifierPackage;
 struct TransactionChangeInfo;
+
+struct UnsupportedSchemaChange : std::logic_error {
+    UnsupportedSchemaChange();
+};
 
 namespace transaction {
 // Advance the read transaction version, with change notifications sent to delegate

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -166,6 +166,10 @@ struct SchemaMismatchException : public std::logic_error {
 struct InvalidSchemaChangeException : public std::logic_error {
     InvalidSchemaChangeException(std::vector<ObjectSchemaValidationException> const& errors);
 };
+
+struct InvalidExternalSchemaChangeException : public std::logic_error {
+    InvalidExternalSchemaChangeException(std::vector<ObjectSchemaValidationException> const& errors);
+};
 } // namespace realm
 
 #endif /* defined(REALM_OBJECT_STORE_HPP) */

--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -196,7 +196,7 @@ void Schema::zip_matching(T&& a, U&& b, Func&& func)
 
 }
 
-std::vector<SchemaChange> Schema::compare(Schema const& target_schema) const
+std::vector<SchemaChange> Schema::compare(Schema const& target_schema, bool include_table_removals) const
 {
     std::vector<SchemaChange> changes;
 
@@ -204,6 +204,9 @@ std::vector<SchemaChange> Schema::compare(Schema const& target_schema) const
     zip_matching(target_schema, *this, [&](const ObjectSchema* target, const ObjectSchema* existing) {
         if (target && !existing) {
             changes.emplace_back(schema_change::AddTable{target});
+        }
+        else if (include_table_removals && existing && !target) {
+            changes.emplace_back(schema_change::RemoveTable{existing});
         }
     });
 
@@ -256,6 +259,7 @@ bool operator==(SchemaChange const& lft, SchemaChange const& rgt)
         REALM_SC_COMPARE(AddProperty, v.object, v.property)
         REALM_SC_COMPARE(AddInitialProperties, v.object)
         REALM_SC_COMPARE(AddTable, v.object)
+        REALM_SC_COMPARE(RemoveTable, v.object)
         REALM_SC_COMPARE(ChangePrimaryKey, v.object, v.property)
         REALM_SC_COMPARE(ChangePropertyType, v.object, v.old_property, v.new_property)
         REALM_SC_COMPARE(MakePropertyNullable, v.object, v.property)

--- a/src/schema.hpp
+++ b/src/schema.hpp
@@ -58,7 +58,7 @@ public:
     void validate() const;
 
     // Get the changes which must be applied to this schema to produce the passed-in schema
-    std::vector<SchemaChange> compare(Schema const&) const;
+    std::vector<SchemaChange> compare(Schema const&, bool include_removals=false) const;
 
     void copy_table_columns_from(Schema const&);
 
@@ -79,6 +79,10 @@ private:
 
 namespace schema_change {
 struct AddTable {
+    const ObjectSchema* object;
+};
+
+struct RemoveTable {
     const ObjectSchema* object;
 };
 
@@ -130,6 +134,7 @@ struct ChangePrimaryKey {
 
 #define REALM_FOR_EACH_SCHEMA_CHANGE_TYPE(macro) \
     macro(AddTable) \
+    macro(RemoveTable) \
     macro(AddInitialProperties) \
     macro(AddProperty) \
     macro(RemoveProperty) \

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -415,6 +415,7 @@ private:
 
     void add_schema_change_handler();
     void cache_new_schema();
+    void translate_schema_error();
     void notify_schema_changed();
 
     bool init_permission_cache();

--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -56,6 +56,7 @@ struct SchemaChangePrinter {
     REALM_SC_PRINT(AddIndex, v.object, v.property)
     REALM_SC_PRINT(AddProperty, v.object, v.property)
     REALM_SC_PRINT(AddTable, v.object)
+    REALM_SC_PRINT(RemoveTable, v.object)
     REALM_SC_PRINT(AddInitialProperties, v.object)
     REALM_SC_PRINT(ChangePrimaryKey, v.object, v.property)
     REALM_SC_PRINT(ChangePropertyType, v.object, v.old_property, v.new_property)


### PR DESCRIPTION
Add in a description of what the incompatible schema changes were along with a note that this is probably happening due to a lack of permissions so that users will hopefully have some idea of what they need to do to resolve the problem.