### PR TITLE
Disable change notifications for internal transient realms

### DIFF
--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -961,6 +961,7 @@ T Realm::resolve_thread_safe_reference(ThreadSafeReference<T> reference)
         if (reference_version < current_version) {
             // Duplicate config for uncached Realm so we don't advance the user's Realm
             Realm::Config config = m_coordinator->get_config();
+            config.automatic_change_notifications = false;
             config.cache = false;
             config.schema = util::none;
             SharedRealm temporary_realm = m_coordinator->get_realm(config);

--- a/src/sync/impl/sync_metadata.cpp
+++ b/src/sync/impl/sync_metadata.cpp
@@ -87,6 +87,7 @@ SyncMetadataManager::SyncMetadataManager(std::string path,
     constexpr uint64_t SCHEMA_VERSION = 2;
 
     Realm::Config config;
+    config.automatic_change_notifications = false;
     config.path = path;
     config.schema = make_schema();
     config.schema_version = SCHEMA_VERSION;

--- a/src/sync/impl/sync_metadata.cpp
+++ b/src/sync/impl/sync_metadata.cpp
@@ -87,7 +87,6 @@ SyncMetadataManager::SyncMetadataManager(std::string path,
     constexpr uint64_t SCHEMA_VERSION = 2;
 
     Realm::Config config;
-    config.automatic_change_notifications = false;
     config.path = path;
     config.schema = make_schema();
     config.schema_version = SCHEMA_VERSION;
@@ -158,6 +157,23 @@ SyncMetadataManager::SyncMetadataManager(std::string path,
     };
 
     m_metadata_config = std::move(config);
+
+    m_client_uuid = [&]() -> std::string {
+        TableRef table = ObjectStore::table_for_object_type(realm->read_group(), c_sync_clientMetadata);
+        if (table->is_empty()) {
+            realm->begin_transaction();
+            if (table->is_empty()) {
+                size_t idx = table->add_empty_row();
+                REALM_ASSERT_DEBUG(idx == 0);
+                auto uuid = uuid_string();
+                table->set_string(m_client_schema.idx_uuid, idx, uuid);
+                realm->commit_transaction();
+                return uuid;
+            }
+            realm->cancel_transaction();
+        }
+        return table->get_string(m_client_schema.idx_uuid, 0);
+    }();
 }
 
 SyncUserMetadataResults SyncMetadataManager::all_unmarked_users() const
@@ -308,26 +324,6 @@ util::Optional<SyncFileActionMetadata> SyncMetadataManager::get_file_action_meta
         return none;
 
     return SyncFileActionMetadata(std::move(schema), std::move(realm), table->get(row_idx));
-}
-
-std::string SyncMetadataManager::client_uuid() const
-{
-    auto realm = Realm::get_shared_realm(m_metadata_config);
-    TableRef table = ObjectStore::table_for_object_type(realm->read_group(), c_sync_clientMetadata);
-    if (table->is_empty()) {
-        realm->begin_transaction();
-        if (table->is_empty()) {
-            size_t idx = table->add_empty_row();
-            REALM_ASSERT_DEBUG(idx == 0);
-            auto uuid = uuid_string();
-            table->set_string(m_client_schema.idx_uuid, idx, uuid);
-            realm->commit_transaction();
-            return uuid;
-        }
-        realm->cancel_transaction();
-    }
-
-    return table->get_string(m_client_schema.idx_uuid, 0);
 }
 
 // MARK: - Sync user metadata

--- a/src/sync/impl/sync_metadata.hpp
+++ b/src/sync/impl/sync_metadata.hpp
@@ -204,8 +204,8 @@ public:
                                                      SyncFileActionMetadata::Action action,
                                                      util::Optional<std::string> new_name=none) const;
 
-    // Get the unique identifier of this client, generating one if it does not already exist.
-    std::string client_uuid() const;
+    // Get the unique identifier of this client.
+    const std::string& client_uuid() const { return m_client_uuid; }
 
     /// Construct the metadata manager.
     ///
@@ -222,6 +222,7 @@ private:
     SyncUserMetadata::Schema m_user_schema;
     SyncFileActionMetadata::Schema m_file_action_schema;
     SyncClientMetadata::Schema m_client_schema;
+    std::string m_client_uuid;
 };
 
 }


### PR DESCRIPTION
A customer using partial sync and thread-safe references with .NET on Android reported a deadlock in a peculiar scenario.

Basically he had a partial realm where he was writing objects that didn't match any of the subscriptions and so the server was deleting them from the partial realm.

On Linux (and Android) this causes a lot of churn in `ExternalCommitHelper` because of the constant opening and closing of realms due to `GetInstance` and `ResolveReference` calls coupled with the sync client integrating frequent changesets. This apparently causes `ExternalCommitHelper::DaemonThread::m_mutex` to deadlock.

The solution is to disable automatic change notifications for realms that don't need them so that `ExternalCommitHelper` instances don't get created needlessly.

The .NET reproduction follows.

```csharp
public class Person : RealmObject
{
    public string Name { get; set; }

    [Backlink(nameof(Dog.Owner))]
    public IQueryable<Dog> Dogs { get; }
}

public class Dog : RealmObject
{
    public string Name { get; set; }

    public Person Owner { get; set; }
}

async Task Repro()
{
    var config = new SyncConfiguration(user, serverUri)
    {
        IsPartial = true,
        ObjectClasses = new[] { typeof(Person), typeof(Dog) }
    };

    var person = new Person { Name = "Пешо" };
    var realm = Realm.GetInstance(config);
    var query = await realm.SubscribeToObjectsAsync<Person>("Name == 'Пешо'");

    realm.Write(() => realm.Add(person));

    var thread = new AsyncContextThread();
    await Enumerable.Range(0, 100).Select(i =>
    {
        var @ref = ThreadSafeReference.Create(person);
        return thread.Factory.Run(() =>
        {
            using (var realm = Realm.GetInstance(config))
            {
                var @object = realm.ResolveReference(@ref);
                realm.Write(() =>
                {
                    realm.Add(new Dog { Name = $"Шаро №{i + 1}", Owner = @object });
                });
            }
        });
    }).WhenAll();
}
```