### PR TITLE
Initial implementation of diff-only update of objects

### DIFF
--- a/src/impl/object_accessor_impl.hpp
+++ b/src/impl/object_accessor_impl.hpp
@@ -123,7 +123,7 @@ public:
     // using the provided value. If `update` is true then upsert semantics
     // should be used for this.
     template<typename T>
-    T unbox(util::Any& v, bool /*create*/= false, bool /*update*/= false) const { return any_cast<T>(v); }
+    T unbox(util::Any& v, bool /*create*/= false, bool /*update*/= false, bool /*update_only_diff*/ = true) const { return any_cast<T>(v); }
 
     bool is_null(util::Any const& v) const noexcept { return !v.has_value(); }
     util::Any null_value() const noexcept { return {}; }
@@ -155,7 +155,7 @@ inline util::Any CppContext::box(RowExpr row) const
 }
 
 template<>
-inline StringData CppContext::unbox(util::Any& v, bool, bool) const
+inline StringData CppContext::unbox(util::Any& v, bool, bool, bool) const
 {
     if (!v.has_value())
         return StringData();
@@ -164,7 +164,7 @@ inline StringData CppContext::unbox(util::Any& v, bool, bool) const
 }
 
 template<>
-inline BinaryData CppContext::unbox(util::Any& v, bool, bool) const
+inline BinaryData CppContext::unbox(util::Any& v, bool, bool, bool) const
 {
     if (!v.has_value())
         return BinaryData();
@@ -173,7 +173,7 @@ inline BinaryData CppContext::unbox(util::Any& v, bool, bool) const
 }
 
 template<>
-inline RowExpr CppContext::unbox(util::Any& v, bool create, bool update) const
+inline RowExpr CppContext::unbox(util::Any& v, bool create, bool update, bool update_only_diff) const
 {
     if (auto object = any_cast<Object>(&v))
         return object->row();
@@ -183,35 +183,35 @@ inline RowExpr CppContext::unbox(util::Any& v, bool create, bool update) const
         return RowExpr();
 
     REALM_ASSERT(object_schema);
-    return Object::create(const_cast<CppContext&>(*this), realm, *object_schema, v, update).row();
+    return Object::create(const_cast<CppContext&>(*this), realm, *object_schema, v, update, update_only_diff).row();
 }
 
 template<>
-inline util::Optional<bool> CppContext::unbox(util::Any& v, bool, bool) const
+inline util::Optional<bool> CppContext::unbox(util::Any& v, bool, bool, bool) const
 {
     return v.has_value() ? util::make_optional(unbox<bool>(v)) : util::none;
 }
 
 template<>
-inline util::Optional<int64_t> CppContext::unbox(util::Any& v, bool, bool) const
+inline util::Optional<int64_t> CppContext::unbox(util::Any& v, bool, bool, bool) const
 {
     return v.has_value() ? util::make_optional(unbox<int64_t>(v)) : util::none;
 }
 
 template<>
-inline util::Optional<double> CppContext::unbox(util::Any& v, bool, bool) const
+inline util::Optional<double> CppContext::unbox(util::Any& v, bool, bool, bool) const
 {
     return v.has_value() ? util::make_optional(unbox<double>(v)) : util::none;
 }
 
 template<>
-inline util::Optional<float> CppContext::unbox(util::Any& v, bool, bool) const
+inline util::Optional<float> CppContext::unbox(util::Any& v, bool, bool, bool) const
 {
     return v.has_value() ? util::make_optional(unbox<float>(v)) : util::none;
 }
 
 template<>
-inline Mixed CppContext::unbox(util::Any&, bool, bool) const
+inline Mixed CppContext::unbox(util::Any&, bool, bool, bool) const
 {
     throw std::logic_error("'Any' type is unsupported");
 }

--- a/src/impl/object_accessor_impl.hpp
+++ b/src/impl/object_accessor_impl.hpp
@@ -123,7 +123,7 @@ public:
     // using the provided value. If `update` is true then upsert semantics
     // should be used for this.
     template<typename T>
