### PR TITLE
Reset status flag when updating subscription

### DIFF
--- a/src/sync/partial_sync.cpp
+++ b/src/sync/partial_sync.cpp
@@ -300,6 +300,12 @@ struct ResultSetsColumns {
         query = table.get_column_index(property_query);
         REALM_ASSERT(query != npos);
 
+        error_message = table.get_column_index(property_error_message);
+        REALM_ASSERT(error_message != npos);
+
+        status = table.get_column_index(property_status);
+        REALM_ASSERT(status != npos);
+
         this->matches_property_name = table.get_column_index(property_matches_property_name);
         REALM_ASSERT(this->matches_property_name != npos);
 
@@ -321,6 +327,8 @@ struct ResultSetsColumns {
 
     size_t name;
     size_t query;
+    size_t error_message;
+    size_t status;
     size_t matches_property_name;
     size_t matches_property;
     size_t created_at;
@@ -376,6 +384,11 @@ Row write_subscription(std::string const& object_type, std::string const& name, 
         // TODO: Consider how Binding API's are going to use this. It might make sense to disallow
         // updating TTL using this API and instead require updates to TTL to go through a managed Subscription.
         if (update) {
+            // If the query changed we must reset state to force the server to re-evaluate the subscription.
+            if (table->get_string(columns.query, row_ndx) != query) {
+                table->set_string(columns.error_message, row_ndx, "");
+                table->set_int(columns.status, row_ndx, 0);
+            }
             table->set_string(columns.query, row_ndx, query);
             table->set(columns.time_to_live, row_ndx, time_to_live_ms);
         }

--- a/src/sync/partial_sync.cpp
+++ b/src/sync/partial_sync.cpp
@@ -712,8 +712,6 @@ Subscription& Subscription::operator=(Subscription&&) = default;
 SubscriptionNotificationToken Subscription::add_notification_callback(std::function<void ()> callback)
 {
     auto callback_wrapper = std::make_shared<SubscriptionCallbackWrapper>(SubscriptionCallbackWrapper{callback, none});
-    auto token = std::make_shared<SubscriptionNotificationToken>();
-
     auto result_sets_token = m_result_sets.add_notification_callback([this, callback_wrapper] (CollectionChangeSet, std::exception_ptr) {
         run_callback(*callback_wrapper);
     });

--- a/src/sync/partial_sync.hpp
+++ b/src/sync/partial_sync.hpp
@@ -83,16 +83,31 @@ private:
     util::Optional<Object> result_set_object() const;
 
     void error_occurred(std::exception_ptr);
+    void run_callback(Subscription* subscription, std::function<void()> callback);
 
     ObjectSchema m_object_schema;
 
     mutable Results m_result_sets;
+    // Timestamp indicating when the subscription wrapper is created. This is used when checking the Results notifications
+    // By comparing this timestamp against the real subscriptions `created_at` and `updated_at` fields we can determine
+    // whether the subscription is in progress of being updated or created.
+    Timestamp m_wrapper_created_at;
+
+    // Track the last state reported by the callbacks. This is needed to prevent reporting the same state twice, which
+    // can otherwise happen in some cases. Note, `Complete` should still be allowed to be reported multiple times
+    // since this indicates the underlying subscription has changed. But all other callbacks should only happen once.
+    util::Optional<SubscriptionState> m_last_state;
+
+    // Track the actual underlying subscription object once it is available. This is used to better track
+    // unsubscriptions.
+    util::Optional<Row> m_result_sets_object = none;
 
     struct Notifier;
     _impl::CollectionNotifier::Handle<Notifier> m_notifier;
 
     friend Subscription subscribe(Results const&, util::Optional<std::string>, util::Optional<int64_t> time_to_live, bool update);
     friend void unsubscribe(Subscription&);
+
 };
 
 /// Create a Query-based subscription from the query associated with the `Results`.

--- a/src/sync/partial_sync.hpp
+++ b/src/sync/partial_sync.hpp
@@ -88,7 +88,7 @@ private:
     util::Optional<Object> result_set_object() const;
 
     void error_occurred(std::exception_ptr);
-    void run_callback(Subscription* subscription, SubscriptionCallbackWrapper& callback_wrapper);
+    void run_callback(SubscriptionCallbackWrapper& callback_wrapper);
 
     ObjectSchema m_object_schema;
 

--- a/tests/sync/partial_sync.cpp
+++ b/tests/sync/partial_sync.cpp
@@ -42,6 +42,7 @@
 #include <realm/parser/parser.hpp>
 #include <realm/parser/query_builder.hpp>
 #include <realm/util/optional.hpp>
+#include <sync/partial_sync.hpp>
 
 using namespace realm;
 using namespace std::string_literals;
@@ -616,10 +617,135 @@ TEST_CASE("Query-based Sync", "[sync]") {
            auto table = ObjectStore::table_for_object_type(realm->read_group(), "object_a");
            REQUIRE(table->size() == 3);
         });
-        auto results = results_for_query("number = 3", partial_config, "object_a");
-        auto subscription = partial_sync::subscribe(results, "query"s, none, true);
-        auto table = ObjectStore::table_for_object_type(realm->read_group(), "object_a");
-        EventLoop::main().run_until([&] { return table->size() == 1; });
+
+        subscribe_and_wait("number = 3", partial_config, "object_a", "query"s, none, true, [&](Results, std::exception_ptr error) {
+            REQUIRE(!error);
+            auto table = ObjectStore::table_for_object_type(realm->read_group(), "object_a");
+            REQUIRE(table->size() == 1);
+        });
+    }
+
+    SECTION("The same subscription state should not be reported twice until the Complete state ") {
+        auto results = results_for_query("number > 1", partial_config, "object_a");
+        auto subscription = partial_sync::subscribe(results, "sub"s);
+        bool partial_sync_done = false;
+        std::exception_ptr exception;
+        util::Optional<partial_sync::SubscriptionState> last_state = none;
+        auto token = subscription.add_notification_callback([&] {
+            auto new_state = subscription.state();
+            if (last_state) {
+                REQUIRE(last_state.value() != new_state);
+            }
+            last_state = new_state;
+            switch (new_state) {
+                case partial_sync::SubscriptionState::Creating:
+                case partial_sync::SubscriptionState::Pending:
+                case partial_sync::SubscriptionState::Error:
+                case partial_sync::SubscriptionState::Invalidated:
+                    break;
+                case partial_sync::SubscriptionState::Complete:
+                    partial_sync_done = true;
+                    break;
+                default:
+                    throw std::logic_error(util::format("Unexpected state: %1", static_cast<uint8_t>(subscription.state())));
+            }
+        });
+
+        // Also create the same subscription on the UI thread to force the subscription notifications to run.
+        // This could potentially trigger the Pending state twice if this isn't prevented by the notification
+        // handling.
+        auto realm = Realm::get_shared_realm(partial_config);
+        realm->begin_transaction();
+        partial_sync::subscribe_blocking(results, "sub"s);
+        realm->commit_transaction();
+
+        EventLoop::main().run_until([&] { return partial_sync_done; });
+    }
+
+    SECTION("Manually deleting a Subscription also triggers the Invalidated state") {
+        auto results = results_for_query("number > 1", partial_config, "object_a");
+        auto subscription = partial_sync::subscribe(results, "sub"s);
+        bool subscription_created = false;
+        bool subscription_deleted = false;
+        std::exception_ptr exception;
+        util::Optional<partial_sync::SubscriptionState> last_state = none;
+        auto token = subscription.add_notification_callback([&] {
+            if (subscription_created)
+                // Next state after creating the subscription should be that it is deleted
+                REQUIRE(subscription.state() == partial_sync::SubscriptionState::Invalidated);
+
+            switch (subscription.state()) {
+                case partial_sync::SubscriptionState::Creating:
+                case partial_sync::SubscriptionState::Pending:
+                case partial_sync::SubscriptionState::Error:
+                    break;
+                case partial_sync::SubscriptionState::Complete:
+                    subscription_created = true;
+                    break;
+                case partial_sync::SubscriptionState::Invalidated:
+                    subscription_deleted = true;
+                    break;
+                default:
+                    throw std::logic_error(util::format("Unexpected state: %1", static_cast<uint8_t>(subscription.state())));
+            }
+        });
+
+        EventLoop::main().run_until([&] { return subscription_created; });
+
+        auto realm = Realm::get_shared_realm(partial_config);
+        realm->begin_transaction();
+        Results subs = results_for_query("name = 'sub'", partial_config, partial_sync::result_sets_type_name);
+        subs.clear();
+        realm->commit_transaction();
+
+        EventLoop::main().run_until([&] { return subscription_deleted; });
+    }
+
+    SECTION("Updating a subscription will not report Complete from a previous subscription") {
+        // Due to the asynchronous nature of updating subscriptions and listening to changes
+        // in the query that returns the subscription there is a small chance that the query
+        // returns before the update does. In that case, the previous state of the subscription
+        // will be returned, i.e you might see `Complete` before it goes into `Pending`.
+        // This test
+        auto realm = Realm::get_shared_realm(partial_config);
+
+        // Create initial subscription
+        subscribe_and_wait("number > 1", partial_config, "object_a", "query"s, [&](Results, std::exception_ptr error) {
+            REQUIRE(!error);
+            auto table = ObjectStore::table_for_object_type(realm->read_group(), "object_a");
+            REQUIRE(table->size() == 2);
+        });
+
+        // Start an update and verify that Complete is not called before Pending
+        // Note: This is racy, so not 100% reproducible
+        for (size_t i = 0; i < 100; ++i) {
+            auto results = results_for_query((i % 2 == 0) ? "truepredicate" : "falsepredicate", partial_config, "object_a");
+            auto subscription = partial_sync::subscribe(results, "query"s, none, true);
+            bool seen_completed_state = false;
+            bool seen_pending_state = false;
+            bool seen_complete_before_pending = false;
+            auto token = subscription.add_notification_callback([&] {
+                switch (subscription.state()) {
+                    case partial_sync::SubscriptionState::Creating:
+                    case partial_sync::SubscriptionState::Error:
+                    case partial_sync::SubscriptionState::Invalidated:
+                        break;
+                    case partial_sync::SubscriptionState::Pending:
+                        seen_complete_before_pending = seen_completed_state;
+                        seen_pending_state = true;
+                        break;
+                    case partial_sync::SubscriptionState::Complete:
+                        seen_completed_state = true;
+                        break;
+                    default:
+                        throw std::logic_error(util::format("Unexpected state: %1", static_cast<uint8_t>(subscription.state())));
+                }
+            });
+            EventLoop::main().run_until([&] { return seen_pending_state; });
+            REQUIRE(!seen_complete_before_pending);
+            EventLoop::main().run_until([&] { return seen_completed_state; });
+            REQUIRE(results.size() == ((i % 2 == 0) ? 3 : 0));
+        }
     }
 }
 

