### PR TITLE
Add hooks for the audit functionality

### DIFF
--- a/src/audit.hpp
+++ b/src/audit.hpp
@@ -1,0 +1,34 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2018 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+namespace realm {
+class Table;
+class TableView;
+template<typename> class BasicRowExpr;
+using RowExpr = BasicRowExpr<Table>;
+struct VersionID;
+
+class AuditInterface {
+public:
+    virtual ~AuditInterface() {}
+
+    virtual void record_query(realm::VersionID, realm::TableView const&) = 0;
+    virtual void record_read(realm::VersionID, realm::RowExpr) = 0;
+    virtual void record_write(realm::VersionID, realm::VersionID) = 0;
+};
+}

--- a/src/impl/apple/external_commit_helper.cpp
+++ b/src/impl/apple/external_commit_helper.cpp
@@ -154,7 +154,7 @@ ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent)
     m_shutdown_read_fd = shutdown_pipe[0];
     m_shutdown_write_fd = shutdown_pipe[1];
 
-    m_thread = std::async(std::launch::async, [=] {
+    m_thread = std::thread([=] {
         try {
             listen();
         }
@@ -177,7 +177,7 @@ ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent)
 ExternalCommitHelper::~ExternalCommitHelper()
 {
     notify_fd(m_shutdown_write_fd, m_shutdown_read_fd);
-    m_thread.wait(); // Wait for the thread to exit
+    m_thread.join(); // Wait for the thread to exit
 }
 
 void ExternalCommitHelper::listen()

--- a/src/impl/apple/external_commit_helper.hpp
+++ b/src/impl/apple/external_commit_helper.hpp
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#include <future>
+#include <thread>
 
 namespace realm {
 class Realm;
@@ -59,7 +59,7 @@ private:
     RealmCoordinator& m_parent;
 
     // The listener thread
-    std::future<void> m_thread;
+    std::thread m_thread;
 
     // Pipe which is waited on for changes and written to when there is a new
     // commit to notify others of. When using a named pipe m_notify_fd is

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -196,6 +196,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
     auto schema = std::move(config.schema);
     auto migration_function = std::move(config.migration_function);
     auto initialization_function = std::move(config.initialization_function);
+    auto audit_factory = std::move(config.audit_factory);
     config.schema = {};
 
     if (config.cache) {
@@ -238,6 +239,9 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config)
 
     if (realm->config().sync_config)
         create_sync_session();
+
+    if (!m_audit_context && audit_factory)
+        m_audit_context = audit_factory();
 
     if (schema) {
         lock.unlock();

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -146,6 +146,8 @@ public:
     partial_sync::WorkQueue& partial_sync_work_queue();
 #endif
 
+    AuditInterface* audit_context() const noexcept { return m_audit_context.get(); }
+
 private:
     Realm::Config m_config;
 
@@ -183,6 +185,8 @@ private:
     std::shared_ptr<SyncSession> m_sync_session;
     std::unique_ptr<partial_sync::WorkQueue> m_partial_sync_work_queue;
 #endif
+
+    std::shared_ptr<AuditInterface> m_audit_context;
 
     // must be called with m_notifier_mutex locked
     void pin_version(VersionID version);

--- a/src/results.cpp
+++ b/src/results.cpp
@@ -20,6 +20,7 @@
 
 #include "impl/realm_coordinator.hpp"
 #include "impl/results_notifier.hpp"
+#include "audit.hpp"
 #include "object_schema.hpp"
 #include "object_store.hpp"
 #include "schema.hpp"
@@ -267,6 +268,8 @@ void Results::evaluate_query_if_needed(bool wants_notifications)
                 prepare_async(ForCallback{false});
             m_has_used_table_view = true;
             m_table_view.sync_if_needed();
+            if (auto audit = m_realm->audit_context())
+                audit->record_query(m_realm->read_transaction_version(), m_table_view);
             break;
     }
 }

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -22,6 +22,7 @@
 #include "impl/realm_coordinator.hpp"
 #include "impl/transact_log_handler.hpp"
 
+#include "audit.hpp"
 #include "binding_context.hpp"
 #include "list.hpp"
 #include "object.hpp"
@@ -583,14 +584,14 @@ void Realm::notify_schema_changed()
     }
 }
 
-static void check_read_write(Realm *realm)
+static void check_read_write(const Realm* realm)
 {
     if (realm->config().immutable()) {
         throw InvalidTransactionException("Can't perform transactions on read-only Realms.");
     }
 }
 
-static void check_write(Realm* realm)
+static void check_write(const Realm* realm)
 {
     if (realm->config().immutable() || realm->config().read_only_alternative()) {
         throw InvalidTransactionException("Can't perform transactions on read-only Realms.");
@@ -619,6 +620,14 @@ void Realm::verify_open() const
     if (is_closed()) {
         throw ClosedRealmException();
     }
+}
+
+VersionID Realm::read_transaction_version() const
+{
+    verify_thread();
+    verify_open();
+    check_read_write(this);
+    return m_shared_group->get_version_of_current_transaction();
 }
 
 bool Realm::is_in_transaction() const noexcept
@@ -676,7 +685,15 @@ void Realm::commit_transaction()
         throw InvalidTransactionException("Can't commit a non-existing write transaction");
     }
 
-    m_coordinator->commit_write(*this);
+    if (auto audit = audit_context()) {
+        auto prev_version = m_shared_group->pin_version();
+        m_coordinator->commit_write(*this);
+        audit->record_write(prev_version, m_shared_group->get_version_of_current_transaction());
+        m_shared_group->unpin_version(prev_version);
+    }
+    else {
+        m_coordinator->commit_write(*this);
+    }
     cache_new_schema();
     invalidate_permission_cache();
 }
