### PR TITLE
Fix running the tests with sync 3.14

### DIFF
--- a/tests/sync/permission.cpp
+++ b/tests/sync/permission.cpp
@@ -97,6 +97,7 @@ static void subscribe_to_all(std::shared_ptr<Realm> const& r)
         {"status", int64_t(0)},
         {"error_message", ""s},
         {"query_parse_counter", int64_t(0)},
+        {"matches_count", int64_t(0)},
     }, false);
 
     r->commit_transaction();


### PR DESCRIPTION
3.14 added a new property to the __ResultSets table and a few of the tests use an object schema read from the table, so object creation in those tests now require a value for that property. Supplying a value for a property that doesn't exist is harmless, so there's no need to make this conditional.