### PR TITLE
Allows changing url_prefix of a created sync session

### DIFF
--- a/src/sync/sync_config.hpp
+++ b/src/sync/sync_config.hpp
@@ -138,6 +138,8 @@ struct SyncConfig {
     util::Optional<std::string> authorization_header_name = none;
     std::map<std::string, std::string> custom_http_headers;
 
+    // Set the URL path prefix sync will use when opening a websocket for this session. Default is `/realm-sync`.
+    // Useful when the sync worker sits behind a firewall or load-balancer that rewrites incoming requests.
     util::Optional<std::string> url_prefix = none;
 
     // The name of the directory which Realms should be backed up to following

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -836,6 +836,11 @@ void SyncSession::set_multiplex_identifier(std::string multiplex_identity)
     m_multiplex_identity = std::move(multiplex_identity);
 }
 
+void SyncSession::set_url_prefix(std::string url_prefix)
+{
+    m_config.url_prefix = std::move(url_prefix);
+}
+
 SyncSession::PublicState SyncSession::get_public_state() const
 {
     if (m_state == nullptr) {

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -213,6 +213,13 @@ public:
     // not make the session reconnect.
     void set_multiplex_identifier(std::string multiplex_identity);
 
+    // See SyncConfig::url_prefix
+    //
+    // This method allows to override this value after the session is created but before it is bound
+    // because of Realm Cloud's token refresh service returning the sync worker ingress path with the token response.
+    // Prefer using the SyncConfig field in all other cases.
+    void set_url_prefix(std::string url_prefix);
+
     // Inform the sync session that it should close.
     void close();
 


### PR DESCRIPTION
On Cloud we're doing away with the Sync Proxy. Previously sync clients would open websockets pointing to `my-awesome-instance.us1.cloud.realm.io/realm-sync/url-encoded-realm-path` and the server-side routing to different sync workers was done by the Sync Proxy sitting on the `/realm-sync` endpoint - it would inspect an incoming request, determine where to proxy it, and open another socket to do so.

We're adding a new mechanism that bypasses proxying and instead exposes every sync worker for an instance on a public path like `/sync/{worker-name}` so it would be possible for the client to make a request to `/sync/alpha/url-encoded-realm-path` and connect directly to the sync worker.

To this end token refresh responses by Cloud will now include the URL path of the sync worker in question which needs to go to the `url_prefix` field of the sync session configuration. However, by the time the first token refresh request is made bindings will have already created a sync session so we need the ability to set the url prefix after the session is created.