@@ -983,6 +1000,11 @@ template Object Realm::resolve_thread_safe_reference(ThreadSafeReference<Object>
 template List Realm::resolve_thread_safe_reference(ThreadSafeReference<List> reference);
 template Results Realm::resolve_thread_safe_reference(ThreadSafeReference<Results> reference);
 
+AuditInterface* Realm::audit_context() const noexcept
+{
+    return m_coordinator ? m_coordinator->audit_context() : nullptr;
+}
+
 #if REALM_ENABLE_SYNC
 static_assert(static_cast<int>(ComputedPrivileges::Read) == static_cast<int>(sync::Privilege::Read), "");
 static_assert(static_cast<int>(ComputedPrivileges::Update) == static_cast<int>(sync::Privilege::Update), "");
@@ -1096,9 +1118,4 @@ Group& RealmFriend::read_group_to(Realm& realm, VersionID version)
         realm.m_shared_group->end_read();
     realm.begin_read(version);
     return *realm.m_group;
-}
-
-std::size_t Realm::compute_size() {
-    Group& group = read_group();
-    return group.compute_aggregated_byte_size();
 }

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -204,7 +204,7 @@ void Realm::open_with_config(const Config& config,
             translate_file_exception(config.path, config.immutable()); // Throws
 
         // Move the Realm file into the recovery directory.
-        std::string recovery_directory = SyncManager::shared().recovery_directory_path();
+        std::string recovery_directory = SyncManager::shared().recovery_directory_path(config.sync_config ? config.sync_config->recovery_directory : none);
         std::string new_realm_path = util::reserve_unique_file_name(recovery_directory, "synced-realm-XXXXXXX");
         util::File::move(config.path, new_realm_path);
 

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -32,6 +32,7 @@
 #include <memory>
 
 namespace realm {
+class AuditInterface;
 class BindingContext;
 class Group;
 class Realm;
@@ -241,9 +242,12 @@ public:
         /// A data structure storing data used to configure the Realm for sync support.
         std::shared_ptr<SyncConfig> sync_config;
 
-        // FIXME: Realm Java manages sync at the Java level, so it needs to create Realms using the sync history
-        //        format.
+        // Open the Realm using the sync history mode even if a sync
+        // configuration is not supplied.
         bool force_sync_history = false;
+
+        // A factory function which produces an audit implementation.
+        std::function<std::shared_ptr<AuditInterface>()> audit_factory;
     };
 
     // Get a cached Realm or create a new one if no cached copies exists
@@ -278,7 +282,10 @@ public:
     void commit_transaction();
     void cancel_transaction();
     bool is_in_transaction() const noexcept;
+
     bool is_in_read_transaction() const { return !!m_group; }
+    VersionID read_transaction_version() const;
+    Group& read_group();
 
     bool is_in_migration() const noexcept { return m_in_migration; }
 
@@ -327,6 +334,8 @@ public:
     ComputedPrivileges get_privileges();
     ComputedPrivileges get_privileges(StringData object_type);
     ComputedPrivileges get_privileges(RowExpr row);
+
+    AuditInterface* audit_context() const noexcept;
 
     static SharedRealm make_shared_realm(Config config, std::shared_ptr<_impl::RealmCoordinator> coordinator = nullptr) {
         struct make_shared_enabler : public Realm {
@@ -424,12 +433,8 @@ private:
 public:
     std::unique_ptr<BindingContext> m_binding_context;
 
-    // FIXME private
-    Group& read_group();
-
-    std::size_t compute_size();
-    
-    Replication *history() { return m_history.get(); }
+    // FIXME: This is currently needed by the adapter to get access to its changeset cooker
+    Replication* history() { return m_history.get(); }
 
     friend class _impl::RealmFriend;
 };

--- a/src/sync/impl/sync_file.hpp
+++ b/src/sync/impl/sync_file.hpp
@@ -97,13 +97,13 @@ public:
         return m_base_path;
     }
 
-    std::string recovery_directory_path() const
+    std::string recovery_directory_path(util::Optional<std::string> const& directory) const
     {
-        return get_special_directory(c_recovery_directory);
+        return get_special_directory(directory.value_or(c_recovery_directory));
     }
 
 private:
-    std::string m_base_path;
+    const std::string m_base_path;
 
     static constexpr const char c_sync_directory[] = "realm-object-server";
     static constexpr const char c_utility_directory[] = "io.realm.object-server-utility";

--- a/src/sync/sync_config.hpp
+++ b/src/sync/sync_config.hpp
@@ -137,6 +137,10 @@ struct SyncConfig {
 
     util::Optional<std::string> url_prefix = none;
 
+    // The name of the directory which Realms should be backed up to following
+    // a client reset
+    util::Optional<std::string> recovery_directory = none;
+
     // The URL that will be used when connecting to the object server.
     // This will differ from `reference_realm_url` when partial sync is being used.
     std::string realm_url() const;

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -409,11 +409,11 @@ std::string SyncManager::path_for_realm(const SyncUser& user, const std::string&
     return m_file_manager->path(user.local_identity(), raw_realm_url);
 }
 
-std::string SyncManager::recovery_directory_path() const
+std::string SyncManager::recovery_directory_path(util::Optional<std::string> const& custom_dir_name) const
 {
     std::lock_guard<std::mutex> lock(m_file_system_mutex);
     REALM_ASSERT(m_file_manager);
-    return m_file_manager->recovery_directory_path();
+    return m_file_manager->recovery_directory_path(custom_dir_name);
 }
 
 std::shared_ptr<SyncSession> SyncManager::get_existing_active_session(const std::string& path) const

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -140,7 +140,7 @@ public:
     std::string path_for_realm(const SyncUser& user, const std::string& raw_realm_url) const;
 
     // Get the path of the recovery directory for backed-up or recovered Realms.
-    std::string recovery_directory_path() const;
+    std::string recovery_directory_path(util::Optional<std::string> const& custom_dir_name) const;
 
     // Get the unique identifier of this client.
     std::string client_uuid() const;

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -444,7 +444,7 @@ SyncSession::SyncSession(SyncClient& client, std::string realm_path, SyncConfig 
 
 std::string SyncSession::get_recovery_file_path()
 {
-    return util::reserve_unique_file_name(SyncManager::shared().recovery_directory_path(),
+    return util::reserve_unique_file_name(SyncManager::shared().recovery_directory_path(m_config.recovery_directory),
                                           util::create_timestamped_template("recovered_realm"));
 }
 
@@ -676,7 +676,8 @@ void SyncSession::create_sync_session()
 
     // Sets up the connection state listener. This callback is used for both reporting errors as well as changes to the
     // connection state.
-    m_session->set_connection_state_change_listener([weak_self](realm::sync::Session::ConnectionState state, const realm::sync::Session::ErrorInfo* error) {
+    m_session->set_connection_state_change_listener([weak_self](sync::Session::ConnectionState state,
+                                                                const sync::Session::ErrorInfo* error) {
         // If the OS SyncSession object is destroyed, we ignore any events from the underlying Session as there is
         // nothing useful we can do with them.
         if (auto self = weak_self.lock()) {

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -404,6 +404,11 @@ struct sync_session_states::Inactive : public SyncSession::State {
     {
         session.m_server_override = SyncSession::ServerOverride{address, port};
     }
+
+    void close(std::unique_lock<std::mutex>& lock, SyncSession& session) const override
+    {
+        session.unregister(lock); // releases lock
+    }
 };
 
 

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -327,7 +327,7 @@ private:
     void cancel_pending_waits(std::unique_lock<std::mutex>&);
     enum class ShouldBackup { yes, no };
     void update_error_and_mark_file_for_deletion(SyncError&, ShouldBackup);
-    static std::string get_recovery_file_path();
+    std::string get_recovery_file_path();
     void handle_progress_update(uint64_t, uint64_t, uint64_t, uint64_t, uint64_t, uint64_t);
 
     void set_sync_transact_callback(std::function<SyncSessionTransactCallback>);

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -1580,7 +1580,7 @@ TEST_CASE("Statistics on Realms") {
     });
 
     SECTION("compute_size") {
-        auto s = r->compute_size();
+        auto s = r->read_group().compute_aggregated_byte_size();
         REQUIRE(s > 0);
     }
 }


### PR DESCRIPTION
This adds an abstract interface which is implemented by the actual audit implementation for reporting auditable events, along with some tweaks required to get client reset handling working.