-    T unbox(util::Any& v, bool /*create*/= false, bool /*update*/= false, bool /*update_only_diff*/ = true) const { return any_cast<T>(v); }
+    T unbox(util::Any& v, bool /*create*/= false, bool /*update*/= false, bool /*update_only_diff*/ = false) const { return any_cast<T>(v); }
 
     bool is_null(util::Any const& v) const noexcept { return !v.has_value(); }
     util::Any null_value() const noexcept { return {}; }

--- a/src/impl/object_accessor_impl.hpp
+++ b/src/impl/object_accessor_impl.hpp
@@ -122,8 +122,12 @@ public:
     // true then `unbox()` should create a new object in the context's Realm
     // using the provided value. If `update` is true then upsert semantics
     // should be used for this.
+    // If `update_only_diff` is true, only properties that are different from
+    // already existing properties should be updated. If `create` and `update_only_diff`
+    // is true, `current_row` may hold a reference to the object that should
+    // be compared against.
     template<typename T>
-    T unbox(util::Any& v, bool /*create*/= false, bool /*update*/= false, bool /*update_only_diff*/ = false) const { return any_cast<T>(v); }
+    T unbox(util::Any& v, bool /*create*/= false, bool /*update*/= false, bool /*update_only_diff*/ = false, size_t /*current_row*/ = realm::npos) const { return any_cast<T>(v); }
 
     bool is_null(util::Any const& v) const noexcept { return !v.has_value(); }
     util::Any null_value() const noexcept { return {}; }
@@ -155,7 +159,7 @@ inline util::Any CppContext::box(RowExpr row) const
 }
 
 template<>
-inline StringData CppContext::unbox(util::Any& v, bool, bool, bool) const
+inline StringData CppContext::unbox(util::Any& v, bool, bool, bool, size_t) const
 {
     if (!v.has_value())
         return StringData();
@@ -164,7 +168,7 @@ inline StringData CppContext::unbox(util::Any& v, bool, bool, bool) const
 }
 
 template<>
-inline BinaryData CppContext::unbox(util::Any& v, bool, bool, bool) const
+inline BinaryData CppContext::unbox(util::Any& v, bool, bool, bool, size_t) const
 {
     if (!v.has_value())
         return BinaryData();
@@ -173,7 +177,7 @@ inline BinaryData CppContext::unbox(util::Any& v, bool, bool, bool) const
 }
 
 template<>
