### PR TITLE
Add support for creating a subscription object immediately

### DIFF
--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -711,6 +711,7 @@ static void create_default_permissions(Group& group, std::vector<SchemaChange> c
     static_cast<void>(changes);
     static_cast<void>(sync_user_id);
 #else
+    _impl::initialize_schema(group);
     sync::set_up_basic_permissions(group, true);
 
     // Ensure that this user exists so that local privileges checks work immediately

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -36,7 +36,6 @@
 
 #if REALM_ENABLE_SYNC
 #include "sync/impl/sync_file.hpp"
-#include "sync/partial_sync.hpp"
 #include "sync/sync_config.hpp"
 #include "sync/sync_manager.hpp"
 
@@ -500,12 +499,6 @@ void Realm::update_schema(Schema schema, uint64_t version, MigrationFunction mig
 #endif
         ObjectStore::apply_schema_changes(read_group(), m_schema_version, schema, version,
                                           m_config.schema_mode, required_changes, std::move(sync_user_id));
-#if REALM_ENABLE_SYNC
-        // If the caller didn't supply the schema for __ResultSets we need to add it now since it is required by Sync
-        // for Query-based Realms.
-        if (m_config.sync_config && m_config.sync_config->is_partial)
-            initialize_schema(read_group());
-#endif
         REALM_ASSERT_DEBUG(additive || (required_changes = ObjectStore::schema_from_group(read_group()).compare(schema)).empty());
     }
 

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -36,6 +36,7 @@
 
 #if REALM_ENABLE_SYNC
 #include "sync/impl/sync_file.hpp"
+#include "sync/partial_sync.hpp"
 #include "sync/sync_config.hpp"
 #include "sync/sync_manager.hpp"
 
@@ -499,6 +500,12 @@ void Realm::update_schema(Schema schema, uint64_t version, MigrationFunction mig
 #endif
         ObjectStore::apply_schema_changes(read_group(), m_schema_version, schema, version,
                                           m_config.schema_mode, required_changes, std::move(sync_user_id));
+#if REALM_ENABLE_SYNC
+        // If the caller didn't supply the schema for __ResultSets we need to add it now since it is required by Sync
+        // for Query-based Realms.
+        if (m_config.sync_config && m_config.sync_config->is_partial)
+            initialize_schema(read_group());
+#endif
         REALM_ASSERT_DEBUG(additive || (required_changes = ObjectStore::schema_from_group(read_group()).compare(schema)).empty());
     }
 

--- a/src/sync/partial_sync.cpp
+++ b/src/sync/partial_sync.cpp
@@ -169,28 +169,6 @@ void with_open_shared_group(Realm::Config const& config, F&& function)
 
     function(*sg);
 }
