### PR TITLE
Handle EINTR in the apple version of ExternalCommitHelper

### DIFF
--- a/src/impl/apple/external_commit_helper.cpp
+++ b/src/impl/apple/external_commit_helper.cpp
@@ -196,7 +196,7 @@ ExternalCommitHelper::~ExternalCommitHelper()
 
 void ExternalCommitHelper::listen()
 {
-    pthread_setname_np("RLMRealm notification listener");
+    pthread_setname_np("Realm notification listener");
 
     // Set up the kqueue
     // EVFILT_READ indicates that we care about data being available to read
@@ -214,11 +214,11 @@ void ExternalCommitHelper::listen()
         // Wait for data to become on either fd
         // Return code is number of bytes available or -1 on error
         ret = kevent(m_kq, nullptr, 0, &event, 1, nullptr);
-        assert(ret >= 0);
-        if (ret == 0) {
+        if (ret == 0 || (ret < 0 && errno == EINTR)) {
             // Spurious wakeup; just wait again
             continue;
         }
+        assert(ret > 0);
 
         // Check which file descriptor had activity: if it's the shutdown
         // pipe, then someone called -stop; otherwise it's the named pipe


### PR DESCRIPTION
We just want to re-call kevent when it happens. The epoll version already did this.

Might be the cause of https://github.com/realm/realm-cocoa/issues/6144 or might be unrelated.