### PR TITLE
Remove Subscription::results()

### DIFF
--- a/src/sync/partial_sync.cpp
+++ b/src/sync/partial_sync.cpp
@@ -588,16 +588,5 @@ std::exception_ptr Subscription::error() const
     return nullptr;
 }
 
-Results Subscription::results() const
-{
-    auto object = result_set_object();
-    REALM_ASSERT_RELEASE(object);
-
-    CppContext context;
-    auto matches_property = any_cast<std::string>(object->get_property_value<util::Any>(context, "matches_property"));
-    auto list = any_cast<List>(object->get_property_value<util::Any>(context, matches_property));
-    return list.as_results();
-}
-
 } // namespace partial_sync
 } // namespace realm

--- a/src/sync/partial_sync.hpp
+++ b/src/sync/partial_sync.hpp
@@ -60,8 +60,6 @@ public:
     SubscriptionState state() const;
     std::exception_ptr error() const;
 
-    Results results() const;
-
     SubscriptionNotificationToken add_notification_callback(std::function<void()> callback);
 
 private:


### PR DESCRIPTION
This returned the list of objects matching the subscription which used to be populated by the server, but no longer is and now is just always empty.