### PR TITLE
Recheck if the realm is closed after before_notify()

### DIFF
--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -806,6 +806,9 @@ void Realm::notify()
 
     if (m_binding_context) {
         m_binding_context->before_notify();
+        if (is_closed() || is_in_transaction()) {
+            return;
+        }
     }
 
     auto cleanup = util::make_scope_exit([this]() noexcept { m_is_sending_notifications = false; });


### PR DESCRIPTION
Needed for https://github.com/realm/realm-js/pull/2373 since that results in `clearTestState()` being called while processing the before_notify() handler, which closes the realm.