### PR TITLE
Don't call session completion callbacks while holding the state mutex

### DIFF
--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -364,13 +364,14 @@ struct sync_session_states::Dying : public SyncSession::State {
 struct sync_session_states::Inactive : public SyncSession::State {
     void enter_state(std::unique_lock<std::mutex>& lock, SyncSession& session) const override
     {
-        // Inform any queued-up completion handlers that they were cancelled.
-        for (auto& package : session.m_completion_wait_packages) {
-            package.callback(util::error::operation_aborted);
-        }
+        auto completion_wait_packages = std::move(session.m_completion_wait_packages);
         session.m_completion_wait_packages.clear();
         session.m_session = nullptr;
-        session.unregister(lock);
+        session.unregister(lock); // releases lock
+
+        // Inform any queued-up completion handlers that they were cancelled.
+        for (auto& package : completion_wait_packages)
+            package.callback(util::error::operation_aborted);
     }
 
     bool revive_if_needed(std::unique_lock<std::mutex>& lock, SyncSession& session) const override
@@ -519,7 +520,7 @@ void SyncSession::handle_error(SyncError error)
                 {
                     std::unique_lock<std::mutex> lock(m_state_mutex);
                     user_to_invalidate = user();
-                    cancel_pending_waits();
+                    cancel_pending_waits(lock);
                 }
                 if (user_to_invalidate)
                     user_to_invalidate->invalidate();
@@ -584,7 +585,7 @@ void SyncSession::handle_error(SyncError error)
         }
         case NextStateAfterError::error: {
             std::unique_lock<std::mutex> lock(m_state_mutex);
-            cancel_pending_waits();
+            cancel_pending_waits(lock);
             break;
         }
     }
@@ -593,13 +594,15 @@ void SyncSession::handle_error(SyncError error)
     }
 }
 
-void SyncSession::cancel_pending_waits()
+void SyncSession::cancel_pending_waits(std::unique_lock<std::mutex>& lock)
 {
+    auto packages = std::move(m_completion_wait_packages);
+    lock.unlock();
+
     // Inform any queued-up completion handlers that they were cancelled.
-    for (auto& package : m_completion_wait_packages) {
+    for (auto& package : packages) {
         package.callback(util::error::operation_aborted);
     }
-    m_completion_wait_packages.clear();
 }
 
 void SyncSession::handle_progress_update(uint64_t downloaded, uint64_t downloadable,

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -291,7 +291,7 @@ private:
     SyncSession(_impl::SyncClient&, std::string realm_path, SyncConfig);
 
     void handle_error(SyncError);
-    void cancel_pending_waits();
+    void cancel_pending_waits(std::unique_lock<std::mutex>&);
     enum class ShouldBackup { yes, no };
     void update_error_and_mark_file_for_deletion(SyncError&, ShouldBackup);
     static std::string get_recovery_file_path();


### PR DESCRIPTION
Doing so produces a deadlock if the callbacks attempt to interact with the session, or release the last strong pointer to the session.