### PR TITLE
Add support for field aliases to properties 

### DIFF
--- a/src/object.hpp
+++ b/src/object.hpp
@@ -70,6 +70,9 @@ public:
     template<typename ValueType, typename ContextType>
     ValueType get_property_value(ContextType& ctx, StringData prop_name);
 
+    template<typename ValueType, typename ContextType>
+    ValueType get_property_value(ContextType& ctx, const Property& property);
+
     // create an Object from a native representation
     template<typename ValueType, typename ContextType>
     static Object create(ContextType& ctx, std::shared_ptr<Realm> const& realm,

--- a/src/object_accessor.hpp
+++ b/src/object_accessor.hpp
@@ -57,6 +57,12 @@ void Object::set_property_value(ContextType& ctx, StringData prop_name, ValueTyp
 }
 
 template <typename ValueType, typename ContextType>
+ValueType Object::get_property_value(ContextType& ctx, const Property& property)
+{
+    return get_property_value_impl<ValueType>(ctx, property);
+}
+
+template <typename ValueType, typename ContextType>
 ValueType Object::get_property_value(ContextType& ctx, StringData prop_name)
 {
     return get_property_value_impl<ValueType>(ctx, property_for_name(prop_name));

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -247,7 +247,7 @@ void ObjectSchema::validate(Schema const& schema, std::vector<ObjectSchemaValida
     for (auto const& prop: computed_properties) {
         props.emplace_back(&prop);
     }
-\
+
     // Detect duplicated names
     std::sort(props.begin(), props.end(), [](const Property* left, const Property* right) {
         return left->name < right->name;

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -110,12 +110,17 @@ Property *ObjectSchema::property_for_name(StringData name)
 
 Property *ObjectSchema::property_for_alias(StringData alias)
 {
+    // If no alias is defined it is the equivalent of name = alias.
     for (auto& prop : persisted_properties) {
-        if (StringData(prop.alias) == alias || StringData(prop.name) == alias)
+        if ((prop.alias.empty() ? StringData(prop.name) :  StringData(prop.alias)) == alias)
             return &prop;
     }
+
+    // Computed properties are not persisted, so creating an alias for such properties
+    // are a bit pointless since the internal name is already the "alias", but since
+    // this distinction isn't visible in the Property struct we allow it anyway.
     for (auto& prop : computed_properties) {
-        if (StringData(prop.alias) == alias || StringData(prop.name) == alias)
+        if ((prop.alias.empty() ? StringData(prop.name) :  StringData(prop.alias)) == alias)
             return &prop;
     }
     return nullptr;

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -288,9 +288,8 @@ void ObjectSchema::validate(Schema const& schema, std::vector<ObjectSchemaValida
         };
 
         Proxy operator*() { return Proxy{os, exceptions}; }
-
+        ErrorWriter &operator=(const ErrorWriter &) { return *this; }
         ErrorWriter &operator++() { return *this; }
-
         ErrorWriter &operator++(int) { return *this; }
     } writer{*this, exceptions};
     std::set_intersection(public_property_names.begin(), public_property_names.end(),

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -112,8 +112,13 @@ Property *ObjectSchema::property_for_public_name(StringData public_name)
 {
     // If no `public_name` is defined, the internal `name` is also considered the public name.
     for (auto& prop : persisted_properties) {
-        if ((prop.public_name.empty() ? StringData(prop.name) :  StringData(prop.public_name)) == public_name)
-            return &prop;
+        if (prop.public_name.empty()) {
+            if (StringData(prop.name) == public_name)
+                return &prop;
+        } else {
+            if (StringData(prop.public_name) == public_name)
+                return &prop;
+        }
     }
 
     // Computed properties are not persisted, so creating a public name for such properties

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -93,7 +93,8 @@ ObjectSchema::ObjectSchema(Group const& group, StringData name, size_t index) : 
     set_primary_key_property();
 }
 
-Property *ObjectSchema::property_for_name(StringData name) {
+Property *ObjectSchema::property_for_name(StringData name)
+{
     for (auto& prop : persisted_properties) {
         if (StringData(prop.name) == name) {
             return &prop;
@@ -107,11 +108,31 @@ Property *ObjectSchema::property_for_name(StringData name) {
     return nullptr;
 }
 
-const Property *ObjectSchema::property_for_name(StringData name) const {
+Property *ObjectSchema::property_for_alias(StringData alias)
+{
+    for (auto& prop : persisted_properties) {
+        if (StringData(prop.alias.empty() ? prop.name : prop.alias) == alias)
+            return &prop;
+    }
+    for (auto& prop : computed_properties) {
+        if (StringData(prop.alias.empty() ? prop.name : prop.alias) == alias)
+            return &prop;
+    }
+    return nullptr;
+}
+
+const Property *ObjectSchema::property_for_alias(StringData alias) const
+{
+    return const_cast<ObjectSchema *>(this)->property_for_alias(alias);
+}
+
+const Property *ObjectSchema::property_for_name(StringData name) const
+{
     return const_cast<ObjectSchema *>(this)->property_for_name(name);
 }
 
-bool ObjectSchema::property_is_computed(Property const& property) const {
+bool ObjectSchema::property_is_computed(Property const& property) const
+{
     auto end = computed_properties.end();
     return std::find(computed_properties.begin(), end, property) != end;
 }

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -235,6 +235,61 @@ static void validate_property(Schema const& schema,
 
 void ObjectSchema::validate(Schema const& schema, std::vector<ObjectSchemaValidationException>& exceptions) const
 {
+
+    // Merge persisted and computed properties into one list to make it easier to detect duplicates across the
+    // two lists. Sorting the list and comparing adjacent elements is O(log(n)+n) compared to O(n^2) for the simple
+    // solution. We can also eliminate reporting duplicates twice this way.
+    std::vector<const Property*> props;
+    props.reserve(persisted_properties.size() + computed_properties.size());
+    for (auto const& prop: persisted_properties) {
+        props.emplace_back(&prop);
+    }
+    for (auto const& prop: computed_properties) {
+        props.emplace_back(&prop);
+    }
+\
+    // Detect duplicated names
+    std::sort(props.begin(), props.end(), [](const Property* left, const Property* right) {
+        return left->name < right->name;
+    });
+    auto find_next_duplicate_name = [&](auto start) {
+        return std::adjacent_find(start, props.cend(), [](const Property* left, const Property* right) {
+            return left->name == right->name;
+        });
+    };
+    for (auto it = find_next_duplicate_name(props.cbegin()); it != props.cend(); it = find_next_duplicate_name(++it)) {
+        exceptions.emplace_back(ObjectSchemaValidationException("Property '%1' appears more than once in the schema for type '%2'.",
+                                                                (*it)->name, name));
+    }
+
+    // Detect duplicated aliases
+    std::sort(props.begin(), props.end(), [](const Property* left, const Property* right) {
+        return left->alias < right->alias;
+    });
+    auto find_next_duplicate_alias = [&](auto start) {
+        return std::adjacent_find(start, props.cend(), [](const Property* left, const Property* right) {
+            return !left->alias.empty() && left->alias == right->alias;
+        });
+    };
+    for (auto it = find_next_duplicate_alias(props.cbegin()); it != props.cend(); it = find_next_duplicate_alias(++it)) {
+        exceptions.emplace_back(ObjectSchemaValidationException("Alias '%1' appears more than once in the schema for type '%2'.",
+                                                                (*it)->alias, name));
+    }
+
+    // Detect conflicts between aliases and names.
+    // Technically, nothing should prevent supporting this, expect it being potentially confusing to
+    // end users, so for now we disallow it.
+    // We cannot use the above approach for detecting conflicts between aliases and names. In this case, do the slow
+    // comparison and accept that the same error will be reported as both `name vs. alias` and `alias vs. name` conflict.
+    for (auto prop: props) {
+        for (auto other_prop: props) {
+            if (!prop->alias.empty() && prop->alias == other_prop->name) {
+                exceptions.emplace_back(ObjectSchemaValidationException("Property '%1' has an alias '%2' that conflicts with a property of the same name.",
+                                                                        prop->name, prop->alias));
+            }
+        }
+    }
+
     const Property *primary = nullptr;
     for (auto const& prop : persisted_properties) {
         validate_property(schema, name, prop, &primary, exceptions);

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -283,7 +283,7 @@ void ObjectSchema::validate(Schema const& schema, std::vector<ObjectSchemaValida
     // comparison and accept that the same error will be reported as both `name vs. alias` and `alias vs. name` conflict.
     for (auto prop: props) {
         for (auto other_prop: props) {
-            if (!prop->alias.empty() && prop->alias == other_prop->name) {
+            if (prop != other_prop && !prop->alias.empty() && prop->alias == other_prop->name) {
                 exceptions.emplace_back(ObjectSchemaValidationException("Property '%1' has an alias '%2' that conflicts with a property of the same name.",
                                                                         prop->name, prop->alias));
             }

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -272,8 +272,8 @@ void ObjectSchema::validate(Schema const& schema, std::vector<ObjectSchemaValida
 
     // Check that no aliases conflict with property names
     struct ErrorWriter {
-        const ObjectSchema* os;
-        std::vector<ObjectSchemaValidationException>* exceptions;
+        ObjectSchema const &os;
+        std::vector<ObjectSchemaValidationException> &exceptions;
 
         struct Proxy {
             ObjectSchema const &os;
@@ -287,10 +287,12 @@ void ObjectSchema::validate(Schema const& schema, std::vector<ObjectSchemaValida
             }
         };
 
-        Proxy operator*() { return Proxy{*os, *exceptions}; }
+        Proxy operator*() { return Proxy{os, exceptions}; }
+
         ErrorWriter &operator++() { return *this; }
+
         ErrorWriter &operator++(int) { return *this; }
-    } writer{this, &exceptions};
+    } writer{*this, exceptions};
     std::set_intersection(public_property_names.begin(), public_property_names.end(),
                           internal_property_names.begin(), internal_property_names.end(), writer);
 

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -111,11 +111,11 @@ Property *ObjectSchema::property_for_name(StringData name)
 Property *ObjectSchema::property_for_alias(StringData alias)
 {
     for (auto& prop : persisted_properties) {
-        if (StringData(prop.alias) == alias)
+        if (StringData(prop.alias) == alias || StringData(prop.name) == alias)
             return &prop;
     }
     for (auto& prop : computed_properties) {
-        if (StringData(prop.alias) == alias)
+        if (StringData(prop.alias) == alias || StringData(prop.name) == alias)
             return &prop;
     }
     return nullptr;

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -111,11 +111,11 @@ Property *ObjectSchema::property_for_name(StringData name)
 Property *ObjectSchema::property_for_alias(StringData alias)
 {
     for (auto& prop : persisted_properties) {
-        if (StringData(prop.alias.empty() ? prop.name : prop.alias) == alias)
+        if (StringData(prop.alias) == alias)
             return &prop;
     }
     for (auto& prop : computed_properties) {
-        if (StringData(prop.alias.empty() ? prop.name : prop.alias) == alias)
+        if (StringData(prop.alias) == alias)
             return &prop;
     }
     return nullptr;

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -272,8 +272,8 @@ void ObjectSchema::validate(Schema const& schema, std::vector<ObjectSchemaValida
 
     // Check that no aliases conflict with property names
     struct ErrorWriter {
-        ObjectSchema const &os;
-        std::vector<ObjectSchemaValidationException> &exceptions;
+        const ObjectSchema* os;
+        std::vector<ObjectSchemaValidationException>* exceptions;
 
         struct Proxy {
             ObjectSchema const &os;
@@ -287,12 +287,10 @@ void ObjectSchema::validate(Schema const& schema, std::vector<ObjectSchemaValida
             }
         };
 
-        Proxy operator*() { return Proxy{os, exceptions}; }
-
+        Proxy operator*() { return Proxy{*os, *exceptions}; }
         ErrorWriter &operator++() { return *this; }
-
         ErrorWriter &operator++(int) { return *this; }
-    } writer{*this, exceptions};
+    } writer{this, &exceptions};
     std::set_intersection(public_property_names.begin(), public_property_names.end(),
                           internal_property_names.begin(), internal_property_names.end(), writer);
 

--- a/src/object_schema.hpp
+++ b/src/object_schema.hpp
@@ -49,6 +49,8 @@ public:
     std::vector<Property> computed_properties;
     std::string primary_key;
 
+    Property *property_for_alias(StringData alias);
+    const Property *property_for_alias(StringData alias) const;
     Property *property_for_name(StringData name);
     const Property *property_for_name(StringData name) const;
     Property *primary_key_property() {

--- a/src/object_schema.hpp
+++ b/src/object_schema.hpp
@@ -49,8 +49,8 @@ public:
     std::vector<Property> computed_properties;
     std::string primary_key;
 
-    Property *property_for_alias(StringData alias);
-    const Property *property_for_alias(StringData alias) const;
+    Property *property_for_public_name(StringData public_name);
+    const Property *property_for_public_name(StringData public_name) const;
     Property *property_for_name(StringData name);
     const Property *property_for_name(StringData name) const;
     Property *primary_key_property() {

--- a/src/property.hpp
+++ b/src/property.hpp
@@ -68,7 +68,7 @@ struct Property {
     // The public name used by the binding to represent the internal column name in the Realm file. Bindings can use
     // this to expose a different name in the binding API, e.g. to map between different naming conventions.
     //
-    // Public names are only ever used defined, they are not persisted on disk, so reading the schema from the file
+    // Public names are only ever user defined, they are not persisted on disk, so reading the schema from the file
     // will leave this field empty. If `public_name` is empty, the internal and public name are considered to be the same.
     //
     // ObjectStore will ensure that no conflicts occur between persisted properties and the public name, so

--- a/src/property.hpp
+++ b/src/property.hpp
@@ -63,6 +63,7 @@ struct Property {
     using IsIndexed = util::TaggedBool<class IsIndexedTag>;
 
     std::string name;
+    std::string alias;
     PropertyType type = PropertyType::Int;
     std::string object_type;
     std::string link_origin_property_name;
@@ -73,10 +74,10 @@ struct Property {
 
     Property() = default;
 
-    Property(std::string name, PropertyType type, IsPrimary primary = false, IsIndexed indexed = false);
+    Property(std::string name, PropertyType type, IsPrimary primary = false, IsIndexed indexed = false, std::string alias = "");
 
     Property(std::string name, PropertyType type, std::string object_type,
-             std::string link_origin_property_name = "");
+             std::string link_origin_property_name = "", std::string alias = "");
 
     Property(Property const&) = default;
     Property(Property&&) = default;
@@ -196,21 +197,25 @@ static const char *string_for_property_type(PropertyType type)
 }
 
 inline Property::Property(std::string name, PropertyType type,
-                          IsPrimary primary, IsIndexed indexed)
+                          IsPrimary primary, IsIndexed indexed,
+                          std::string alias)
 : name(std::move(name))
 , type(type)
 , is_primary(primary)
 , is_indexed(indexed)
+, alias(std::move(alias))
 {
 }
 
 inline Property::Property(std::string name, PropertyType type,
                           std::string object_type,
-                          std::string link_origin_property_name)
+                          std::string link_origin_property_name,
+                          std::string alias)
 : name(std::move(name))
 , type(type)
 , object_type(std::move(object_type))
 , link_origin_property_name(std::move(link_origin_property_name))
+, alias(std::move(alias))
 {
 }
 

--- a/src/property.hpp
+++ b/src/property.hpp
@@ -65,18 +65,21 @@ struct Property {
     // The internal column name used in the Realm file.
     std::string name;
 
-    // An alias for the internal column names in the Realm file. Bindings can use to expose a different name,
-    // e.g. to map between different naming conventions.
+    // The public name used by the binding to represent the internal column name in the Realm file. Bindings can use
+    // this to expose a different name in the binding API, e.g. to map between different naming conventions.
     //
-    // ObjectStore will ensure that no conflicts occur between persisted properties and the alias, so
-    // an alias is just as unique an identifier as the property name in the file.
+    // Public names are only ever used defined, they are not persisted on disk, so reading the schema from the file
+    // will leave this field empty. If `public_name` is empty, the internal and public name are considered to be the same.
     //
-    // In order to respect aliases bindings should use `ObjectSchema::property_for_alias()` in the schema
-    // and `Object::value_for_property()` in the Object accessor for reading fields defined by an alias.
+    // ObjectStore will ensure that no conflicts occur between persisted properties and the public name, so
+    // the public name is just as unique an identifier as the internal name in the file.
+    //
+    // In order to respect public names bindings should use `ObjectSchema::property_for_public_name()` in the schema
+    // and `Object::value_for_property()` in the Object accessor for reading fields defined by the public name.
     //
     // For queries, bindings should provide an appropriate `KeyPathMapping` definition. Bindings are responsible
     // for creating this.
-    std::string alias;
+    std::string public_name;
     PropertyType type = PropertyType::Int;
     std::string object_type;
     std::string link_origin_property_name;
@@ -87,10 +90,10 @@ struct Property {
 
     Property() = default;
 
-    Property(std::string name, PropertyType type, IsPrimary primary = false, IsIndexed indexed = false, std::string alias = "");
+    Property(std::string name, PropertyType type, IsPrimary primary = false, IsIndexed indexed = false, std::string public_name = "");
 
     Property(std::string name, PropertyType type, std::string object_type,
-             std::string link_origin_property_name = "", std::string alias = "");
+             std::string link_origin_property_name = "", std::string public_name = "");
 
     Property(Property const&) = default;
     Property(Property&&) = default;
@@ -211,9 +214,9 @@ static const char *string_for_property_type(PropertyType type)
 
 inline Property::Property(std::string name, PropertyType type,
                           IsPrimary primary, IsIndexed indexed,
-                          std::string alias)
+                          std::string public_name)
 : name(std::move(name))
-, alias(std::move(alias))
+, public_name(std::move(public_name))
 , type(type)
 , is_primary(primary)
 , is_indexed(indexed)
@@ -223,9 +226,9 @@ inline Property::Property(std::string name, PropertyType type,
 inline Property::Property(std::string name, PropertyType type,
                           std::string object_type,
                           std::string link_origin_property_name,
-                          std::string alias)
+                          std::string public_name)
 : name(std::move(name))
-, alias(std::move(alias))
+, public_name(std::move(public_name))
 , type(type)
 , object_type(std::move(object_type))
 , link_origin_property_name(std::move(link_origin_property_name))

--- a/src/property.hpp
+++ b/src/property.hpp
@@ -65,18 +65,17 @@ struct Property {
     // The internal column name used in the Realm file.
     std::string name;
 
-    // An alias for the internal column names in the Real file. Bindings can use to expose a different name,
+    // An alias for the internal column names in the Realm file. Bindings can use to expose a different name,
     // e.g. to map between different naming conventions.
-    //
-    // If no alias is defined a property `alias` is equal to its `name`.
     //
     // ObjectStore will ensure that no conflicts occur between persisted properties and the alias, so
     // an alias is just as unique an identifier as the property name in the file.
     //
-    // In order to respect aliases bindings should use `ObjectSchema::property_for_alias()`
-    // and XXX for read fields defined by an alias.
-    // If alias are allowed in queries, an XXX must be parsed to XXX. It is up to bindings to
-    // keep track of this.
+    // In order to respect aliases bindings should use `ObjectSchema::property_for_alias()` in the schema
+    // and `Object::value_for_property()` in the Object accessor for reading fields defined by an alias.
+    //
+    // For queries, bindings should provide an appropriate `KeyPathMapper` definition. Bindings are responsible
+    // for creating this.
     std::string alias;
     PropertyType type = PropertyType::Int;
     std::string object_type;

--- a/src/property.hpp
+++ b/src/property.hpp
@@ -74,7 +74,7 @@ struct Property {
     // In order to respect aliases bindings should use `ObjectSchema::property_for_alias()` in the schema
     // and `Object::value_for_property()` in the Object accessor for reading fields defined by an alias.
     //
-    // For queries, bindings should provide an appropriate `KeyPathMapper` definition. Bindings are responsible
+    // For queries, bindings should provide an appropriate `KeyPathMapping` definition. Bindings are responsible
     // for creating this.
     std::string alias;
     PropertyType type = PropertyType::Int;

--- a/src/property.hpp
+++ b/src/property.hpp
@@ -62,7 +62,21 @@ struct Property {
     using IsPrimary = util::TaggedBool<class IsPrimaryTag>;
     using IsIndexed = util::TaggedBool<class IsIndexedTag>;
 
+    // The internal column name used in the Realm file.
     std::string name;
+
+    // An alias for the internal column names in the Real file. Bindings can use to expose a different name,
+    // e.g. to map between different naming conventions.
+    //
+    // If no alias is defined a property `alias` is equal to its `name`.
+    //
+    // ObjectStore will ensure that no conflicts occur between persisted properties and the alias, so
+    // an alias is just as unique an identifier as the property name in the file.
+    //
+    // In order to respect aliases bindings should use `ObjectSchema::property_for_alias()`
+    // and XXX for read fields defined by an alias.
+    // If alias are allowed in queries, an XXX must be parsed to XXX. It is up to bindings to
+    // keep track of this.
     std::string alias;
     PropertyType type = PropertyType::Int;
     std::string object_type;
@@ -200,10 +214,10 @@ inline Property::Property(std::string name, PropertyType type,
                           IsPrimary primary, IsIndexed indexed,
                           std::string alias)
 : name(std::move(name))
+, alias(std::move(alias))
 , type(type)
 , is_primary(primary)
 , is_indexed(indexed)
-, alias(std::move(alias))
 {
 }
 
@@ -212,10 +226,10 @@ inline Property::Property(std::string name, PropertyType type,
                           std::string link_origin_property_name,
                           std::string alias)
 : name(std::move(name))
+, alias(std::move(alias))
 , type(type)
 , object_type(std::move(object_type))
 , link_origin_property_name(std::move(link_origin_property_name))
-, alias(std::move(alias))
 {
 }
 

--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -80,6 +80,7 @@ void Schema::validate() const
 {
     std::vector<ObjectSchemaValidationException> exceptions;
 
+    // As the types are added sorted by name, we can detect duplicates by just looking at the following element.
     auto find_next_duplicate = [&](const_iterator start) {
         return std::adjacent_find(start, cend(), [](ObjectSchema const& lft, ObjectSchema const& rgt) {
             return lft.name == rgt.name;

--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -108,8 +108,8 @@ TEST_CASE("ObjectSchema") {
         };
 
         REQUIRE(schema.find("object")->property_for_public_name("value") == nullptr);
-        REQUIRE(schema.find("object")->property_for_public_name("alias")->name == std::string("value"));
-        REQUIRE(schema.find("object")->property_for_public_name("other_value")->name == std::string("other_value"));
+        REQUIRE(schema.find("object")->property_for_public_name("alias")->name == "value");
+        REQUIRE(schema.find("object")->property_for_public_name("other_value")->name == "other_value");
     }
 
     SECTION("from a Group") {
@@ -622,9 +622,9 @@ TEST_CASE("Schema") {
             };
 
             REQUIRE_THROWS_CONTAINING(schema.validate(),
-                  "- Property 'field1' has an alias 'field2' that conflicts with a property of the same name.\n"
-                  "- Property 'field2' has an alias 'parent' that conflicts with a property of the same name.\n"
-                  "- Property 'parent' has an alias 'field1' that conflicts with a property of the same name.");
+                  "- Property 'object.parent' has an alias 'field1' that conflicts with a property of the same name.\n"
+                  "- Property 'object.field1' has an alias 'field2' that conflicts with a property of the same name.\n"
+                  "- Property 'object.field2' has an alias 'parent' that conflicts with a property of the same name.");
         }
     }
 

--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #include "catch.hpp"
+#include "util/test_file.hpp"
 
 #include "object_schema.hpp"
 #include "object_store.hpp"
@@ -26,7 +27,6 @@
 #include <realm/descriptor.hpp>
 #include <realm/group.hpp>
 #include <realm/table.hpp>
-#include <util/test_file.hpp>
 
 using namespace realm;
 
@@ -99,15 +99,17 @@ TEST_CASE("ObjectSchema") {
         REQUIRE(realm->schema().find("object")->property_for_name("value")->alias == "alias");
     }
 
-    SECTION("looking up properties by alias only matches the alias") {
+    SECTION("looking up properties by alias matches name if alias is not set") {
         auto schema = Schema{
             {"object", {
-               {"value", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{false}, "alias"}
+               {"value", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{false}, "alias"},
+               {"other_value", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{false}}
             }},
         };
 
         REQUIRE(schema.find("object")->property_for_alias("value") == nullptr);
         REQUIRE(schema.find("object")->property_for_alias("alias")->name == std::string("value"));
+        REQUIRE(schema.find("object")->property_for_alias("other_value")->name == std::string("other_value"));
     }
 
     SECTION("from a Group") {

--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -581,6 +581,27 @@ TEST_CASE("Schema") {
                   "- Property 'parent' appears more than once in the schema for type 'object'.");
         }
 
+        SECTION("rejects schema if all properties have the same name") {
+            Schema schema = {
+                {"object", {
+                    {"field", PropertyType::Int},
+                    {"otherField", PropertyType::Int},
+                    {"field", PropertyType::Int},
+                    {"otherField", PropertyType::Int},
+                    {"field", PropertyType::Int},
+                    {"otherField", PropertyType::Int},
+                    {"field", PropertyType::Int},
+                    {"otherField", PropertyType::Int},
+                    {"field", PropertyType::Int},
+                    {"otherField", PropertyType::Int},
+                }}
+            };
+
+            REQUIRE_THROWS_CONTAINING(schema.validate(),
+                    "- Property 'field' appears more than once in the schema for type 'object'.\n"
+                    "- Property 'otherField' appears more than once in the schema for type 'object'.");
+        }
+
         SECTION("rejects properties with the same alias") {
             Schema schema = {
                 {"object", {

--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -572,13 +572,21 @@ TEST_CASE("Schema") {
             Schema schema = {
                 {"object", {
                     {"child", PropertyType::Object|PropertyType::Nullable, "object"},
+
+                    // Alias == Name on computed property
                     {"parentA", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{false}, "_parent"},
+
+                    // Name == Alias on other property
                     {"fieldA", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{false}, "_field1"},
                     {"fieldB", PropertyType::String, Property::IsPrimary{false}, Property::IsIndexed{false}, "_field2"},
                     {"fieldC", PropertyType::String, Property::IsPrimary{false}, Property::IsIndexed{false}, "_field1"},
                     {"fieldD", PropertyType::String, Property::IsPrimary{false}, Property::IsIndexed{false}, "_field2"},
                     {"fieldE", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{false}, "_field1"},
+
+                    // Name == Alias
+                    {"fieldF", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{false}, "fieldF"},
                 }, {
+                    // Computed property alias == name on persisted property
                     {"parentB", PropertyType::Array|PropertyType::LinkingObjects, "object", "child", "_parent"}
                 }}
             };

--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -622,9 +622,9 @@ TEST_CASE("Schema") {
             };
 
             REQUIRE_THROWS_CONTAINING(schema.validate(),
-                  "- Property 'parent' has an alias 'field1' that conflicts with a property of the same name.\n"
                   "- Property 'field1' has an alias 'field2' that conflicts with a property of the same name.\n"
-                  "- Property 'field2' has an alias 'parent' that conflicts with a property of the same name.");
+                  "- Property 'field2' has an alias 'parent' that conflicts with a property of the same name.\n"
+                  "- Property 'parent' has an alias 'field1' that conflicts with a property of the same name.");
         }
     }
 

--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -26,6 +26,7 @@
 #include <realm/descriptor.hpp>
 #include <realm/group.hpp>
 #include <realm/table.hpp>
+#include <util/test_file.hpp>
 
 using namespace realm;
 
@@ -84,6 +85,20 @@ struct StringMaker<SchemaChange> {
     REQUIRE_THROWS_WITH(expr, Catch::Matchers::Contains(msg))
 
 TEST_CASE("ObjectSchema") {
+
+    SECTION("Aliases are still present in schema returned from the Realm") {
+        TestFile config;
+        config.schema_version = 1;
+        config.schema = Schema{
+                {"object", {
+                   {"value", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{false}, "alias"}
+               }},
+        };
+
+        auto realm = Realm::get_shared_realm(config);
+        REQUIRE(realm->schema().find("object")->property_for_name("value")->alias == "alias");
+    }
+
     SECTION("from a Group") {
         Group g;
         TableRef pk = g.add_table("pk");

--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -99,6 +99,17 @@ TEST_CASE("ObjectSchema") {
         REQUIRE(realm->schema().find("object")->property_for_name("value")->alias == "alias");
     }
 
+    SECTION("looking up properties by alias only matches the alias") {
+        auto schema = Schema{
+            {"object", {
+               {"value", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{false}, "alias"}
+            }},
+        };
+
+        REQUIRE(schema.find("object")->property_for_alias("value") == nullptr);
+        REQUIRE(schema.find("object")->property_for_alias("alias")->name == std::string("value"));
+    }
+
     SECTION("from a Group") {
         Group g;
         TableRef pk = g.add_table("pk");

--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -96,7 +96,7 @@ TEST_CASE("ObjectSchema") {
         };
 
         auto realm = Realm::get_shared_realm(config);
-        REQUIRE(realm->schema().find("object")->property_for_name("value")->alias == "alias");
+        REQUIRE(realm->schema().find("object")->property_for_name("value")->public_name == "alias");
     }
 
     SECTION("looking up properties by alias matches name if alias is not set") {
@@ -107,9 +107,9 @@ TEST_CASE("ObjectSchema") {
             }},
         };
 
-        REQUIRE(schema.find("object")->property_for_alias("value") == nullptr);
-        REQUIRE(schema.find("object")->property_for_alias("alias")->name == std::string("value"));
-        REQUIRE(schema.find("object")->property_for_alias("other_value")->name == std::string("other_value"));
+        REQUIRE(schema.find("object")->property_for_public_name("value") == nullptr);
+        REQUIRE(schema.find("object")->property_for_public_name("alias")->name == std::string("value"));
+        REQUIRE(schema.find("object")->property_for_public_name("other_value")->name == std::string("other_value"));
     }
 
     SECTION("from a Group") {


### PR DESCRIPTION
In order to avoid breaking changes in JS (see https://github.com/realm/realm-js/issues/2266), we need to have support for re-mapping fields in the JS schema. This feature is already present in Java, Cocoa and the core query engine, so this PR just adds the tempory data to the schema objects in Object Store similar to computed properties. 

**Usage in bindings**
Bindings are responsible for setting and using the alias field.
Reading/Writing fields are supported by overriding the `Object::value_for_property` method in the Object Accessor. 
Queries support this by creating a specific `KeyPathMapping` with the alias fields.

See https://github.com/realm/realm-js/pull/2306 for an example on how this is used.

**Performance considerations:**
A few comments about performance impact:

We don't currently check if properties are in the schema twice. This PR fixes this. It has currently not been a problem because most (all?) bindings use maps/dictionaries to store properties which effectively makes this impossible. But it is possible to get into this situation using the C++ API's.

With this PR we now validate that no duplicate names, aliases or conflicts between the two exists. Unfortunately, this runs in `(O(n*log(n) + n) + (O(n*log(n) + n) + O(n^2)` in order to avoid duplicated properties being reported multiple times. This is similar to how duplicated types  are reported in `schema.cpp`

This runtime penalty is a bit heavy, so I'm not 100% sure we want to keep this behaviour. Some alternatives could  be:

* Remove the check for duplicated names and document it since all bindings already handle this by using appropriate dictionary types.  This will remove a `(O(n*log(n) + n)` check.

* Remove the check for conflicts between names and aliases. Nothing prevents us from supporting this expect perhaps users being confused by reported names mapping to different things. Removing this would remove an `O(n^2)`

* We could combine all 3 checks into one `O(n^2)` run, the downside would be that duplicated names and aliases are reported multiple times, once for each duplicate.

* The minimal check we would need is checking for duplicated aliases which are not caught by using dictionaries in bindings. Only having this would run in `(O(n*log(n) + n)`.

For now, I have opted for the most user-friendly approach, but thoughts on the above are appreciated.


**Performance update**

The checks now run in pure `O(n^2)` and then we only sort any name/alias conflicts afterwards.

