### PR TITLE
Make sure to refetch the schema in case the matches property is missing

### DIFF
--- a/src/sync/partial_sync.hpp
+++ b/src/sync/partial_sync.hpp
@@ -62,7 +62,7 @@ private:
 
     void error_occurred(std::exception_ptr);
 
-    ObjectSchema m_object_schema;
+    mutable ObjectSchema m_object_schema;
 
     mutable Results m_result_sets;
 


### PR DESCRIPTION
In the .NET implementation, we hit a case where we try to get the subscription results and an `InvalidPropertyException` is thrown because `m_object_schema->property_for_name` returns `null`. I'm not sure how the other SDKs get around this issue, but browsing the code, it seems like the object schema is locked to the point in time the subscription is created and if at that point the matches property isn't already present, `results()` will always throw.