### PR TITLE
Disable change notifications for SyncMetadataManager

### DIFF
--- a/src/sync/impl/sync_metadata.cpp
+++ b/src/sync/impl/sync_metadata.cpp
@@ -87,6 +87,8 @@ SyncMetadataManager::SyncMetadataManager(std::string path,
     constexpr uint64_t SCHEMA_VERSION = 2;
 
     Realm::Config config;
+    config.automatic_change_notifications = false;
+    config.cache = false;
     config.path = path;
     config.schema = make_schema();
     config.schema_version = SCHEMA_VERSION;


### PR DESCRIPTION
The libuv implementation of EventLoopSignal always invokes notifications on the main thread rather than the thread where the Realm was created. This works fine for user-created Realms since we don't support using multiple threads at once in realm-js, but it means that when we create our own Realms on background threads we need to ensure that they never have an autorefresh notification fire or we'll hit an incorrect thread error.

SyncMetadataManager's Realm is always short-lived and typically do not get any notifications simply because it was closed before they could happen, but a client reset error will sometimes trigger one. We don't want the notifications anyway, so just disable them.

This fixes inconsistent IncorrectThreadException crashes in the realm-js-private tests which test client reset-related functionality.