### PR TITLE
Skip some pointless background work for LinkingObjects notifiers

### DIFF
--- a/src/impl/results_notifier.cpp
+++ b/src/impl/results_notifier.cpp
@@ -117,7 +117,7 @@ bool ResultsNotifier::need_to_run()
 void ResultsNotifier::calculate_changes()
 {
     size_t table_ndx = m_query->get_table()->get_index_in_group();
-    if (has_run()) {
+    if (has_run() && have_callbacks()) {
         CollectionChangeBuilder* changes = nullptr;
         if (table_ndx == npos)
             changes = &m_changes;

--- a/src/results.cpp
+++ b/src/results.cpp
@@ -266,10 +266,8 @@ void Results::evaluate_query_if_needed(bool wants_notifications)
             m_mode = Mode::TableView;
             REALM_FALLTHROUGH;
         case Mode::TableView:
-            if (wants_notifications && !m_notifier && !m_realm->is_in_transaction() && m_realm->can_deliver_notifications()) {
-                m_notifier = std::make_shared<_impl::ResultsNotifier>(*this);
-                _impl::RealmCoordinator::register_notifier(m_notifier);
-            }
+            if (wants_notifications)
+                prepare_async(ForCallback{false});
             m_has_used_table_view = true;
             m_table_view.sync_if_needed();
             break;
@@ -691,19 +689,34 @@ Results Results::snapshot() &&
     REALM_COMPILER_HINT_UNREACHABLE();
 }
 
-void Results::prepare_async()
+void Results::prepare_async(ForCallback force)
 {
     if (m_notifier) {
         return;
     }
     if (m_realm->config().immutable()) {
-        throw InvalidTransactionException("Cannot create asynchronous query for immutable Realms");
+        if (force)
+            throw InvalidTransactionException("Cannot create asynchronous query for immutable Realms");
+        return;
     }
     if (m_realm->is_in_transaction()) {
-        throw InvalidTransactionException("Cannot create asynchronous query while in a write transaction");
+        if (force)
+            throw InvalidTransactionException("Cannot create asynchronous query while in a write transaction");
+        return;
     }
     if (m_update_policy == UpdatePolicy::Never) {
-        throw std::logic_error("Cannot create asynchronous query for snapshotted Results.");
+        if (force)
+            throw std::logic_error("Cannot create asynchronous query for snapshotted Results.");
+        return;
+    }
+    if (!force) {
+        // Don't do implicit background updates if we can't actually deliver them
+        if (!m_realm->can_deliver_notifications())
+            return;
+        // Don't do implicit background updates if there isn't actually anything
+        // that needs to be run.
+        if (!m_query.get_table() && m_descriptor_ordering.is_empty())
+            return;
     }
 
     m_wants_background_updates = true;
@@ -713,7 +726,7 @@ void Results::prepare_async()
 
 NotificationToken Results::add_notification_callback(CollectionChangeCallback cb) &
 {
-    prepare_async();
+    prepare_async(ForCallback{true});
     return {m_notifier, m_notifier->add_callback(std::move(cb))};
 }
 

--- a/src/results.hpp
+++ b/src/results.hpp
@@ -242,7 +242,8 @@ private:
     void validate_read() const;
     void validate_write() const;
 
-    void prepare_async();
+    using ForCallback = util::TaggedBool<class ForCallback>;
+    void prepare_async(ForCallback);
 
     template<typename T>
     util::Optional<T> try_get(size_t);


### PR DESCRIPTION
See https://github.com/realm/realm-cocoa/issues/5816. This fixes the problem in two ways: it skips implicitly creating a notifier at all for LinkingObjects, and skips calculating the change sets for Results which do need a background notifier but don't have any callbacks.

No new tests as this should have no functional impact other than being faster. The obj-c tests do attempt to verify that the implicit notifier is created in the places where we actually want it (and those tests still pass).