-inline RowExpr CppContext::unbox(util::Any& v, bool create, bool update, bool update_only_diff) const
+inline RowExpr CppContext::unbox(util::Any& v, bool create, bool update, bool update_only_diff, size_t current_row) const
 {
     if (auto object = any_cast<Object>(&v))
         return object->row();
@@ -183,35 +187,35 @@ inline RowExpr CppContext::unbox(util::Any& v, bool create, bool update, bool up
         return RowExpr();
 
     REALM_ASSERT(object_schema);
-    return Object::create(const_cast<CppContext&>(*this), realm, *object_schema, v, update, update_only_diff).row();
+    return Object::create(const_cast<CppContext&>(*this), realm, *object_schema, v, update, update_only_diff, current_row).row();
 }
 
 template<>
-inline util::Optional<bool> CppContext::unbox(util::Any& v, bool, bool, bool) const
+inline util::Optional<bool> CppContext::unbox(util::Any& v, bool, bool, bool, size_t) const
 {
     return v.has_value() ? util::make_optional(unbox<bool>(v)) : util::none;
 }
 
 template<>
-inline util::Optional<int64_t> CppContext::unbox(util::Any& v, bool, bool, bool) const
+inline util::Optional<int64_t> CppContext::unbox(util::Any& v, bool, bool, bool, size_t) const
 {
     return v.has_value() ? util::make_optional(unbox<int64_t>(v)) : util::none;
 }
 
 template<>
-inline util::Optional<double> CppContext::unbox(util::Any& v, bool, bool, bool) const
+inline util::Optional<double> CppContext::unbox(util::Any& v, bool, bool, bool, size_t) const
 {
     return v.has_value() ? util::make_optional(unbox<double>(v)) : util::none;
 }
 
 template<>
-inline util::Optional<float> CppContext::unbox(util::Any& v, bool, bool, bool) const
+inline util::Optional<float> CppContext::unbox(util::Any& v, bool, bool, bool, size_t) const
 {
     return v.has_value() ? util::make_optional(unbox<float>(v)) : util::none;
 }
 
 template<>
-inline Mixed CppContext::unbox(util::Any&, bool, bool, bool) const
+inline Mixed CppContext::unbox(util::Any&, bool, bool, bool, size_t) const
 {
     throw std::logic_error("'Any' type is unsupported");
 }

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -26,6 +26,7 @@
 #include <realm/link_view_fwd.hpp>
 #include <realm/row.hpp>
 #include <realm/table_ref.hpp>
+#include <realm/util/any.hpp>
 
 #include <functional>
 #include <memory>
@@ -129,10 +130,12 @@ public:
     void insert(Context&, size_t list_ndx, T&& value, bool update=false);
     template<typename T, typename Context>
     void set(Context&, size_t row_ndx, T&& value, bool update=false);
+    template<typename T, typename Context>
+    void set_if_different(Context&, size_t row_ndx, T&& value, bool update=false);
 
     // Replace the values in this list with the values from an enumerable object
     template<typename T, typename Context>
-    void assign(Context&, T&& value, bool update=false);
+    void assign(Context&, T&& value, bool update=false, bool update_only_diff = false);
 
     // The List object has been invalidated (due to the Realm being invalidated,
     // or the containing object being deleted)
@@ -204,16 +207,57 @@ void List::set(Context& ctx, size_t row_ndx, T&& value, bool update)
     dispatch([&](auto t) { this->set(row_ndx, ctx.template unbox<std::decay_t<decltype(*t)>>(value, true, update)); });
 }
 
+template <class T>
+inline bool help_compare_values(const T& v1, const T& v2)
+{
+    return v1 != v2;
+}
+
+template <>
+inline bool help_compare_values(const RowExpr& v1, const RowExpr& v2)
+{
+    return v1.get_table() != v2.get_table() || v1.get_index() != v2.get_index();
+}
+
+
 template<typename T, typename Context>
-void List::assign(Context& ctx, T&& values, bool update)
+void List::set_if_different(Context& ctx, size_t row_ndx, T&& value, bool update)
+{
+    dispatch([&](auto t) {
+        using U = std::decay_t<decltype(*t)>;
+        auto old_value =  this->get<U>(row_ndx);
+        auto new_value = ctx.template unbox<U>(value, true, update, true);
+        if (help_compare_values(old_value, new_value))
+            this->set(row_ndx, new_value);
+    });
+}
+
+
+template<typename T, typename Context>
+void List::assign(Context& ctx, T&& values, bool update, bool update_only_diff)
 {
     if (ctx.is_same_list(*this, values))
         return;
 
-    remove_all();
-    if (ctx.is_null(values))
+    if (ctx.is_null(values)) {
+        remove_all();
         return;
+    }
 
+    if (update_only_diff) {
+        size_t sz = util::any_cast<std::vector<util::Any>&>(values).size();
+        // If size is the same, we can compare element by element
+        if (size() == sz) {
+            size_t index = 0;
+            ctx.enumerate_list(values, [&](auto&& element) {
+                this->set_if_different(ctx, index, element, update);
+                index++;
+            });
+            return;
+        }
+    }
+
+    remove_all();
     ctx.enumerate_list(values, [&](auto&& element) {
         this->add(ctx, element, update);
     });

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -245,22 +245,28 @@ void List::assign(Context& ctx, T&& values, bool update, bool update_only_diff)
     }
 
     if (update_only_diff) {
-        size_t sz = util::any_cast<std::vector<util::Any>&>(values).size();
-        // If size is the same, we can compare element by element
-        if (size() == sz) {
-            size_t index = 0;
-            ctx.enumerate_list(values, [&](auto&& element) {
+        size_t sz = size();
+        size_t index = 0;
+        ctx.enumerate_list(values, [&](auto&& element) {
+            if (index < sz) {
                 this->set_if_different(ctx, index, element, update);
-                index++;
-            });
-            return;
+            }
+            else {
+                this->add(ctx, element, update);
+            }
+            index++;
+        });
+        while (index < sz) {
+            remove(index);
+            sz--;
         }
     }
-
-    remove_all();
-    ctx.enumerate_list(values, [&](auto&& element) {
-        this->add(ctx, element, update);
-    });
+    else {
+        remove_all();
+        ctx.enumerate_list(values, [&](auto&& element) {
+            this->add(ctx, element, update);
+        });
+    }
 }
 } // namespace realm
 

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -130,8 +130,6 @@ public:
     void insert(Context&, size_t list_ndx, T&& value, bool update=false);
     template<typename T, typename Context>
     void set(Context&, size_t row_ndx, T&& value, bool update=false);
