### PR TITLE
Avoid creating Realm instances on the sync worker thread

### DIFF
--- a/src/sync/impl/sync_metadata.hpp
+++ b/src/sync/impl/sync_metadata.hpp
@@ -218,6 +218,8 @@ private:
     SyncFileActionMetadata::Schema m_file_action_schema;
     SyncClientMetadata::Schema m_client_schema;
     std::string m_client_uuid;
+
+    std::shared_ptr<Realm> get_realm() const;
 };
 
 }

--- a/src/sync/impl/sync_metadata.hpp
+++ b/src/sync/impl/sync_metadata.hpp
@@ -185,24 +185,19 @@ public:
     // Return a Results object containing all pending actions.
     SyncFileActionMetadataResults all_pending_actions() const;
 
-    // Delete an existing metadata action given the original name of the Realm it involves.
-    // Returns true iff there was an existing metadata action and it was deleted.
-    bool delete_metadata_action(const std::string&) const;
-
     // Retrieve or create user metadata.
     // Note: if `make_is_absent` is true and the user has been marked for deletion, it will be unmarked.
     util::Optional<SyncUserMetadata> get_or_make_user_metadata(const std::string& identity, const std::string& url,
                                                                bool make_if_absent=true) const;
 
     // Retrieve file action metadata.
-    util::Optional<SyncFileActionMetadata> get_file_action_metadata(const std::string& path) const;
+    util::Optional<SyncFileActionMetadata> get_file_action_metadata(StringData path) const;
 
     // Create file action metadata.
-    SyncFileActionMetadata make_file_action_metadata(const std::string& original_name,
-                                                     const std::string& url,
-                                                     const std::string& local_uuid,
-                                                     SyncFileActionMetadata::Action action,
-                                                     util::Optional<std::string> new_name=none) const;
+    void make_file_action_metadata(StringData original_name, StringData url,
+                                   StringData local_uuid,
+                                   SyncFileActionMetadata::Action action,
+                                   StringData new_name = {}) const;
 
     // Get the unique identifier of this client.
     const std::string& client_uuid() const { return m_client_uuid; }

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -465,12 +465,11 @@ void SyncSession::update_error_and_mark_file_for_deletion(SyncError& error, Shou
     }
     using Action = SyncFileActionMetadata::Action;
     auto action = should_backup == ShouldBackup::yes ? Action::BackUpThenDeleteRealm : Action::DeleteRealm;
