### PR TITLE
Add a missing virtual destructor to CollectionChangeCallback

### DIFF
--- a/src/collection_notifications.hpp
+++ b/src/collection_notifications.hpp
@@ -126,6 +126,7 @@ public:
 
 private:
     struct Base {
+        virtual ~Base() {}
         virtual void before(CollectionChangeSet const&)=0;
         virtual void after(CollectionChangeSet const&)=0;
         virtual void error(std::exception_ptr)=0;


### PR DESCRIPTION
This resulted in the destructor for the callback object passed to `add_notification_callback()` not being called, potentially resulting in memory leaks when removing notification callbacks.