-    template<typename T, typename Context>
-    void set_if_different(Context&, size_t row_ndx, T&& value, bool update=false);
 
     // Replace the values in this list with the values from an enumerable object
     template<typename T, typename Context>
@@ -165,6 +163,9 @@ private:
 
     template<typename Fn>
     auto dispatch(Fn&&) const;
+
+    template<typename T, typename Context>
+    void set_if_different(Context&, size_t row_ndx, T&& value, bool update=false);
 
     size_t to_table_ndx(size_t row) const noexcept;
 
@@ -207,18 +208,30 @@ void List::set(Context& ctx, size_t row_ndx, T&& value, bool update)
     dispatch([&](auto t) { this->set(row_ndx, ctx.template unbox<std::decay_t<decltype(*t)>>(value, true, update)); });
 }
 
+namespace _impl {
+template <class T>
+inline size_t help_get_current_row(const T&)
+{
+    return size_t(-1);
+}
+
+template <>
+inline size_t help_get_current_row(const RowExpr& v)
+{
+    return v.get_index();
+}
+
 template <class T>
 inline bool help_compare_values(const T& v1, const T& v2)
 {
     return v1 != v2;
 }
-
 template <>
 inline bool help_compare_values(const RowExpr& v1, const RowExpr& v2)
 {
     return v1.get_table() != v2.get_table() || v1.get_index() != v2.get_index();
 }
-
+}
 
 template<typename T, typename Context>
 void List::set_if_different(Context& ctx, size_t row_ndx, T&& value, bool update)
@@ -226,8 +239,8 @@ void List::set_if_different(Context& ctx, size_t row_ndx, T&& value, bool update
     dispatch([&](auto t) {
         using U = std::decay_t<decltype(*t)>;
         auto old_value =  this->get<U>(row_ndx);
-        auto new_value = ctx.template unbox<U>(value, true, update, true);
-        if (help_compare_values(old_value, new_value))
+        auto new_value = ctx.template unbox<U>(value, true, update, true, _impl::help_get_current_row(old_value));
+        if (_impl::help_compare_values(old_value, new_value))
             this->set(row_ndx, new_value);
     });
 }

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -74,12 +74,12 @@ public:
     template<typename ValueType, typename ContextType>
     static Object create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
                          const ObjectSchema &object_schema, ValueType value,
-                         bool try_update = false, Row* = nullptr);
+                         bool try_update = false, bool update_only_diff = false, Row* = nullptr);
 
     template<typename ValueType, typename ContextType>
     static Object create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
                          StringData object_type, ValueType value,
