### PR TITLE
Fix some async open issues

### DIFF
--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -66,6 +66,16 @@ public:
     std::shared_ptr<AsyncOpenTask> get_synchronized_realm(Realm::Config config);
 #endif
 
+    // Get a Realm which is not bound to the current execution context
+    ThreadSafeReference<Realm> get_unbound_realm();
+
+    // Get the existing cached Realm for the given execution context if it exists
+    std::shared_ptr<Realm> get_cached_realm(Realm::Config const&, AnyExecutionContextID);
+
+    // Bind an unbound Realm to a specific execution context. The Realm must
+    // be managed by this coordinator.
+    void bind_to_context(Realm& realm, AnyExecutionContextID);
+
     Realm::Config get_config() const { return m_config; }
 
     uint64_t get_schema_version() const noexcept { return m_schema_version; }
@@ -201,8 +211,7 @@ private:
     void set_config(const Realm::Config&);
     void create_sync_session(bool force_client_reset);
     void do_get_realm(Realm::Config config, std::shared_ptr<Realm>& realm,
-                      std::unique_lock<std::mutex>& realm_lock);
-    std::shared_ptr<Realm> get_cached_realm(Realm::Config const& config);
+                      std::unique_lock<std::mutex>& realm_lock, bool bind_to_context=true);
 
     void run_async_notifiers();
     void open_helper_shared_group();

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -160,7 +160,7 @@ public:
 
 #if REALM_ENABLE_SYNC
     // A work queue that can be used to perform background work related to partial sync.
-    partial_sync::WorkQueue& partial_sync_work_queue();
+    _impl::partial_sync::WorkQueue& partial_sync_work_queue();
 #endif
 
     AuditInterface* audit_context() const noexcept { return m_audit_context.get(); }

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -209,7 +209,7 @@ private:
     void pin_version(VersionID version);
 
     void set_config(const Realm::Config&);
-    void create_sync_session(bool force_client_reset);
+    void create_sync_session(bool force_client_reset, bool validate_sync_history);
     void do_get_realm(Realm::Config config, std::shared_ptr<Realm>& realm,
                       std::unique_lock<std::mutex>& realm_lock, bool bind_to_context=true);
 

