### PR TITLE
Create columns rather than assert their existence

### DIFF
--- a/src/sync/partial_sync.cpp
+++ b/src/sync/partial_sync.cpp
@@ -125,19 +125,26 @@ void initialize_schema(Group& group)
     if (!table) {
         // Create the schema required by Sync
         table = sync::create_table(group, result_sets_table_name);
-        table->add_column(type_String, property_query);
-        table->add_column(type_String, property_matches_property_name);
-        table->add_column(type_Int, property_status);
-        table->add_column(type_String, property_error_message);
-        table->add_column(type_Int, property_query_parse_counter);
     }
-    else {
-        // The table already existed, so it should have all of the columns that are in the shared schema.
-        REALM_ASSERT(table->get_column_index(property_query) != npos);
-        REALM_ASSERT(table->get_column_index(property_matches_property_name) != npos);
-        REALM_ASSERT(table->get_column_index(property_status) != npos);
-        REALM_ASSERT(table->get_column_index(property_error_message) != npos);
-        REALM_ASSERT(table->get_column_index(property_query_parse_counter) != npos);
+    
+    if (table->get_column_index(property_query) == npos) {
+        table->add_column(type_String, property_query);
+    }
+    
+    if (table->get_column_index(property_matches_property_name) == npos) {
+        table->add_column(type_String, property_matches_property_name);
+    }
+    
+    if (table->get_column_index(property_status) == npos) {
+        table->add_column(type_Int, property_status);
+    }
+    
+    if (table->get_column_index(property_error_message) == npos) {
+        table->add_column(type_String, property_error_message);
+    }
+    
+    if (table->get_column_index(property_query_parse_counter) == npos) {
+        table->add_column(type_Int, property_query_parse_counter);
     }
 
     // Add columns not required by Sync, but used by the bindings to offer better tracking of subscriptions.


### PR DESCRIPTION
When we explicitly specify the schema for the `__ResultSets` table, we may want to specify a subset of the properties in the SDK (e.g. `query_parse_counter` is not something we care about). In this case, rather than assert that the columns were created by someone, we can just go ahead and create those that are missing.

This is based on https://github.com/realm/realm-object-store/pull/782 because I was working on the .NET implementation of subscription inclusions when I ran into this.