### PR TITLE
Fix user operations on a deleted user

### DIFF
--- a/src/sync/impl/sync_metadata.hpp
+++ b/src/sync/impl/sync_metadata.hpp
@@ -33,6 +33,10 @@ template<typename T> class BasicRowExpr;
 using RowExpr = BasicRowExpr<Table>;
 class SyncMetadataManager;
 
+struct InvalidUserException : public std::runtime_error {
+    InvalidUserException(const std::string& msg);
+};
+
 // A facade for a metadata Realm object representing a sync user.
 class SyncUserMetadata {
 public:
@@ -74,13 +78,13 @@ public:
 
     bool is_valid() const
     {
-        return !m_invalid;
+        return m_row.is_attached();
     }
 
     // INTERNAL USE ONLY
     SyncUserMetadata(Schema schema, SharedRealm realm, RowExpr row);
 private:
-    bool m_invalid = false;
+    void checkValidOrThrow(const std::string operation) const;
     SharedRealm m_realm;
     Schema m_schema;
     Row m_row;


### PR DESCRIPTION
The `SyncUserMetadata` was operating on a row accessor and using it's own locally cached `m_invalid` state to check for validity. This would only work if no other accessors exist. Instead we should check the row accessor to see if it is valid before operating on it. Behaviour is changed so that invalid operations on a user metadata will now throw an `InvalidUserException`.

Specifically this fixes https://github.com/realm/realm-sync/issues/2586. The included script there both makes a "DELETE" http request on a user and logs the user out locally. This means that the server deletes the user (via ROS handling the DELETE request), and the user is marked for deletion locally the next time the client connects a session. So the next time the local client connects, it sees the locally marked user object which is marked for removal and begins to delete the associated files on disk. While this happens, sync tells the client that the row is now deleted and the accessor becomes invalid. Then when the client finishes cleaning the user's disk state, it removes the (now invalid) row accessor. This causes undefined behaviour later on, including corruption and/or crashes, including the assertion seen in https://github.com/realm/realm-sync/issues/2586.