-                         bool try_update = false, Row* = nullptr);
+                         bool try_update = false, bool update_only_diff = false, Row* = nullptr);
 
     template<typename ValueType, typename ContextType>
     static Object get_for_primary_key(ContextType& ctx,
@@ -102,7 +102,7 @@ private:
 
     template<typename ValueType, typename ContextType>
     void set_property_value_impl(ContextType& ctx, const Property &property,
-                                 ValueType value, bool try_update, bool is_default=false);
+                                 ValueType value, bool try_update, bool update_only_diff, bool is_default);
     template<typename ValueType, typename ContextType>
     ValueType get_property_value_impl(ContextType& ctx, const Property &property);
 

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -74,12 +74,14 @@ public:
     template<typename ValueType, typename ContextType>
     static Object create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
                          const ObjectSchema &object_schema, ValueType value,
-                         bool try_update = false, bool update_only_diff = false, Row* = nullptr);
+                         bool try_update = false, bool update_only_diff = false,
+                         size_t current_row = size_t(-1), Row* = nullptr);
 
     template<typename ValueType, typename ContextType>
     static Object create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
                          StringData object_type, ValueType value,
-                         bool try_update = false, bool update_only_diff = false, Row* = nullptr);
+                         bool try_update = false, bool update_only_diff = false,
+                         size_t current_row = size_t(-1), Row* = nullptr);
 
     template<typename ValueType, typename ContextType>
     static Object get_for_primary_key(ContextType& ctx,

--- a/src/object_accessor.hpp
+++ b/src/object_accessor.hpp
@@ -102,7 +102,7 @@ void Object::set_property_value_impl(ContextType& ctx, const Property &property,
             throw ReadOnlyPropertyException(m_object_schema->name, property.name);
 
         ContextType child_ctx(ctx, property);
-        List list(m_realm, *m_row.get_table(), col, m_row.get_index());
+        List list(m_realm, table, col, m_row.get_index());
         list.assign(child_ctx, value, try_update, update_only_diff);
         ctx.did_change();
         return;

--- a/src/object_accessor.hpp
+++ b/src/object_accessor.hpp
@@ -53,7 +53,7 @@ void Object::set_property_value(ContextType& ctx, StringData prop_name, ValueTyp
     if (property.is_primary && !m_realm->is_in_migration())
         throw ModifyPrimaryKeyException(m_object_schema->name, property.name);
 
-    set_property_value_impl(ctx, property, value, try_update, true, false);
+    set_property_value_impl(ctx, property, value, try_update, false, false);
 }
 
 template <typename ValueType, typename ContextType>
@@ -112,41 +112,27 @@ void Object::set_property_value_impl(ContextType& ctx, const Property &property,
         case PropertyType::Object: {
             auto linked_schema = m_realm->schema().find(property.object_type);
             ContextType child_ctx(m_realm, &*linked_schema);
-            if (update_only_diff) {
-                // Check if we are linking to an object already
-                auto curr_link = table.get_link(col,row);
-                bool has_primary_key = linked_schema->primary_key_property() != nullptr;
-                // Check if value is an object already in the database
-                // If the target table has a primary key, it is ok to try and create the object
-                auto link = child_ctx.template unbox<RowExpr>(value, has_primary_key, try_update, true);
-                if (link) {
-                    // Update link if different
-                    if (curr_link != link.get_index()) {
-                        table.set_link(col, row, link.get_index(), is_default);
-                    }
-                }
-                else {
-                    // Do we already link to an object
-                    if (curr_link != realm::npos) {
-                        // We have just values and no primary keys - update individual values
-                        TableRef table = ObjectStore::table_for_object_type(m_realm->read_group(), property.object_type);
-                        Object linked_object(m_realm, *linked_schema, table->get(curr_link));
-                        for (size_t i = 0; i < linked_schema->persisted_properties.size(); ++i) {
-                            auto& prop = linked_schema->persisted_properties[i];
-                            if (auto v = ctx.value_for_property(value, prop, i))
-                                linked_object.set_property_value_impl(child_ctx, prop, *v, try_update, true, false);
-                        }
-                    }
-                    else {
-                        // No previous link - just create object
-                        link = child_ctx.template unbox<RowExpr>(value, true, try_update, true);
-                        table.set_link(col, row, link.get_index(), is_default);
-                    }
+            auto curr_link = table.get_link(col,row);
+            if (!update_only_diff || curr_link == realm::npos || linked_schema->primary_key_property() != nullptr) {
+                // If we are
+                //  - not updating differences only or
+                //  - not currently linking to an object or
+                //  - the target table has primary keys
+                // then we can just call unbox<RowExpr>()
+                auto link = child_ctx.template unbox<RowExpr>(value, true, try_update, true);
+                if (!update_only_diff || curr_link != link.get_index()) {
+                    table.set_link(col, row, link.get_index(), is_default);
                 }
             }
             else {
-                auto link = child_ctx.template unbox<RowExpr>(value, true, try_update, false);
-                table.set_link(col, row, link.get_index(), is_default);
+                // Otherwise we will have to update the values individually
+                TableRef table = ObjectStore::table_for_object_type(m_realm->read_group(), property.object_type);
+                Object linked_object(m_realm, *linked_schema, table->get(curr_link));
+                for (size_t i = 0; i < linked_schema->persisted_properties.size(); ++i) {
+                    auto& prop = linked_schema->persisted_properties[i];
+                    if (auto v = child_ctx.value_for_property(value, prop, i))
+                        linked_object.set_property_value_impl(child_ctx, prop, *v, try_update, true, false);
+                }
             }
             break;
         }

--- a/src/object_accessor.hpp
+++ b/src/object_accessor.hpp
@@ -103,7 +103,7 @@ void Object::set_property_value_impl(ContextType& ctx, const Property &property,
 
         ContextType child_ctx(ctx, property);
         List list(m_realm, *m_row.get_table(), col, m_row.get_index());
-        list.assign(child_ctx, value, try_update);
+        list.assign(child_ctx, value, try_update, update_only_diff);
         ctx.did_change();
         return;
     }

--- a/src/results.hpp
+++ b/src/results.hpp
@@ -349,7 +349,7 @@ void Results::set_property_value(ContextType& ctx, StringData prop_name, ValueTy
     size_t size = this->size();
     for (size_t i = 0; i < size; ++i) {
         Object obj(m_realm, *m_object_schema, get(i));
-        obj.set_property_value_impl(ctx, *prop, value, true);
+        obj.set_property_value_impl(ctx, *prop, value, true, false, false);
     }
 }
 

--- a/tests/object.cpp
+++ b/tests/object.cpp
@@ -591,8 +591,19 @@ TEST_CASE("object") {
         REQUIRE(!callback_called);
 
         // Now, only update sub-object)
-        donald.emplace("scores", AnyVec{INT64_C(3), INT64_C(4), INT64_C(5)});
+        donald["scores"] = AnyVec{INT64_C(3), INT64_C(4), INT64_C(5)};
         // Insert the new donald
+        eddie["assistant"] = donald;
+        create_company(eddie, true, true);
+
+        REQUIRE(table->size() == 5);
+        callback_called = false;
+        advance_and_notify(*r);
+        REQUIRE(callback_called);
+        REQUIRE_INDICES(change.modifications, 1);
+
+        // Shorten list
+        donald["scores"] = AnyVec{INT64_C(3), INT64_C(4)};
         eddie["assistant"] = donald;
         create_company(eddie, true, true);
 
@@ -627,6 +638,9 @@ TEST_CASE("object") {
         });
         advance_and_notify(*r);
 
+        auto table = r->read_group().get_table("class_link target");
+        REQUIRE(table->size() == 1);
+
         create(AnyDict{
             {"pk", INT64_C(1)},
             {"bool", true},
@@ -639,6 +653,7 @@ TEST_CASE("object") {
             {"object", AnyDict{{"value", INT64_C(10)}}},
         }, true, true);
 
+        REQUIRE(table->size() == 1);
         callback_called = false;
         sub_callback_called = false;
         advance_and_notify(*r);


### PR DESCRIPTION
Lists will be compared if the length is preserved - otherwise rewritten.
Objects with primary key will always just be updated if they already exist in the database.
In the case of single link to object without primary key we compare each value individually.
Lists of objects without primary key wil not yet be compared.