--- a/src/impl/weak_realm_notifier.hpp
+++ b/src/impl/weak_realm_notifier.hpp
@@ -39,7 +39,7 @@ namespace _impl {
 // a Realm instance is released from within a function holding the cache lock.
 class WeakRealmNotifier {
 public:
-    WeakRealmNotifier(const std::shared_ptr<Realm>& realm, bool cache);
+    WeakRealmNotifier(const std::shared_ptr<Realm>& realm, bool cache, bool bind_to_context);
     ~WeakRealmNotifier();
 
     // Get a strong reference to the cached realm
@@ -58,6 +58,8 @@ public:
     bool is_for_realm(Realm* realm) const { return realm == m_realm_key; }
 
     void notify();
+
+    void bind_to_execution_context(AnyExecutionContextID context);
 
 private:
     std::weak_ptr<Realm> m_realm;

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -262,6 +262,10 @@ public:
     // encryption key will raise an exception.
     static SharedRealm get_shared_realm(Config config);
 
+    // Get a Realm for the given execution context (or current thread if `none`)
+    // from the thread safe reference. May return a cached Realm or create a new one.
+    static SharedRealm get_shared_realm(ThreadSafeReference<Realm>, util::Optional<AbstractExecutionContextID> = util::none);
+
 #if REALM_ENABLE_SYNC
     // Open a synchronized Realm and make sure it is fully up to date before
     // returning it.

--- a/src/sync/async_open_task.cpp
+++ b/src/sync/async_open_task.cpp
@@ -38,7 +38,7 @@ void AsyncOpenTask::start(std::function<void(ThreadSafeReference<Realm>, std::ex
         return;
 
     std::shared_ptr<AsyncOpenTask> self(shared_from_this());
-   session->wait_for_download_completion([callback, self, this](std::error_code ec) {
+    session->wait_for_download_completion([callback, self, this](std::error_code ec) {
        auto session = m_session.exchange(nullptr);
         if (!session)
             return; // Swallow all events if the task as been canceled.

--- a/src/sync/async_open_task.cpp
+++ b/src/sync/async_open_task.cpp
@@ -16,10 +16,12 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#include "impl/realm_coordinator.hpp"
 #include "sync/async_open_task.hpp"
+
+#include "impl/realm_coordinator.hpp"
 #include "sync/sync_manager.hpp"
 #include "sync/sync_session.hpp"
+#include "thread_safe_reference.hpp"
 
 namespace realm {
 
@@ -29,7 +31,7 @@ AsyncOpenTask::AsyncOpenTask(std::shared_ptr<_impl::RealmCoordinator> coordinato
 {
 }
 
-void AsyncOpenTask::start(std::function<void(std::shared_ptr<Realm>, std::exception_ptr)> callback)
+void AsyncOpenTask::start(std::function<void(ThreadSafeReference<Realm>, std::exception_ptr)> callback)
 {
     std::weak_ptr<AsyncOpenTask> weak_self(shared_from_this());
     m_session->wait_for_download_completion([callback, weak_self](std::error_code ec) {
@@ -37,18 +39,24 @@ void AsyncOpenTask::start(std::function<void(std::shared_ptr<Realm>, std::except
             if (self->m_canceled)
                 return; // Swallow all events if the task as been canceled.
 
+            // Release our references to the session and coordinator after calling
+            // the callback
+            auto session = std::move(self->m_session);
+            auto coordinator = std::move(self->m_coordinator);
+            self->m_session = nullptr;
+            self->m_coordinator = nullptr;
+
             if (ec)
-                callback(nullptr, std::make_exception_ptr(std::system_error(ec)));
-            else {
-                std::shared_ptr<Realm> realm;
-                try {
-                    realm = self->m_coordinator->get_realm();
-                }
-                catch (...) {
-                    return callback(nullptr, std::current_exception());
-                }
-                callback(realm, nullptr);
+                return callback({}, std::make_exception_ptr(std::system_error(ec)));
+
+            ThreadSafeReference<Realm> realm;
+            try {
+                realm = coordinator->get_unbound_realm();
             }
+            catch (...) {
+                return callback({}, std::current_exception());
+            }
+            callback(std::move(realm), nullptr);
         }
     });
 }

--- a/src/sync/async_open_task.hpp
+++ b/src/sync/async_open_task.hpp
@@ -19,6 +19,8 @@
 #ifndef ASYNC_OPEN_TASK_HPP
 #define ASYNC_OPEN_TASK_HPP
 
+#include <util/atomic_shared_ptr.hpp>
+
 #include <functional>
 #include <memory>
 
@@ -50,8 +52,7 @@ public:
 
 private:
     std::shared_ptr<_impl::RealmCoordinator> m_coordinator;
-    std::shared_ptr<SyncSession> m_session;
-    bool m_canceled = false;
+    util::AtomicSharedPtr<SyncSession> m_session;
 };
 
 }

--- a/src/sync/async_open_task.hpp
+++ b/src/sync/async_open_task.hpp
@@ -19,13 +19,16 @@
 #ifndef ASYNC_OPEN_TASK_HPP
 #define ASYNC_OPEN_TASK_HPP
 
+#include <functional>
+#include <memory>
+
 namespace realm {
 class Realm;
 class SyncSession;
+template<typename> class ThreadSafeReference;
 namespace _impl {
 class RealmCoordinator;
 }
-
 
 // Class used to wrap the intent of opening a new Realm or fully synchronize it before returning it to the user
 // Timeouts are not handled by this class but must be handled by each binding.
@@ -37,7 +40,7 @@ public:
     //
     // If multiple AsyncOpenTasks all attempt to download the same Realm and one of them is canceled,
     // the other tasks will receive a "Cancelled" exception.
-    void start(std::function<void(std::shared_ptr<Realm>, std::exception_ptr)> callback);
+    void start(std::function<void(ThreadSafeReference<Realm>, std::exception_ptr)> callback);
 
     // Cancels the download and stops the session. No further functions should be called on this class.
     void cancel();

--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -202,7 +202,6 @@ std::string reserve_unique_file_name(const std::string& path, const std::string&
 
 constexpr const char SyncFileManager::c_sync_directory[];
 constexpr const char SyncFileManager::c_utility_directory[];
-constexpr const char SyncFileManager::c_state_directory[];
 constexpr const char SyncFileManager::c_recovery_directory[];
 constexpr const char SyncFileManager::c_metadata_directory[];
 constexpr const char SyncFileManager::c_metadata_realm[];

--- a/src/sync/impl/sync_file.hpp
+++ b/src/sync/impl/sync_file.hpp
@@ -102,17 +102,11 @@ public:
         return get_special_directory(directory.value_or(c_recovery_directory));
     }
 
-    std::string get_state_directory() const
-    {
-        return get_special_directory(c_state_directory);
-    }
-
 private:
     const std::string m_base_path;
 
     static constexpr const char c_sync_directory[] = "realm-object-server";
     static constexpr const char c_utility_directory[] = "io.realm.object-server-utility";
-    static constexpr const char c_state_directory[] = "io.realm.object-server-state";
     static constexpr const char c_recovery_directory[] = "io.realm.object-server-recovered-realms";
     static constexpr const char c_metadata_directory[] = "metadata";
     static constexpr const char c_metadata_realm[] = "sync_metadata.realm";

--- a/src/sync/partial_sync.cpp
+++ b/src/sync/partial_sync.cpp
@@ -18,7 +18,7 @@
 
 // Work-around for GCC bug: See https://stackoverflow.com/a/3233069/1389357
 // Must be defined at top of file
-#define __STDC_LIMIT_MACROS 
+#define __STDC_LIMIT_MACROS
 
 #include "sync/partial_sync.hpp"
 
@@ -125,19 +125,26 @@ void initialize_schema(Group& group)
     if (!table) {
         // Create the schema required by Sync
         table = sync::create_table(group, result_sets_table_name);
-        table->add_column(type_String, property_query);
-        table->add_column(type_String, property_matches_property_name);
-        table->add_column(type_Int, property_status);
-        table->add_column(type_String, property_error_message);
-        table->add_column(type_Int, property_query_parse_counter);
     }
-    else {
-        // The table already existed, so it should have all of the columns that are in the shared schema.
-        REALM_ASSERT(table->get_column_index(property_query) != npos);
-        REALM_ASSERT(table->get_column_index(property_matches_property_name) != npos);
-        REALM_ASSERT(table->get_column_index(property_status) != npos);
-        REALM_ASSERT(table->get_column_index(property_error_message) != npos);
-        REALM_ASSERT(table->get_column_index(property_query_parse_counter) != npos);
+
+    if (table->get_column_index(property_query) == npos) {
+        table->add_column(type_String, property_query);
+    }
+
+    if (table->get_column_index(property_matches_property_name) == npos) {
+        table->add_column(type_String, property_matches_property_name);
+    }
+
+    if (table->get_column_index(property_status) == npos) {
+        table->add_column(type_Int, property_status);
+    }
+
+    if (table->get_column_index(property_error_message) == npos) {
+        table->add_column(type_String, property_error_message);
+    }
+
+    if (table->get_column_index(property_query_parse_counter) == npos) {
+        table->add_column(type_Int, property_query_parse_counter);
     }
 
     // Add columns not required by Sync, but used by the bindings to offer better tracking of subscriptions.

--- a/src/sync/partial_sync.cpp
+++ b/src/sync/partial_sync.cpp
@@ -157,14 +157,14 @@ void ensure_partial_sync_schema_initialized(Realm& realm)
     auto& group = realm.read_group();
     // Check if the result sets table already has the expected number of columns
     auto table = ObjectStore::table_for_object_type(group, result_sets_type_name);
-    if (table && table->size() >= 10)
+    if (table && table->size() >= result_sets_property_count)
         return;
 
     realm.begin_transaction();
     // Recheck after starting the transaction as it refreshes
     if (!table)
         table = ObjectStore::table_for_object_type(group, result_sets_type_name);
-    if (table && table->size() >= 10)
+    if (table && table->size() >= result_sets_property_count)
         return;
     initialize_schema(group);
     realm.commit_transaction();

--- a/src/sync/partial_sync.hpp
+++ b/src/sync/partial_sync.hpp
@@ -46,6 +46,7 @@ static constexpr const char* property_created_at = "created_at";
 static constexpr const char* property_updated_at = "updated_at";
 static constexpr const char* property_expires_at = "expires_at";
 static constexpr const char* property_time_to_live = "time_to_live";
+static constexpr const size_t result_sets_property_count = 10;
 
 struct InvalidRealmStateException : public std::logic_error {
     InvalidRealmStateException(const std::string& msg);

--- a/src/sync/partial_sync.hpp
+++ b/src/sync/partial_sync.hpp
@@ -178,6 +178,7 @@ void unsubscribe(Object&&);
 namespace _impl {
 
 void initialize_schema(Group&);
+void ensure_partial_sync_schema_initialized(Realm&);
 
 } // namespace _impl
 } // namespace realm

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -666,9 +666,9 @@ void SyncSession::create_sync_session()
     }
 
     if (m_force_client_reset) {
-        std::string metadata_dir = SyncManager::shared().m_file_manager->get_state_directory();
+        std::string metadata_dir = m_realm_path + ".resync";
         util::try_make_dir(metadata_dir);
-        
+
         sync::Session::Config::ClientReset config;
         config.metadata_dir = metadata_dir;
         session_config.client_reset_config = config;

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -442,9 +442,10 @@ SyncSession::SyncSession(SyncClient& client, std::string realm_path, SyncConfig 
                       realm_config.encryption_key.begin());
         }
 
-        // FIXME: Opening a Realm only to discard it is relatively expensive. It may be preferable to have
-        // realm-sync open the Realm when the `sync::Session` is created since it can continue to use it.
-        Realm::get_shared_realm(realm_config); // Throws
+        std::unique_ptr<Replication> history;
+        std::unique_ptr<SharedGroup> shared_group;
+        std::unique_ptr<Group> read_only_group;
+        Realm::open_with_config(realm_config, history, shared_group, read_only_group, nullptr);
    }
 }
 

--- a/src/thread_safe_reference.hpp
+++ b/src/thread_safe_reference.hpp
@@ -19,7 +19,6 @@
 #ifndef REALM_THREAD_SAFE_REFERENCE_HPP
 #define REALM_THREAD_SAFE_REFERENCE_HPP
 
-
 #include <realm/group_shared.hpp>
 
 namespace realm {
@@ -32,6 +31,7 @@ class Results;
 class TableView;
 template<typename T> class BasicRow;
 typedef BasicRow<Table> Row;
+namespace _impl { class RealmCoordinator; }
 
 // Opaque type representing an object for handover
 class ThreadSafeReferenceBase {
@@ -107,6 +107,24 @@ class ThreadSafeReference<Results>: public ThreadSafeReferenceBase {
 
     // Precondition: Realm and handover are on same version.
     Results import_into_realm(std::shared_ptr<Realm> realm) &&;
+};
+
+template<>
+class ThreadSafeReference<Realm> {
+    friend class Realm;
+    friend class _impl::RealmCoordinator;
+
+    std::shared_ptr<Realm> m_realm;
+
+    ThreadSafeReference(std::shared_ptr<Realm>);
+    std::shared_ptr<Realm> resolve() &&;
+public:
+
+    ThreadSafeReference() = default;
+    ThreadSafeReference(ThreadSafeReference const&) = delete;
+    ThreadSafeReference(ThreadSafeReference &&) = default;
+    ThreadSafeReference& operator=(ThreadSafeReference const&) = delete;
+    ThreadSafeReference& operator=(ThreadSafeReference&&) = default;
 };
 }
 

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -557,6 +557,28 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
         // No subscriptions, so no objects
         REQUIRE(Realm::get_shared_realm(config)->read_group().get_table("class_object")->size() == 0);
     }
+
+    SECTION("can download multiple Realms at a time") {
+        SyncTestFile config1(server, "realm1");
+        SyncTestFile config2(server, "realm2");
+        SyncTestFile config3(server, "realm3");
+        SyncTestFile config4(server, "realm4");
+
+        std::vector<std::shared_ptr<AsyncOpenTask>> tasks = {
+            Realm::get_synchronized_realm(config1),
+            Realm::get_synchronized_realm(config2),
+            Realm::get_synchronized_realm(config3),
+            Realm::get_synchronized_realm(config4),
+        };
+
+        std::atomic<int> completed{0};
+        for (auto& task : tasks) {
+            task->start([&](auto, auto) {
+                ++completed;
+            });
+        }
+        util::EventLoop::main().run_until([&]{ return completed == 4; });
+    }
 }
 #endif
 

--- a/tests/sync/permission.cpp
+++ b/tests/sync/permission.cpp
@@ -69,6 +69,7 @@ static void update_schema(Group& group, Property matches_property)
 
     Schema desired_schema({
         ObjectSchema(result_sets_type_name, {
+            {"name", PropertyType::String},
             {"matches_property", PropertyType::String},
             {"query", PropertyType::String},
             {"status", PropertyType::Int},
@@ -93,12 +94,17 @@ static void subscribe_to_all(std::shared_ptr<Realm> const& r)
 
     CppContext context;
     auto obj = Object::create<util::Any>(context, r, schema, AnyDict{
+        {"name", ""s},
         {"matches_property", "object_matches"s},
         {"query", "TRUEPREDICATE"s},
         {"status", int64_t(0)},
         {"error_message", ""s},
         {"query_parse_counter", int64_t(0)},
         {"matches_count", int64_t(0)},
+        {"created_at", Timestamp(0, 0)},
+        {"updated_at", Timestamp(0, 0)},
+        {"expires_at", Timestamp()},
+        {"ttl", Timestamp()},
     }, false);
 
     r->commit_transaction();

--- a/tests/sync/permission.cpp
+++ b/tests/sync/permission.cpp
@@ -104,7 +104,7 @@ static void subscribe_to_all(std::shared_ptr<Realm> const& r)
         {"created_at", Timestamp(0, 0)},
         {"updated_at", Timestamp(0, 0)},
         {"expires_at", Timestamp()},
-        {"ttl", Timestamp()},
+        {"time_to_live", {}},
     }, false);
 
     r->commit_transaction();

--- a/tests/sync/session/session.cpp
+++ b/tests/sync/session/session.cpp
@@ -729,5 +729,10 @@ TEST_CASE("sync: Migration from Sync 1.x to Sync 2.x", "[sync]") {
         });
     }
 
+    SECTION("Realm::get_synchronized_realm allows recovery from Sync 1.x to Sync 2.x migration") {
+        check([&]{
+            return Realm::get_synchronized_realm(config);
+        });
+    }
 }
 


### PR DESCRIPTION
This includes changes needed to get the realm-js and realm-cocoa tests passing using the new async open, and fixes a bug which hits Cocoa which wasn't caught by those tests.

AsyncOpenTask now takes more control over its lifetime: the callback holds a strong reference to the task until it's called so that retaining the AsyncOpenTask externally is optional, and cleans itself up after calling the callback passed to `start()` so that the SDK code doesn't have to worry about that. Some thread-safety problems around using `m_session` from multiple threads have been fixed by using `AtomicSharedPtr<>`, and calling `cancel()` while it happens to be processing the callback will no longer crash.

The state dir for async open/resync is now a directory named after the Realm rather than a single shared directory, since it turns out that's what the sync code expects. Sharing a single directory resulted in async opening more than one Realm at a time breaking.

The AsyncOpenTask callback is now passed a `ThreadSafeReference<Realm>` rather than `std::shared_ptr<Realm>`. The TSR can be resolved to an actual Realm by passing it to `Realm::get_shared_realm()`. This avoids creating the EventLoopSignal for the Realm on the background thread (which doesn't work with the libuv implementation because libuv event loops aren't thread-safe), and lets the JS SDK skip closing and re-opening the Realm back on the main thread. This also happened to reveal that the background-opened Realm wasn't really in a valid state, so a few fixes were needed there.

Async open failed to check that the history schema for existing Realm files was compatible before creating the sync session, which resulted in an exception being thrown on the sync client thread that did not get funneled back to the appropraite place.