### PR TITLE
Don't create the __user_info file

### DIFF
--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -206,7 +206,6 @@ constexpr const char SyncFileManager::c_utility_directory[];
 constexpr const char SyncFileManager::c_recovery_directory[];
 constexpr const char SyncFileManager::c_metadata_directory[];
 constexpr const char SyncFileManager::c_metadata_realm[];
-constexpr const char SyncFileManager::c_user_info_file[];
 
 std::string SyncFileManager::get_special_directory(std::string directory_name) const
 {
@@ -226,8 +225,7 @@ std::string SyncFileManager::get_base_sync_directory() const
     return sync_path;
 }
 
-std::string SyncFileManager::user_directory(const std::string& local_identity,
-                                            util::Optional<SyncUserIdentifier> user_info) const
+std::string SyncFileManager::user_directory(const std::string& local_identity) const
 {
     REALM_ASSERT(local_identity.length() > 0);
     std::string escaped = util::make_percent_encoded_string(local_identity);
@@ -237,18 +235,7 @@ std::string SyncFileManager::user_directory(const std::string& local_identity,
     auto user_path = file_path_by_appending_component(get_base_sync_directory(),
                                                       escaped,
                                                       util::FilePathType::Directory);
-    bool dir_created = util::try_make_dir(user_path);
-    if (dir_created && user_info) {
-        // Add a text file in the user directory containing the user identity, for backup purposes.
-        // Only do this the first time the directory is created.
-        auto info_path = util::file_path_by_appending_component(user_path, c_user_info_file);
-        std::ofstream info_file;
-        info_file.open(info_path.c_str());
-        if (info_file.is_open()) {
-            info_file << user_info->user_id << "\n" << user_info->auth_server_url << "\n";
-            info_file.close();
-        }
-    }
+    util::try_make_dir(user_path);
     return user_path;
 }
 
@@ -335,8 +322,7 @@ bool SyncFileManager::remove_realm(const std::string& local_identity, const std:
     return remove_realm(realm_path);
 }
 
-std::string SyncFileManager::path(const std::string& local_identity, const std::string& raw_realm_path,
-                                  util::Optional<SyncUserIdentifier> user_info) const
+std::string SyncFileManager::path(const std::string& local_identity, const std::string& raw_realm_path) const
 {
     REALM_ASSERT(local_identity.length() > 0);
     REALM_ASSERT(raw_realm_path.length() > 0);
@@ -344,8 +330,7 @@ std::string SyncFileManager::path(const std::string& local_identity, const std::
         throw std::invalid_argument("A user or Realm can't have an identifier reserved by the filesystem.");
 
     auto escaped = util::make_percent_encoded_string(raw_realm_path);
-    auto realm_path = util::file_path_by_appending_component(user_directory(local_identity, user_info), escaped);
-    return realm_path;
+    return util::file_path_by_appending_component(user_directory(local_identity), escaped);
 }
 
 std::string SyncFileManager::metadata_path() const

--- a/src/sync/impl/sync_file.hpp
+++ b/src/sync/impl/sync_file.hpp
@@ -63,8 +63,7 @@ public:
     SyncFileManager(std::string base_path) : m_base_path(std::move(base_path)) { }
 
     /// Return the user directory for a given user, creating it if it does not already exist.
-    std::string user_directory(const std::string& local_identity,
-                               util::Optional<SyncUserIdentifier> user_info=none) const;
+    std::string user_directory(const std::string& local_identity) const;
 
     /// Remove the user directory for a given user.
     void remove_user_directory(const std::string& local_identity) const;       // throws
@@ -75,8 +74,7 @@ public:
     bool try_rename_user_directory(const std::string& old_name, const std::string& new_name) const;
 
     /// Return the path for a given Realm, creating the user directory if it does not already exist.
-    std::string path(const std::string&, const std::string&,
-                     util::Optional<SyncUserIdentifier> user_info=none) const;
+    std::string path(const std::string&, const std::string&) const;
 
     /// Remove the Realm at a given path for a given user. Returns `true` if the remove operation fully succeeds.
     bool remove_realm(const std::string& local_identity, const std::string& raw_realm_path) const;
@@ -112,7 +110,6 @@ private:
     static constexpr const char c_recovery_directory[] = "io.realm.object-server-recovered-realms";
     static constexpr const char c_metadata_directory[] = "metadata";
     static constexpr const char c_metadata_realm[] = "sync_metadata.realm";
-    static constexpr const char c_user_info_file[] = "__user_info";
 
     std::string get_special_directory(std::string directory_name) const;
 

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -403,12 +403,7 @@ std::string SyncManager::path_for_realm(const SyncUser& user, const std::string&
 {
     std::lock_guard<std::mutex> lock(m_file_system_mutex);
     REALM_ASSERT(m_file_manager);
-    const auto& user_local_identity = user.local_identity();
-    util::Optional<SyncUserIdentifier> user_info;
-    if (user.token_type() == SyncUser::TokenType::Normal)
-        user_info = SyncUserIdentifier{ user.identity(), user.server_url() };
-
-    return m_file_manager->path(user_local_identity, raw_realm_url, std::move(user_info));
+    return m_file_manager->path(user.local_identity(), raw_realm_url);
 }
 
 std::string SyncManager::recovery_directory_path() const

--- a/tests/sync/file.cpp
+++ b/tests/sync/file.cpp
@@ -163,33 +163,6 @@ TEST_CASE("sync_file: SyncFileManager APIs", "[sync]") {
             }
         }
 
-        SECTION("getting a user directory with additional metadata") {
-            const std::string identity = "the-identity";
-            const std::string auth_url = "https://realm.example.org";
-            SyncUserIdentifier info_tuple{identity, auth_url};
-            auto actual = manager.user_directory(local_identity, info_tuple);
-            REQUIRE(actual == expected);
-            REQUIRE_DIR_EXISTS(expected);
-            // Check the backup file
-            auto user_info_path = actual + "/__user_info";
-            std::ifstream user_info;
-            user_info.open(user_info_path.c_str());
-            REQUIRE(user_info.is_open());
-            int ctr = 0;
-            for (std::string current_line; std::getline(user_info, current_line);) {
-                if (ctr == 0) {
-                    // First line is the user's ROS identity
-                    CHECK(current_line == identity);
-                } else if (ctr == 1) {
-                    // Second line is the user's auth server URL
-                    CHECK(current_line == auth_url);
-                }
-                ctr++;
-            }
-            user_info.close();
-            CHECK(ctr == 2);
-        }
-
         SECTION("deleting a user directory") {
             manager.user_directory(local_identity);
             REQUIRE_DIR_EXISTS(expected);


### PR DESCRIPTION
It's unclear what this file was intended to be used for (the comments just say "for backup purposes"), and I can't find any evidence that anything other than the test has ever actually read the file.

Fixes #680.