### PR TITLE
Update catch to 1.12

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "external/catch"]
 	path = external/catch
-	url = https://github.com/philsquared/Catch
+	url = https://github.com/catchorg/Catch2


### PR DESCRIPTION
No particularly interesting changes between 1.09 and 1.12, but they moved the repo URL so it'd be good to point it at the correct place.