### PR TITLE
Add tests for partial sync schema init

### DIFF
--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -284,6 +284,10 @@ public:
         {
             session.handle_error(std::move(error));
         }
+        static void nonsync_transact_notify(SyncSession& session, VersionID::version_type version)
+        {
+            session.nonsync_transact_notify(version);
+        }
     };
 
 private:


### PR DESCRIPTION
This tries to cover all of the cases around pre-existing local Realm files that need some schema changes made for partial sync.

Reverting 2506970c20899ee264c99924978bbc2efb2c2f7e results in the following failures in these tests:

-------------------------------------------------------------------------------
Query-based sync schema initialization
  open existing local Realm which has an older schema with dynamic schema
-------------------------------------------------------------------------------
/src/realm-object-store/tests/sync/partial_sync.cpp:1403
...............................................................................

/src/realm-object-store/tests/sync/partial_sync.cpp:1261: FAILED:
  CHECK( table->get_column_index("created_at") != npos )
/src/realm-object-store/tests/sync/partial_sync.cpp:1262: FAILED:
  CHECK( table->get_column_index("updated_at") != npos )
/src/realm-object-store/tests/sync/partial_sync.cpp:1263: FAILED:
  CHECK( table->get_column_index("expires_at") != npos )
/src/realm-object-store/tests/sync/partial_sync.cpp:1264: FAILED:
  CHECK( table->get_column_index("time_to_live") != npos )

-------------------------------------------------------------------------------
Query-based sync schema initialization
  open non-ObjectStore existing local Realm with dynamic schema
-------------------------------------------------------------------------------
/src/realm-object-store/tests/sync/partial_sync.cpp:1414
...............................................................................

/src/realm-object-store/tests/sync/partial_sync.cpp:1255: FAILED:
  CHECK( table->get_column_index("name") != npos )
/src/realm-object-store/tests/sync/partial_sync.cpp:1261: FAILED:
  CHECK( table->get_column_index("created_at") != npos )
/src/realm-object-store/tests/sync/partial_sync.cpp:1262: FAILED:
  CHECK( table->get_column_index("updated_at") != npos )
/src/realm-object-store/tests/sync/partial_sync.cpp:1263: FAILED:
  CHECK( table->get_column_index("expires_at") != npos )
/src/realm-object-store/tests/sync/partial_sync.cpp:1264: FAILED:
  CHECK( table->get_column_index("time_to_live") != npos )

===============================================================================
test cases:   123 |   122 passed | 1 failed
assertions: 11125 | 11116 passed | 9 failed
