### PR TITLE
Enable notifications for limited query results

### DIFF
--- a/src/results.cpp
+++ b/src/results.cpp
@@ -731,8 +731,6 @@ void Results::prepare_async(ForCallback force)
 
 NotificationToken Results::add_notification_callback(CollectionChangeCallback cb) &
 {
-    if (m_descriptor_ordering.will_apply_limit())
-        throw UnimplementedOperationException("Change notifications for Results with a limit are not yet implemented");
     prepare_async(ForCallback{true});
     return {m_notifier, m_notifier->add_callback(std::move(cb))};
 }

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -2786,8 +2786,7 @@ TEST_CASE("results: limit", "[limit]") {
         table->set_int(0, i, (i + 2) % 4);
     }
     realm->commit_transaction();
-    Results r(realm, table->where());
-
+    Results r(realm, *table);
 
     SECTION("unsorted") {
         REQUIRE(r.limit(0).size() == 0);


### PR DESCRIPTION
It seems that notifications for limited query results "just work" so re-enabling them and adding a smoke test.