### PR TITLE
Support setting binding/application user agent

### DIFF
--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -515,8 +515,8 @@ std::unique_ptr<SyncClient> SyncManager::create_sync_client() const
         logger = std::move(stderr_logger);
     }
 
-    std::string user_agent(m_user_agent_binding_info + std::string(" ") + m_user_agent_application_info);
-    return std::make_unique<SyncClient>(std::move(logger), m_client_reconnect_mode, m_multiplex_sessions, user_agent);
+    return std::make_unique<SyncClient>(std::move(logger), m_client_reconnect_mode, m_multiplex_sessions,
+                                        util::format("%1 %2", m_user_agent_binding_info, m_user_agent_application_info));
 }
 
 std::string SyncManager::client_uuid() const

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -39,7 +39,7 @@ SyncManager& SyncManager::shared()
 
 void SyncManager::configure(const std::string& base_file_path,
                                         MetadataMode metadata_mode,
-                                        const std::string& user_agent_application_info,
+                                        const std::string& user_agent_binding_info,
                                         util::Optional<std::vector<char>> custom_encryption_key,
                                         bool reset_metadata_on_error)
 {
@@ -50,7 +50,7 @@ void SyncManager::configure(const std::string& base_file_path,
         bool is_admin;
     };
 
-    m_user_agent_application_info = user_agent_application_info;
+    m_user_agent_binding_info = user_agent_binding_info;
 
     std::vector<UserCreationData> users_to_add;
     {
@@ -256,6 +256,12 @@ void SyncManager::set_logger_factory(SyncLoggerFactory& factory) noexcept
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     m_logger_factory = &factory;
+}
+
+void SyncManager::set_user_agent(std::string user_agent)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_user_agent_application_info = std::move(user_agent);
 }
 
 void SyncManager::reconnect()
@@ -508,7 +514,9 @@ std::unique_ptr<SyncClient> SyncManager::create_sync_client() const
         stderr_logger->set_level_threshold(m_log_level);
         logger = std::move(stderr_logger);
     }
-    return std::make_unique<SyncClient>(std::move(logger), m_client_reconnect_mode, m_multiplex_sessions, m_user_agent_application_info);
+
+    std::string user_agent(m_user_agent_binding_info + std::string(" ") + m_user_agent_application_info);
+    return std::make_unique<SyncClient>(std::move(logger), m_client_reconnect_mode, m_multiplex_sessions, user_agent);
 }
 
 std::string SyncManager::client_uuid() const

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -69,7 +69,7 @@ public:
     // Configure the metadata and file management subsystems. This MUST be called upon startup.
     void configure(const std::string& base_file_path,
                                MetadataMode metadata_mode=MetadataMode::Encryption,
-                               const std::string& user_agent_application_info = "",
+                               const std::string& user_agent_binding_info = "",
                                util::Optional<std::vector<char>> custom_encryption_key=none,
                                bool reset_metadata_on_error=false);
 
@@ -86,8 +86,17 @@ public:
     // balancer or automatic failover.
     void enable_session_multiplexing();
 
+    // Sets the log level for the Sync Client.
+    // The log level can only be set up until the point the Sync Client is created. This happens when the first Session
+    // is created.
     void set_log_level(util::Logger::Level) noexcept;
     void set_logger_factory(SyncLoggerFactory&) noexcept;
+
+    // Sets the application level user agent string.
+    // This should have the format specified here: https://github.com/realm/realm-sync/blob/develop/src/realm/sync/client.hpp#L126
+    // The user agent can only be set up  until the  point the Sync Client is created. This happens when the first
+    // Session is created.
+    void set_user_agent(std::string user_agent);
 
     /// Ask all valid sync sessions to perform whatever tasks might be necessary to
     /// re-establish connectivity with the Realm Object Server. It is presumed that
@@ -189,8 +198,9 @@ private:
     mutable std::unique_ptr<_impl::SyncClient> m_sync_client;
     bool m_multiplex_sessions = false;
 
-    // Optional information about the application to be added to the user
-    // agent description as sent to the server.
+    // Optional information about the binding/application that is sent as part of the User-Agent
+    // when establishing a connection to the server.
+    std::string m_user_agent_binding_info;
     std::string m_user_agent_application_info;
 
     // Protects m_file_manager and m_metadata_manager


### PR DESCRIPTION
It turned out that setting both the binding and application user-agent info in `configure` wasn't optimal for how JS uses ObjectStore, so in this refactor I split the two parts. The binding level info is still configured when calling `configure` as it doesn't involve user input. The application level info now has a method similar to how `set_log_level` works.