### PR TITLE
Implementing a few missing operations on Realm

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -576,6 +576,21 @@ void RealmCoordinator::commit_write(Realm& realm)
     }
 }
 
+void RealmCoordinator::enable_wait_for_change()
+{
+    m_db->enable_wait_for_change();
+}
+
+bool RealmCoordinator::wait_for_change(std::shared_ptr<Transaction> tr)
+{
+    return m_db->wait_for_change(tr);
+}
+
+void RealmCoordinator::wait_for_change_release()
+{
+    m_db->wait_for_change_release();
+}
+
 void RealmCoordinator::pin_version(VersionID versionid)
 {
     REALM_ASSERT_DEBUG(!m_notifier_mutex.try_lock());

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -142,6 +142,10 @@ public:
     // other Realm instances for that path, including in other processes
     void commit_write(Realm& realm);
 
+    void enable_wait_for_change();
+    bool wait_for_change(std::shared_ptr<Transaction> tr);
+    void wait_for_change_release();
+
     void close();
     bool compact();
 

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -499,6 +499,30 @@ bool Realm::is_in_transaction() const noexcept
         && m_group && transaction().get_transact_stage() == DB::transact_Writing;
 }
 
+util::Optional<VersionID> Realm::current_transaction_version() const
+{
+    util::Optional<VersionID> ret;
+    if (m_group) {
+        ret = static_cast<Transaction&>(*m_group).get_version_of_current_transaction();
+    }
+    return ret;
+}
+
+void Realm::enable_wait_for_change()
+{
+    m_coordinator->enable_wait_for_change();
+}
+
+bool Realm::wait_for_change()
+{
+    return m_group ? m_coordinator->wait_for_change(transaction_ref()) : false;
+}
+
+void Realm::wait_for_change_release()
+{
+    m_coordinator->wait_for_change_release();
+}
+
 void Realm::begin_transaction()
 {
     verify_thread();

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -278,6 +278,7 @@ public:
     // is not in a read transaction
     util::Optional<VersionID> current_transaction_version() const;
 
+    void enable_wait_for_change();
     bool wait_for_change();
     void wait_for_change_release();
 

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -435,9 +435,12 @@ TEST_CASE("SharedRealm: notifications") {
         r2->commit_transaction();
         REQUIRE(realm->refresh());
 
+        auto ver = realm->current_transaction_version();
         realm->m_binding_context.reset();
         // Should advance to the version created in the previous did_change()
         REQUIRE(realm->refresh());
+        auto new_ver = realm->current_transaction_version();
+        REQUIRE(*new_ver > *ver);
         // No more versions, so returns false
         REQUIRE_FALSE(realm->refresh());
     }


### PR DESCRIPTION
- current_transaction_version
- enable_wait_for_change
- wait_for_change
- wait_for_change_release

realm-java was asking for this.