### PR TITLE
Avoid pinning Realm versions when queries are made with automatic change notifications disabled

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -325,18 +325,18 @@ RealmCoordinator::~RealmCoordinator()
 
 void RealmCoordinator::unregister_realm(Realm* realm)
 {
-    {
-        std::lock_guard<std::mutex> lock(m_realm_mutex);
-        auto new_end = remove_if(begin(m_weak_realm_notifiers), end(m_weak_realm_notifiers),
-                                 [=](auto& notifier) { return notifier.expired() || notifier.is_for_realm(realm); });
-        m_weak_realm_notifiers.erase(new_end, end(m_weak_realm_notifiers));
-    }
     // Normally results notifiers are cleaned up by the background worker thread
     // but if that's disabled we need to ensure that any notifiers from this
     // Realm get cleaned up
     if (!m_config.automatic_change_notifications) {
         std::unique_lock<std::mutex> lock(m_notifier_mutex);
         clean_up_dead_notifiers();
+    }
+    {
+        std::lock_guard<std::mutex> lock(m_realm_mutex);
+        auto new_end = remove_if(begin(m_weak_realm_notifiers), end(m_weak_realm_notifiers),
+                                 [=](auto& notifier) { return notifier.expired() || notifier.is_for_realm(realm); });
+        m_weak_realm_notifiers.erase(new_end, end(m_weak_realm_notifiers));
     }
 }
 

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -325,10 +325,19 @@ RealmCoordinator::~RealmCoordinator()
 
 void RealmCoordinator::unregister_realm(Realm* realm)
 {
-    std::lock_guard<std::mutex> lock(m_realm_mutex);
-    auto new_end = remove_if(begin(m_weak_realm_notifiers), end(m_weak_realm_notifiers),
-                             [=](auto& notifier) { return notifier.expired() || notifier.is_for_realm(realm); });
-    m_weak_realm_notifiers.erase(new_end, end(m_weak_realm_notifiers));
+    {
+        std::lock_guard<std::mutex> lock(m_realm_mutex);
+        auto new_end = remove_if(begin(m_weak_realm_notifiers), end(m_weak_realm_notifiers),
+                                 [=](auto& notifier) { return notifier.expired() || notifier.is_for_realm(realm); });
+        m_weak_realm_notifiers.erase(new_end, end(m_weak_realm_notifiers));
+    }
+    // Normally results notifiers are cleaned up by the background worker thread
+    // but if that's disabled we need to ensure that any notifiers from this
+    // Realm get cleaned up
+    if (!m_config.automatic_change_notifications) {
+        std::unique_lock<std::mutex> lock(m_notifier_mutex);
+        clean_up_dead_notifiers();
+    }
 }
 
 void RealmCoordinator::clear_cache()

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -877,11 +877,10 @@ void RealmCoordinator::process_available_async(Realm& realm)
     if (notifiers.empty())
         return;
 
-    if (realm.m_binding_context)
-        realm.m_binding_context->will_send_notifications();
-
     if (auto error = m_async_error) {
         lock.unlock();
+        if (realm.m_binding_context)
+            realm.m_binding_context->will_send_notifications();
         for (auto& notifier : notifiers)
             notifier->deliver_error(m_async_error);
         if (realm.m_binding_context)
@@ -891,18 +890,24 @@ void RealmCoordinator::process_available_async(Realm& realm)
 
     bool in_read = realm.is_in_read_transaction();
     auto& sg = Realm::Internal::get_shared_group(realm);
-    if (!sg) // i.e. the Realm was closed in a callback above
-        return;
     auto version = sg->get_version_of_current_transaction();
     auto package = [&](auto& notifier) {
         return !(notifier->has_run() && (!in_read || notifier->version() == version) && notifier->package_for_delivery());
     };
     notifiers.erase(std::remove_if(begin(notifiers), end(notifiers), package), end(notifiers));
+    if (notifiers.empty())
+        return;
     lock.unlock();
 
     // no before advance because the Realm is already at the given version,
     // because we're either sending initial notifications or the write was
     // done on this Realm instance
+
+    if (realm.m_binding_context) {
+        realm.m_binding_context->will_send_notifications();
+        if (!sg) // i.e. the Realm was closed in the callback above
+            return;
+    }
 
     // Skip delivering if the Realm isn't in a read transaction
     if (in_read) {

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -884,7 +884,7 @@ bool Realm::refresh()
 
 bool Realm::can_deliver_notifications() const noexcept
 {
-    if (m_config.immutable()) {
+    if (m_config.immutable() || !m_config.automatic_change_notifications) {
         return false;
     }
 


### PR DESCRIPTION
The root cause of https://github.com/realm/data-adapters/issues/464

The adapter vends Realm instances to the user code which have automatic change notifications disabled (they wouldn't really work properly with how the adapter integrates into things and disabling them cuts resource usage), but holds on to a long-lived RealmCoordinator for each adapted Realm. If the user code queried one of these Realms we'd implicitly create a ResultsNotifier for the results which pins the current transaction version, which would then never be cleaned up since the worker thread isn't running.

This fixes both of the problems there: if we aren't using the notification worker thread we shouldn't implicitly create notifiers, and if the user explicitly creates a notifier we should clean it up when the Realm is unregistered rather than waiting for the RealmCoordinator to go away.