### PR TITLE
Fix a crash when an observed primitive list is deleted before the first run of the notifier

### DIFF
--- a/src/impl/primitive_list_notifier.cpp
+++ b/src/impl/primitive_list_notifier.cpp
@@ -40,16 +40,17 @@ void PrimitiveListNotifier::release_data() noexcept
 
 void PrimitiveListNotifier::do_attach_to(SharedGroup& sg)
 {
-    REALM_ASSERT(m_table_handover);
     REALM_ASSERT(!m_table);
-    m_table = sg.import_table_from_handover(std::move(m_table_handover));
+    if (m_table_handover)
+        m_table = sg.import_table_from_handover(std::move(m_table_handover));
 }
 
 void PrimitiveListNotifier::do_detach_from(SharedGroup& sg)
 {
     REALM_ASSERT(!m_table_handover);
     if (m_table) {
-        m_table_handover = sg.export_table_for_handover(m_table);
+        if (m_table->is_attached())
+            m_table_handover = sg.export_table_for_handover(m_table);
         m_table = {};
     }
 }

--- a/tests/list.cpp
+++ b/tests/list.cpp
@@ -150,6 +150,15 @@ TEST_CASE("list") {
             REQUIRE(change.empty());
         }
 
+        SECTION("deleting list before first run of notifier reports deletions") {
+            auto token = lst.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
+                change = c;
+            });
+            advance_and_notify(*r);
+            write([&] { origin->move_last_over(0); });
+            REQUIRE_INDICES(change.deletions, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        }
+
         SECTION("modifying one of the target rows sends a change notification") {
             auto token = require_change();
             write([&] { lst.get(5).set_int(0, 6); });


### PR DESCRIPTION
For version management reasons, the first run of a notifier is done on a different SharedGroup from all of the subsequent runs. This requires detaching the notifier from the first SG and attaching it to the second one by handing over the Table. This doesn't work if the Table was deleted, so we need to explicitly handle that case.

Fixes https://github.com/realm/realm-cocoa/issues/6234.