### PR TITLE
Fix the check for if the ResultSets schema needs to be initialized

### DIFF
--- a/src/sync/partial_sync.cpp
+++ b/src/sync/partial_sync.cpp
@@ -157,14 +157,14 @@ void ensure_partial_sync_schema_initialized(Realm& realm)
     auto& group = realm.read_group();
     // Check if the result sets table already has the expected number of columns
     auto table = ObjectStore::table_for_object_type(group, result_sets_type_name);
-    if (table && table->size() >= result_sets_property_count)
+    if (table && table->get_column_count() >= result_sets_property_count)
         return;
 
     realm.begin_transaction();
     // Recheck after starting the transaction as it refreshes
     if (!table)
         table = ObjectStore::table_for_object_type(group, result_sets_type_name);
-    if (table && table->size() >= result_sets_property_count)
+    if (table && table->get_column_count() >= result_sets_property_count)
         return;
     initialize_schema(group);
     realm.commit_transaction();


### PR DESCRIPTION
Table::size() is not the number of columns in the table.

This probably worked out okay in practice because it "works" as long as the user creates at least 4 subscriptions, but until they do it resulted in a bunch of extra empty write transactions.