### PR TITLE
Speed up compact

### DIFF
--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -727,11 +727,11 @@ bool Realm::compact()
         throw InvalidTransactionException("Can't compact a Realm within a write transaction");
     }
 
-    Group& group = read_group();
-    for (auto &object_schema : m_schema) {
-        ObjectStore::table_for_object_type(group, object_schema.name)->optimize();
+    verify_open();
+    // FIXME: when enum columns are ready, optimise all tables in a write transaction
+    if (m_group) {
+        m_shared_group->end_read();
     }
-    m_shared_group->end_read();
     m_group = nullptr;
 
     return m_shared_group->compact();


### PR DESCRIPTION
Since we do the optimisation in a read transaction and never commit, it's wasted cpu cycles. LOL.
We were going to put this in a write transaction (https://github.com/realm/realm-object-store/pull/501 ) but we never got the go ahead because we kept finding problems in the enum columns by fuzz testing.  I think we decided to just enable them in core 6 so that they didn't have to be upgraded from 5->6.