-    SyncManager::shared().perform_metadata_update([this,
-                                                   action,
+    SyncManager::shared().perform_metadata_update([this, action,
                                                    original_path=std::move(original_path),
                                                    recovery_path=std::move(recovery_path)](const auto& manager) {
-        manager.make_file_action_metadata(original_path, m_config.realm_url(), m_config.user->identity(),
-                                          action, std::move(recovery_path));
+        auto realm_url = m_config.realm_url();
+        manager.make_file_action_metadata(original_path, realm_url, m_config.user->identity(), action, recovery_path);
     });
 }
 

--- a/tests/sync/metadata.cpp
+++ b/tests/sync/metadata.cpp
@@ -350,7 +350,8 @@ TEST_CASE("sync_metadata: file action metadata", "[sync]") {
 
     SECTION("can be properly constructed") {
         const auto original_name = tmp_dir() + "foobar/test1";
-        auto metadata = manager.make_file_action_metadata(original_name, url_1, local_uuid_1, SyncAction::BackUpThenDeleteRealm);
+        manager.make_file_action_metadata(original_name, url_1, local_uuid_1, SyncAction::BackUpThenDeleteRealm);
+        auto metadata = *manager.get_file_action_metadata(original_name);
         REQUIRE(metadata.original_name() == original_name);
         REQUIRE(metadata.new_name() == none);
         REQUIRE(metadata.action() == SyncAction::BackUpThenDeleteRealm);
@@ -362,14 +363,17 @@ TEST_CASE("sync_metadata: file action metadata", "[sync]") {
         const auto original_name = tmp_dir() + "foobar/test2a";
         const std::string new_name_1 = tmp_dir() + "foobar/test2b";
         const std::string new_name_2 = tmp_dir() + "foobar/test2c";
-        auto metadata_1 = manager.make_file_action_metadata(original_name, url_1, local_uuid_1, SyncAction::BackUpThenDeleteRealm, new_name_1);
+
+        manager.make_file_action_metadata(original_name, url_1, local_uuid_1, SyncAction::BackUpThenDeleteRealm, new_name_1);
+        auto metadata_1 = *manager.get_file_action_metadata(original_name);
         REQUIRE(metadata_1.original_name() == original_name);
         REQUIRE(metadata_1.new_name() == new_name_1);
         REQUIRE(metadata_1.action() == SyncAction::BackUpThenDeleteRealm);
         REQUIRE(metadata_1.url() == url_1);
         REQUIRE(metadata_1.user_local_uuid() == local_uuid_1);
 
-        auto metadata_2 = manager.make_file_action_metadata(original_name, url_2, local_uuid_2, SyncAction::DeleteRealm, new_name_2);
+        manager.make_file_action_metadata(original_name, url_2, local_uuid_2, SyncAction::DeleteRealm, new_name_2);
+        auto metadata_2 = *manager.get_file_action_metadata(original_name);
         REQUIRE(metadata_1.original_name() == original_name);
         REQUIRE(metadata_1.new_name() == new_name_2);
         REQUIRE(metadata_1.action() == SyncAction::DeleteRealm);
@@ -388,17 +392,17 @@ TEST_CASE("sync_metadata: file action metadata APIs", "[sync]") {
         const auto filename1 = tmp_dir() + "foobar/file1";
         const auto filename2 = tmp_dir() + "foobar/file2";
         const auto filename3 = tmp_dir() + "foobar/file3";
-        auto first = manager.make_file_action_metadata(filename1, "asdf", "realm://realm.example.com/1", SyncAction::BackUpThenDeleteRealm);
-        auto second = manager.make_file_action_metadata(filename2, "asdf", "realm://realm.example.com/2", SyncAction::BackUpThenDeleteRealm);
-        auto third = manager.make_file_action_metadata(filename3, "asdf", "realm://realm.example.com/3", SyncAction::BackUpThenDeleteRealm);
+        manager.make_file_action_metadata(filename1, "asdf", "realm://realm.example.com/1", SyncAction::BackUpThenDeleteRealm);
+        manager.make_file_action_metadata(filename2, "asdf", "realm://realm.example.com/2", SyncAction::BackUpThenDeleteRealm);
+        manager.make_file_action_metadata(filename3, "asdf", "realm://realm.example.com/3", SyncAction::BackUpThenDeleteRealm);
         auto actions = manager.all_pending_actions();
         REQUIRE(actions.size() == 3);
         REQUIRE(results_contains_original_name(actions, filename1));
         REQUIRE(results_contains_original_name(actions, filename2));
         REQUIRE(results_contains_original_name(actions, filename3));
-        first.remove();
-        second.remove();
-        third.remove();
+        manager.get_file_action_metadata(filename1)->remove();
+        manager.get_file_action_metadata(filename2)->remove();
+        manager.get_file_action_metadata(filename3)->remove();
         REQUIRE(actions.size() == 0);
     }
 }

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -332,9 +332,9 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
 
     SECTION("Action::DeleteRealm") {
         // Create some file actions
-        auto a1 = manager.make_file_action_metadata(realm_path_1, realm_url, "user1", Action::DeleteRealm);
-        auto a2 = manager.make_file_action_metadata(realm_path_2, realm_url, "user2", Action::DeleteRealm);
-        auto a3 = manager.make_file_action_metadata(realm_path_3, realm_url, "user3", Action::DeleteRealm);
+        manager.make_file_action_metadata(realm_path_1, realm_url, "user1", Action::DeleteRealm);
+        manager.make_file_action_metadata(realm_path_2, realm_url, "user2", Action::DeleteRealm);
+        manager.make_file_action_metadata(realm_path_3, realm_url, "user3", Action::DeleteRealm);
 
         SECTION("should properly delete the Realm") {
             // Create some Realms
@@ -383,9 +383,9 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
         const std::string recovery_1 = util::file_path_by_appending_component(recovery_dir, "recovery-1");
         const std::string recovery_2 = util::file_path_by_appending_component(recovery_dir, "recovery-2");
         const std::string recovery_3 = util::file_path_by_appending_component(recovery_dir, "recovery-3");
-        auto a1 = manager.make_file_action_metadata(realm_path_1, realm_url, "user1", Action::BackUpThenDeleteRealm, recovery_1);
-        auto a2 = manager.make_file_action_metadata(realm_path_2, realm_url, "user2", Action::BackUpThenDeleteRealm, recovery_2);
-        auto a3 = manager.make_file_action_metadata(realm_path_3, realm_url, "user3", Action::BackUpThenDeleteRealm, recovery_3);
+        manager.make_file_action_metadata(realm_path_1, realm_url, "user1", Action::BackUpThenDeleteRealm, recovery_1);
+        manager.make_file_action_metadata(realm_path_2, realm_url, "user2", Action::BackUpThenDeleteRealm, recovery_2);
+        manager.make_file_action_metadata(realm_path_3, realm_url, "user3", Action::BackUpThenDeleteRealm, recovery_3);
 
         SECTION("should properly copy the Realm file and delete the Realm") {
             // Create some Realms
@@ -415,7 +415,7 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
             REQUIRE_REALM_EXISTS(realm_base_path);
             REQUIRE(!File::exists(recovery_path));
             // Manually create a file action metadata entry to simulate a client reset.
-            auto a = manager.make_file_action_metadata(realm_base_path, realm_url, identity, Action::BackUpThenDeleteRealm, recovery_path);
+            manager.make_file_action_metadata(realm_base_path, realm_url, identity, Action::BackUpThenDeleteRealm, recovery_path);
             auto pending_actions = manager.all_pending_actions();
             REQUIRE(pending_actions.size() == 4);
 
@@ -453,7 +453,7 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
             // Add a file action after the system is configured.
             REQUIRE_REALM_EXISTS(realm_path_4);
             REQUIRE(File::exists(file_manager.recovery_directory_path()));
-            auto a4 = manager.make_file_action_metadata(realm_path_4, realm_url, "user4", Action::BackUpThenDeleteRealm, recovery_1);
+            manager.make_file_action_metadata(realm_path_4, realm_url, "user4", Action::BackUpThenDeleteRealm, recovery_1);
             CHECK(pending_actions.size() == 1);
             // Force the recovery. (In a real application, the user would have closed the files by now.)
             REQUIRE(SyncManager::shared().immediately_run_file_actions(realm_path_4));

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -448,20 +448,18 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
             create_dummy_realm(realm_path_4);
             // Configure the system
             SyncManager::shared().configure(base_path, SyncManager::MetadataMode::NoEncryption);
-            auto pending_actions = manager.all_pending_actions();
-            REQUIRE(pending_actions.size() == 0);
+            REQUIRE(manager.all_pending_actions().size() == 0);
             // Add a file action after the system is configured.
             REQUIRE_REALM_EXISTS(realm_path_4);
             REQUIRE(File::exists(file_manager.recovery_directory_path()));
             manager.make_file_action_metadata(realm_path_4, realm_url, "user4", Action::BackUpThenDeleteRealm, recovery_1);
-            CHECK(pending_actions.size() == 1);
+            REQUIRE(manager.all_pending_actions().size() == 1);
             // Force the recovery. (In a real application, the user would have closed the files by now.)
             REQUIRE(SyncManager::shared().immediately_run_file_actions(realm_path_4));
             // There should be recovery files.
             REQUIRE_REALM_DOES_NOT_EXIST(realm_path_4);
             CHECK(File::exists(recovery_1));
-            pending_actions = manager.all_pending_actions();
-            CHECK(pending_actions.size() == 0);
+            REQUIRE(manager.all_pending_actions().size() == 0);
         }
 
         SECTION("should fail gracefully if there is already a file at the destination") {


### PR DESCRIPTION
Fixes https://github.com/realm/raas/issues/1539.

The core fix here is to use `Realm::open_with_config()` rather than `Realm::get_shared_realm()` in `make_file_action_metadata()` to avoid creating an `EventLoopSignal` instance, as that function is called from the sync worker thread when a client reset error occurs, and the libuv implementation of `EventLoopSignal` can only be constructed on the main thread.

The other changes are related to that the tests relied on `make_file_action_metadata()` reusing the cached Realm instance which they already held on to. This shouldn't be an issue for non-test code as these functions are mostly all internal to objectstore and not things that the SDKs call directly.