-void update_schema(Group& group, Property matches_property)
-{
-    Schema current_schema;
-    std::string table_name = ObjectStore::table_name_for_object_type(result_sets_type_name);
-    if (group.has_table(table_name))
-        current_schema = {ObjectSchema{group, result_sets_type_name}};
-
-    Schema desired_schema({
-        ObjectSchema(result_sets_type_name, {
-            {"name", PropertyType::String, Property::IsPrimary{false}, Property::IsIndexed{true}},
-            {"matches_property", PropertyType::String},
-            {"query", PropertyType::String},
-            {"status", PropertyType::Int},
-            {"error_message", PropertyType::String},
-            {"query_parse_counter", PropertyType::Int},
-            std::move(matches_property)
-        })
-    });
-    auto required_changes = current_schema.compare(desired_schema);
-    if (!required_changes.empty())
-        ObjectStore::apply_additive_changes(group, required_changes, true);
-}
 
 struct ResultSetsColumns {
     ResultSetsColumns(Table& table, std::string const& matches_property_name)
@@ -214,12 +192,16 @@ struct ResultSetsColumns {
     size_t matches_property;
 };
 
-bool validate_existing_subscription(Table& table, ResultSetsColumns const& columns, std::string const& name,
+// Validate the subscription about to be created against existing subscription.
+// If an existing subscription already exists that matches the one  we are about to create, the
+// index of that Subscription is returned. If no current matching subscription exists `npos` is
+// returned.
+size_t validate_existing_subscription(Table& table, ResultSetsColumns const& columns, std::string const& name,
                                     std::string const& query, std::string const& matches_property)
 {
     auto existing_row_ndx = table.find_first_string(columns.name, name);
     if (existing_row_ndx == npos)
-        return false;
+        return npos;
 
     StringData existing_query = table.get_string(columns.query, existing_row_ndx);
     if (existing_query != query)
@@ -233,7 +215,38 @@ bool validate_existing_subscription(Table& table, ResultSetsColumns const& colum
                                               "but a different result type ('%1' vs '%2').",
                                               existing_matches_property, matches_property));
 
-    return true;
+    return existing_row_ndx;
+}
+
+// Performs the logic of actually writing the subscription (if needed) to the Realm and making sure
+// that the `matches_property` field is setup correctly. This method will throw if the query cannot
+// be serialized or the name is already used by another subscription.
+//
+// The row of the resulting subscription is returned. If an old subscription exists that matches
+// the one about to be created, a new subscription is not created, but the old one is returned
+// instead.
+RowExpr write_subscription(std::string const& object_type, std::string const &name, std::string const& query, Group& group) {
+    auto matches_property = std::string(object_type) + "_matches";
+
+    auto table = ObjectStore::table_for_object_type(group, result_sets_type_name);
+    ResultSetsColumns columns(*table, matches_property);
+
+    // Update schema if needed.
+    if (columns.matches_property == npos) {
+        auto target_table = ObjectStore::table_for_object_type(group, object_type);
+        columns.matches_property = table->add_column_link(type_LinkList, matches_property, *target_table);
+    } else {
+        // FIXME: Validate that the column type and link target are correct.
+    }
+
+    size_t row_ndx = validate_existing_subscription(*table, columns, name, query, matches_property);
+    if (row_ndx == npos) {
+        row_ndx = sync::create_object(group, *table);
+        table->set_string(columns.name, row_ndx, name);
+        table->set_string(columns.query, row_ndx, query);
+        table->set_string(columns.matches_property_name, row_ndx, matches_property);
+    }
+    return table->get(row_ndx);
 }
 
 void enqueue_registration(Realm& realm, std::string object_type, std::string query, std::string name,
@@ -247,27 +260,7 @@ void enqueue_registration(Realm& realm, std::string object_type, std::string que
         try {
             with_open_shared_group(config, [&](SharedGroup& sg) {
                 _impl::WriteTransactionNotifyingSync write(config, sg);
-
-                auto matches_property = std::string(object_type) + "_matches";
-
-                auto table = ObjectStore::table_for_object_type(write.get_group(), result_sets_type_name);
-                ResultSetsColumns columns(*table, matches_property);
-
-                // Update schema if needed.
-                if (columns.matches_property == npos) {
-                    auto target_table = ObjectStore::table_for_object_type(write.get_group(), object_type);
-                    columns.matches_property = table->add_column_link(type_LinkList, matches_property, *target_table);
-                } else {
-                    // FIXME: Validate that the column type and link target are correct.
-                }
-
-                if (!validate_existing_subscription(*table, columns, name, query, matches_property)) {
-                    auto row_ndx = sync::create_object(write.get_group(), *table);
-                    table->set_string(columns.name, row_ndx, name);
-                    table->set_string(columns.query, row_ndx, query);
-                    table->set_string(columns.matches_property_name, row_ndx, matches_property);
-                }
-
+                write_subscription(object_type, query, name, write.get_group());
                 write.commit();
             });
         } catch (...) {
@@ -318,77 +311,6 @@ std::string default_name_for_query(const std::string& query, const std::string& 
 
 } // unnamed namespace
 
-void register_query(std::shared_ptr<Realm> realm, const std::string &object_class, const std::string &query,
-                    std::function<void (Results, std::exception_ptr)> callback)
-{
-    auto sync_config = realm->config().sync_config;
-    if (!sync_config || !sync_config->is_partial)
-        throw std::logic_error("A partial sync query can only be registered in a partially synced Realm");
-
-    if (realm->schema().find(object_class) == realm->schema().end())
-        throw std::logic_error("A partial sync query can only be registered for a type that exists in the Realm's schema");
-
-    auto matches_property = object_class + "_matches";
-
-    // The object schema must outlive `object` below.
-    std::unique_ptr<ObjectSchema> result_sets_schema;
-    Object raw_object;
-    {
-        realm->begin_transaction();
-        auto cleanup = util::make_scope_exit([&]() noexcept {
-            if (realm->is_in_transaction())
-                realm->cancel_transaction();
-        });
-
-        update_schema(realm->read_group(),
-                      Property(matches_property, PropertyType::Object|PropertyType::Array, object_class));
-
-        result_sets_schema = std::make_unique<ObjectSchema>(realm->read_group(), result_sets_type_name);
-
-        CppContext context;
-        raw_object = Object::create<util::Any>(context, realm, *result_sets_schema,
-                                               AnyDict{
-                                                   {"name", query},
-                                                   {"matches_property", matches_property},
-                                                   {"query", query},
-                                                   {"status", int64_t(0)},
-                                                   {"error_message", std::string()},
-                                                   {"query_parse_counter", int64_t(0)},
-                                               }, false);
-
-        realm->commit_transaction();
-    }
-
-    auto object = std::make_shared<_impl::NotificationWrapper<Object>>(std::move(raw_object));
-
-    // Observe the new object and notify listener when the results are complete (status != 0).
-    auto notification_callback = [object, matches_property,
-                                  result_sets_schema=std::move(result_sets_schema),
-                                  callback=std::move(callback)](CollectionChangeSet, std::exception_ptr error) mutable {
-        if (error) {
-            callback(Results(), error);
-            object.reset();
-            return;
-        }
-
-        CppContext context;
-        auto status = any_cast<int64_t>(object->get_property_value<util::Any>(context, "status"));
-        if (status == 0) {
-            // Still computing...
-            return;
-        } else if (status == 1) {
-            // Finished successfully.
-            auto list = any_cast<List>(object->get_property_value<util::Any>(context, matches_property));
-            callback(list.as_results(), nullptr);
-        } else {
-            // Finished with error.
-            auto message = any_cast<std::string>(object->get_property_value<util::Any>(context, "error_message"));
-            callback(Results(), std::make_exception_ptr(std::runtime_error(std::move(message))));
-        }
-        object.reset();
-    };
-    object->add_notification_callback(std::move(notification_callback));
-}
 
 struct Subscription::Notifier : public _impl::CollectionNotifier {
     enum State {
@@ -492,7 +414,7 @@ Subscription subscribe(Results const& results, util::Optional<std::string> user_
 
     auto sync_config = realm->config().sync_config;
     if (!sync_config || !sync_config->is_partial)
-        throw std::logic_error("A partial sync query can only be registered in a partially synced Realm");
+        throw std::logic_error("A Subscription can only be created in a Query-based Realm.");
 
     auto query = results.get_query().get_description(); // Throws if the query cannot be serialized.
     query += " " + results.get_descriptor_ordering().get_description(results.get_query().get_table());
@@ -508,6 +430,25 @@ Subscription subscribe(Results const& results, util::Optional<std::string> user_
             notifier->finished_subscribing(error);
     });
     return subscription;
+}
+
+RowExpr subscribe_blocking(Results const& results, util::Optional<std::string> user_provided_name) {
+
+    auto realm = results.get_realm();
+    if (!realm->is_in_transaction()) {
+        throw std::logic_error("The subscription can only be created inside a write transaction.");
+    }
+    auto sync_config = realm->config().sync_config;
+    if (!sync_config || !sync_config->is_partial) {
+        throw std::logic_error("A Subscription can only be created in a Query-based Realm.");
+    }
+
+    auto query = results.get_query().get_description(); // Throws if the query cannot be serialized.
+    query += " " + results.get_descriptor_ordering().get_description(results.get_query().get_table());
+    std::string name = user_provided_name ? std::move(*user_provided_name)
+                                          : default_name_for_query(query, results.get_object_type());
+
+    return write_subscription(results.get_object_type(), name, query, realm->read_group());
 }
 
 void unsubscribe(Subscription& subscription)

--- a/src/sync/partial_sync.cpp
+++ b/src/sync/partial_sync.cpp
@@ -196,7 +196,7 @@ struct ResultSetsColumns {
 // If an existing subscription already exists that matches the one  we are about to create, the
 // index of that Subscription is returned. If no current matching subscription exists `npos` is
 // returned.
-size_t validate_existing_subscription(Table& table, ResultSetsColumns const& columns, std::string const& name,
+static size_t validate_existing_subscription(Table& table, ResultSetsColumns const& columns, std::string const& name,
                                     std::string const& query, std::string const& matches_property)
 {
     auto existing_row_ndx = table.find_first_string(columns.name, name);
@@ -225,7 +225,7 @@ size_t validate_existing_subscription(Table& table, ResultSetsColumns const& col
 // The row of the resulting subscription is returned. If an old subscription exists that matches
 // the one about to be created, a new subscription is not created, but the old one is returned
 // instead.
-RowExpr write_subscription(std::string const& object_type, std::string const &name, std::string const& query, Group& group) {
+static RowExpr write_subscription(std::string const& object_type, std::string const& name, std::string const& query, Group& group) {
     auto matches_property = std::string(object_type) + "_matches";
 
     auto table = ObjectStore::table_for_object_type(group, result_sets_type_name);
@@ -260,7 +260,7 @@ void enqueue_registration(Realm& realm, std::string object_type, std::string que
         try {
             with_open_shared_group(config, [&](SharedGroup& sg) {
                 _impl::WriteTransactionNotifyingSync write(config, sg);
-                write_subscription(object_type, query, name, write.get_group());
+                write_subscription(object_type, name, query, write.get_group());
                 write.commit();
             });
         } catch (...) {

--- a/src/sync/partial_sync.cpp
+++ b/src/sync/partial_sync.cpp
@@ -158,11 +158,11 @@ struct RowHandover {
 namespace partial_sync {
 
 InvalidRealmStateException::InvalidRealmStateException(const std::string& msg)
-        : std::logic_error(msg)
+: std::logic_error(msg)
 {}
 
 ExistingSubscriptionException::ExistingSubscriptionException(const std::string& msg)
-        : std::runtime_error(msg)
+: std::runtime_error(msg)
 {}
 
 namespace {

--- a/src/sync/partial_sync.cpp
+++ b/src/sync/partial_sync.cpp
@@ -441,7 +441,8 @@ Subscription subscribe(Results const& results, util::Optional<std::string> user_
     return subscription;
 }
 
-RowExpr subscribe_blocking(Results const& results, util::Optional<std::string> user_provided_name) {
+RowExpr subscribe_blocking(Results const& results, util::Optional<std::string> user_provided_name)
+{
 
     auto realm = results.get_realm();
     if (!realm->is_in_transaction()) {

--- a/src/sync/partial_sync.cpp
+++ b/src/sync/partial_sync.cpp
@@ -204,8 +204,8 @@ struct ResultSetsColumns {
 // If an existing subscription already exists that matches the one  we are about to create, the
 // index of that Subscription is returned. If no current matching subscription exists `npos` is
 // returned.
-static size_t validate_existing_subscription(Table& table, ResultSetsColumns const& columns, std::string const& name,
-                                    std::string const& query, std::string const& matches_property)
+size_t validate_existing_subscription(Table& table, ResultSetsColumns const& columns, std::string const& name,
+                                      std::string const& query, std::string const& matches_property)
 {
     auto existing_row_ndx = table.find_first_string(columns.name, name);
     if (existing_row_ndx == npos)
@@ -214,14 +214,14 @@ static size_t validate_existing_subscription(Table& table, ResultSetsColumns con
     StringData existing_query = table.get_string(columns.query, existing_row_ndx);
     if (existing_query != query)
         throw ExistingSubscriptionException(util::format("An existing subscription exists with the same name, "
-                                              "but a different query ('%1' vs '%2').",
-                                              existing_query, query));
+                                                         "but a different query ('%1' vs '%2').",
+                                                         existing_query, query));
 
     StringData existing_matches_property = table.get_string(columns.matches_property_name, existing_row_ndx);
     if (existing_matches_property != matches_property)
         throw ExistingSubscriptionException(util::format("An existing subscription exists with the same name, "
-                                              "but a different result type ('%1' vs '%2').",
-                                              existing_matches_property, matches_property));
+                                                         "but a different result type ('%1' vs '%2').",
+                                                         existing_matches_property, matches_property));
 
     return existing_row_ndx;
 }
@@ -233,7 +233,8 @@ static size_t validate_existing_subscription(Table& table, ResultSetsColumns con
 // The row of the resulting subscription is returned. If an old subscription exists that matches
 // the one about to be created, a new subscription is not created, but the old one is returned
 // instead.
-static RowExpr write_subscription(std::string const& object_type, std::string const& name, std::string const& query, Group& group) {
+RowExpr write_subscription(std::string const& object_type, std::string const& name, std::string const& query, Group& group)
+{
     auto matches_property = std::string(object_type) + "_matches";
 
     auto table = ObjectStore::table_for_object_type(group, result_sets_type_name);

--- a/src/sync/partial_sync.hpp
+++ b/src/sync/partial_sync.hpp
@@ -35,6 +35,15 @@ class Object;
 class Realm;
 
 namespace partial_sync {
+
+struct InvalidRealmStateException : public std::logic_error {
+    InvalidRealmStateException(const std::string& msg);
+};
+
+struct ExistingSubscriptionException : public std::runtime_error {
+    ExistingSubscriptionException(const std::string& msg);
+};
+
 enum class SubscriptionState : int8_t;
 
 struct SubscriptionNotificationToken {

--- a/src/sync/partial_sync.hpp
+++ b/src/sync/partial_sync.hpp
@@ -73,26 +73,33 @@ private:
     friend void unsubscribe(Subscription&);
 };
 
-/// Create a partial sync subscription from the query associated with the `Results`.
+/// Create a Query-based subscription from the query associated with the `Results`.
 ///
 /// The subscription is created asynchronously.
 ///
 /// State changes, including runtime errors, are communicated via notifications
 /// registered on the resulting `Subscription` object.
 ///
-/// Programming errors, such as attempting to create a subscription in that is not
-/// partially synced, or subscribing to an unsupported query, will throw an exception.
+/// Programming errors, such as attempting to create a subscription in a Realm that is not
+/// Query-based, or subscribing to an unsupported query, will throw an exception.
 Subscription subscribe(Results const&, util::Optional<std::string> name);
+
+// Create a subscription from the query associated with the `Results`
+//
+// The subscription is created synchronously, so this method should only be called inside
+// a write transaction.
+//
+// Programming errors, such as attempting to create a subscription outside a write transaction or in
+// a Realm that is not Query-based, or subscribing to an unsupported query, will throw an exception.
+//
+// The Row that represents the Subscription in the  __ResultsSets table is returned.
+RowExpr subscribe_blocking(Results const&, util::Optional<std::string> name);
 
 /// Remove a partial sync subscription.
 ///
 /// The operation is performed asynchronously. Completion will be indicated by the
 /// `Subscription` transitioning to the `Invalidated` state.
 void unsubscribe(Subscription&);
-
-// Deprecated
-void register_query(std::shared_ptr<Realm>, const std::string &object_class, const std::string &query,
-					std::function<void (Results, std::exception_ptr)>);
 
 } // namespace partial_sync
 


### PR DESCRIPTION
* This adds the capability of creating subscriptions immediately by using `subscribe_blocking()`. This is required by new additions to Java. 
* Removed old methods that were only used by Java, but are no longer relevant.
* Added support for specifying the __ResultSets class in the users Schema. This fixes: https://github.com/realm/realm-object-store/pull/698

TODO
- [x] Tests