### PR TITLE
Adding check for cache_new_realm

### DIFF
--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -429,14 +429,16 @@ void Realm::add_schema_change_handler()
 
 void Realm::cache_new_schema()
 {
-    auto new_version = transaction().get_version_of_current_transaction().version;
-    if (m_new_schema)
-        m_coordinator->cache_schema(std::move(*m_new_schema),
-                                    m_schema_version, new_version);
-    else
-        m_coordinator->advance_schema_cache(m_schema_transaction_version, new_version);
-    m_schema_transaction_version = new_version;
-    m_new_schema = util::none;
+    if (!is_closed()) {
+        auto new_version = transaction().get_version_of_current_transaction().version;
+        if (m_new_schema)
+            m_coordinator->cache_schema(std::move(*m_new_schema),
+                                        m_schema_version, new_version);
+        else
+            m_coordinator->advance_schema_cache(m_schema_transaction_version, new_version);
+        m_schema_transaction_version = new_version;
+        m_new_schema = util::none;
+    }
 }
 
 void Realm::translate_schema_error()


### PR DESCRIPTION
[cache_new_realm](https://github.com/realm/realm-object-store/blob/master/src/shared_realm.cpp#L574-L577) used to check if the shared_group is still open/valid before proceeding to read the current transaction version id. In Core 6 this checks [is not done](https://github.com/realm/realm-object-store/blob/core-6/src/shared_realm.cpp#L430-L432), which causes the call to `transaction()` to throw. (`transaction()` -> `read_group()` -> `verify_open()` -> Throw `ClosedRealmException`). This PR adds the check to return quickly if the Realm was closed.