--- a/tests/sync/partial_sync.cpp
+++ b/tests/sync/partial_sync.cpp
@@ -608,6 +608,21 @@ TEST_CASE("Query-based Sync", "[sync]") {
             REQUIRE(results_contains(results, {2, 2, "partial"}));
         });
     }
+
+    SECTION("Updating a subscriptions query will download new data and remove old data") {
+        auto realm = Realm::get_shared_realm(partial_config);
+        subscribe_and_wait("truepredicate", partial_config, "object_a", "query"s, [&](Results, std::exception_ptr error) {
+            REQUIRE(!error);
+            auto table = ObjectStore::table_for_object_type(realm->read_group(), "object_a");
+            REQUIRE(table->size() == 3);
+        });
+
+        subscribe_and_wait("number = 3", partial_config, "object_a", "query"s, none, true, [&](Results, std::exception_ptr error) {
+            REQUIRE(!error);
+            auto table = ObjectStore::table_for_object_type(realm->read_group(), "object_a");
+            REQUIRE(table->size() == 1);
+        });
+    }
 }
 
 TEST_CASE("Query-based Sync error checking", "[sync]") {

--- a/tests/sync/partial_sync.cpp
+++ b/tests/sync/partial_sync.cpp
@@ -612,16 +612,14 @@ TEST_CASE("Query-based Sync", "[sync]") {
     SECTION("Updating a subscriptions query will download new data and remove old data") {
         auto realm = Realm::get_shared_realm(partial_config);
         subscribe_and_wait("truepredicate", partial_config, "object_a", "query"s, [&](Results, std::exception_ptr error) {
-            REQUIRE(!error);
-            auto table = ObjectStore::table_for_object_type(realm->read_group(), "object_a");
-            REQUIRE(table->size() == 3);
+           REQUIRE(!error);
+           auto table = ObjectStore::table_for_object_type(realm->read_group(), "object_a");
+           REQUIRE(table->size() == 3);
         });
-
-        subscribe_and_wait("number = 3", partial_config, "object_a", "query"s, none, true, [&](Results, std::exception_ptr error) {
-            REQUIRE(!error);
-            auto table = ObjectStore::table_for_object_type(realm->read_group(), "object_a");
-            REQUIRE(table->size() == 1);
-        });
+        auto results = results_for_query("number = 3", partial_config, "object_a");
+        auto subscription = partial_sync::subscribe(results, "query"s, none, true);
+        auto table = ObjectStore::table_for_object_type(realm->read_group(), "object_a");
+        EventLoop::main().run_until([&] { return table->size() == 1; });
     }
 }
 


### PR DESCRIPTION
It turned out I forgot to reset the status flag when updating a subscription which meant the server never re-evaluated the query. This PR fixes that.

Also, it turned out there was a bunch of race conditions in the subscription notifications. This PR also fixes the following issues:
- The same subscription being reported twice.
- `Invalidated` is now being reported even if the subscription is deleting manually. Previously it was only reported if you used the explicit unsubscribe API.

TODO
- [x] Support for multiple callbacks on the same notification