### PR TITLE
Add has_existing_sessions()

### DIFF
--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -218,13 +218,10 @@ void SyncManager::reset_for_testing()
 
         {
             std::lock_guard<std::mutex> lock(m_session_mutex);
-
-            // Callers of `SyncManager::reset_for_testing` should ensure there are no active sessions
+            // Callers of `SyncManager::reset_for_testing` should ensure there are no existing sessions
             // prior to calling `reset_for_testing`.
-            auto no_active_sessions = std::none_of(m_sessions.begin(), m_sessions.end(), [](auto& element){
-                return element.second->existing_external_reference();
-            });
-            REALM_ASSERT_RELEASE(no_active_sessions);
+            bool no_sessions = !do_has_existing_sessions();
+            REALM_ASSERT_RELEASE(no_sessions);
 
             // Destroy any inactive sessions.
             // FIXME: We shouldn't have any inactive sessions at this point! Sessions are expected to
@@ -468,6 +465,19 @@ std::shared_ptr<SyncSession> SyncManager::get_session(const std::string& path, c
     sync_config.user->register_session(std::move(shared_session));
 
     return external_reference;
+}
+
+
+bool SyncManager::has_existing_sessions()
+{
+    std::lock_guard<std::mutex> lock(m_session_mutex);
+    return do_has_existing_sessions();
+}
+
+bool SyncManager::do_has_existing_sessions(){
+    return std::any_of(m_sessions.begin(), m_sessions.end(), [](auto& element){
+        return element.second->existing_external_reference();
+    });
 }
 
 void SyncManager::unregister_session(const std::string& path)

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -112,6 +112,11 @@ public:
     std::shared_ptr<SyncSession> get_existing_session(const std::string& path) const;
     std::shared_ptr<SyncSession> get_existing_active_session(const std::string& path) const;
 
+    // Returns `true` if the SyncManager still contains any existing sessions not yet fully cleaned up.
+    // This will return true as long as there is an external reference to a session object, no matter
+    // the state of that session.
+    bool has_existing_sessions();
+
     // If the metadata manager is configured, perform an update. Returns `true` iff the code was run.
     bool perform_metadata_update(std::function<void(const SyncMetadataManager&)> update_function) const;
 
@@ -215,6 +220,10 @@ private:
     // Sessions remove themselves from this map by calling `unregister_session` once they're
     // inactive and have performed any necessary cleanup work.
     std::unordered_map<std::string, std::shared_ptr<SyncSession>> m_sessions;
+
+    // Internal method returning `true` if the SyncManager still contains sessions not yet fully closed.
+    // Callers of this method should hold the `m_session_mutex` themselves.
+    bool do_has_existing_sessions();
 
     // The unique identifier of this client.
     util::Optional<std::string> m_client_uuid;


### PR DESCRIPTION
Add helper method that checks if the SyncManager holds any sessions.

The primary use case is cleaning up tests.

We don't seem to have a consistent paradigm for isolating private logic that needs to be guarded by a mutex when called from the public API. It appears that Core heavily uses the `do_xxx` prefix to indicate the unguarded private method and just `xxx` for the public method. So I adopted the same pattern.