### PR TITLE
Add some basic benchmarks

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,3 +67,4 @@ create_coverage_target(generate-coverage tests)
 add_custom_target(run-tests USES_TERMINAL DEPENDS tests COMMAND ./tests)
 
 add_subdirectory(notifications-fuzzer)
+add_subdirectory(benchmarks)

--- a/tests/benchmarks/CMakeLists.txt
+++ b/tests/benchmarks/CMakeLists.txt
@@ -39,3 +39,6 @@ if(REALM_ENABLE_SYNC)
 endif()
 
 target_link_libraries(benchmarks realm-object-store ${PLATFORM_LIBRARIES})
+set_target_properties(benchmarks PROPERTIES
+      EXCLUDE_FROM_ALL 1
+      EXCLUDE_FROM_DEFAULT_BUILD 1)

--- a/tests/benchmarks/CMakeLists.txt
+++ b/tests/benchmarks/CMakeLists.txt
@@ -1,0 +1,41 @@
+include_directories(../../external/catch/single_include .)
+include_directories(../util .)
+
+set(HEADERS
+    ../util/event_loop.hpp
+    ../util/index_helpers.hpp
+    ../util/test_file.hpp
+    ../util/test_utils.hpp
+)
+
+set(SOURCES
+    main.cpp
+    object.cpp
+    results.cpp
+
+    ../util/event_loop.cpp
+    ../util/test_file.cpp
+    ../util/test_utils.cpp
+)
+
+
+if(REALM_ENABLE_SYNC)
+    list(APPEND HEADERS
+        ../sync/sync_test_utils.hpp
+        ../sync/session/session_util.hpp
+    )
+    list(APPEND SOURCES
+        ../sync/sync_test_utils.cpp
+    )
+endif()
+
+add_executable(benchmarks ${SOURCES} ${HEADERS})
+target_compile_definitions(benchmarks PRIVATE ${PLATFORM_DEFINES})
+
+if(REALM_ENABLE_SYNC)
+    # It's necessary to explicitly link to realm-sync here to control the order in which libraries are
+    # linked to avoid link errors when using GNU ld.
+    target_link_libraries(benchmarks realm-sync realm-sync-server realm-parser)
+endif()
+
+target_link_libraries(benchmarks realm-object-store ${PLATFORM_LIBRARIES})

--- a/tests/benchmarks/main.cpp
+++ b/tests/benchmarks/main.cpp
@@ -1,0 +1,54 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2019 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#define CATCH_CONFIG_ENABLE_BENCHMARKING
+
+// FIXME: the nextafter define below can be removed once we upgrade to an
+// Android ndk version which has support for std::nextafter (absent in ndk r10e)
+#define CATCH_CONFIG_GLOBAL_NEXTAFTER
+#define CATCH_CONFIG_RUNNER
+#include "catch2/catch.hpp"
+
+#include <limits.h>
+
+#ifdef _MSC_VER
+#include <Shlwapi.h>
+#pragma comment(lib, "Shlwapi.lib")
+#else
+#include <libgen.h>
+#endif
+
+int main(int argc, char** argv) {
+#ifdef _MSC_VER
+    char path[MAX_PATH];
+    if (GetModuleFileNameA(NULL, path, sizeof(path)) == 0) {
+        fprintf(stderr, "Failed to retrieve path to exectuable.\n");
+        return 1;
+    }
+    PathRemoveFileSpecA(path);
+    SetCurrentDirectoryA(path);
+#else
+    char executable[PATH_MAX];
+    realpath(argv[0], executable);
+    const char* directory = dirname(executable);
+    chdir(directory);
+#endif
+
+    int result = Catch::Session().run(argc, argv);
+    return result < 0xff ? result : 0xff;
+}

--- a/tests/benchmarks/object.cpp
+++ b/tests/benchmarks/object.cpp
@@ -1,0 +1,237 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2019 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#define CATCH_CONFIG_ENABLE_BENCHMARKING
+
+#include "util/test_file.hpp"
+#include "util/test_utils.hpp"
+
+#include "impl/object_accessor_impl.hpp"
+#include "impl/realm_coordinator.hpp"
+#include "binding_context.hpp"
+#include "object_schema.hpp"
+#include "property.hpp"
+#include "results.hpp"
+#include "schema.hpp"
+
+#include <realm/group_shared.hpp>
+#include <realm/query_engine.hpp>
+#include <realm/query_expression.hpp>
+
+using namespace realm;
+
+struct TestContext : CppContext {
+    std::map<std::string, AnyDict> defaults;
+
+    using CppContext::CppContext;
+    TestContext(TestContext& parent, realm::Property const& prop)
+    : CppContext(parent, prop)
+    , defaults(parent.defaults)
+    { }
+
+    util::Optional<util::Any>
+    default_value_for_property(ObjectSchema const& object, Property const& prop)
+    {
+        auto obj_it = defaults.find(object.name);
+        if (obj_it == defaults.end())
+            return util::none;
+        auto prop_it = obj_it->second.find(prop.name);
+        if (prop_it == obj_it->second.end())
+            return util::none;
+        return prop_it->second;
+    }
+
+    void will_change(Object const&, Property const&) {}
+    void did_change() {}
+    std::string print(util::Any) { return "not implemented"; }
+    bool allow_missing(util::Any) { return false; }
+};
+
+
+
+TEST_CASE("Benchmark object", "[benchmark]") {
+    using namespace std::string_literals;
+    using AnyVec = std::vector<util::Any>;
+    using AnyDict = std::map<std::string, util::Any>;
+    _impl::RealmCoordinator::assert_no_open_realms();
+
+    InMemoryTestFile config;
+    config.automatic_change_notifications = false;
+    config.cache = false;
+    config.schema = Schema{
+        {"all types", {
+            {"pk", PropertyType::Int, Property::IsPrimary{true}},
+            {"bool", PropertyType::Bool},
+            {"int", PropertyType::Int},
+            {"float", PropertyType::Float},
+            {"double", PropertyType::Double},
+            {"string", PropertyType::String},
+            {"data", PropertyType::Data},
+            {"date", PropertyType::Date},
+            {"object", PropertyType::Object|PropertyType::Nullable, "link target"},
+
+            {"bool array", PropertyType::Array|PropertyType::Bool},
+            {"int array", PropertyType::Array|PropertyType::Int},
+            {"float array", PropertyType::Array|PropertyType::Float},
+            {"double array", PropertyType::Array|PropertyType::Double},
+            {"string array", PropertyType::Array|PropertyType::String},
+            {"data array", PropertyType::Array|PropertyType::Data},
+            {"date array", PropertyType::Array|PropertyType::Date},
+            {"object array", PropertyType::Array|PropertyType::Object, "array target"},
+        }},
+        {"link target", {
+            {"value", PropertyType::Int},
+        }, {
+            {"origin", PropertyType::LinkingObjects|PropertyType::Array, "all types", "object"},
+        }},
+        {"array target", {
+            {"value", PropertyType::Int},
+        }},
+        {"person", {
+            {"name", PropertyType::String, Property::IsPrimary{true}},
+            {"age", PropertyType::Int},
+            {"scores", PropertyType::Array|PropertyType::Int},
+            {"assistant", PropertyType::Object|PropertyType::Nullable, "person"},
+            {"team", PropertyType::Array|PropertyType::Object, "person"},
+        }},
+    };
+
+    config.schema_version = 0;
+    auto r = Realm::get_shared_realm(config);
+    TestContext d(r);
+
+    auto create_person = [&](util::Any&& value, bool update, bool update_only_diff = false) {
+        r->begin_transaction();
+        auto obj = Object::create(d, r, *r->schema().find("person"), value, update, update_only_diff);
+        r->commit_transaction();
+        return obj;
+    };
+
+    SECTION("create object") {
+        r->begin_transaction();
+        ObjectSchema all_types = *r->schema().find("all types");
+        constexpr bool update = false;
+        constexpr bool update_only_diff = false;
+
+        int64_t benchmark_pk = 0;
+        BENCHMARK("create object") {
+            return Object::create(d, r, all_types, util::Any(AnyDict{
+                {"pk", benchmark_pk++},
+                {"bool", true},
+                {"int", INT64_C(5)},
+                {"float", 2.2f},
+                {"double", 3.3},
+                {"string", "hello"s},
+                {"data", "olleh"s},
+                {"date", Timestamp(10, 20)},
+                {"object", AnyDict{{"value", INT64_C(10)}}},
+
+                {"bool array", AnyVec{true, false}},
+                {"int array", AnyVec{INT64_C(5), INT64_C(6)}},
+                {"float array", AnyVec{1.1f, 2.2f}},
+                {"double array", AnyVec{3.3, 4.4}},
+                {"string array", AnyVec{"a"s, "b"s, "c"s}},
+                {"data array", AnyVec{"d"s, "e"s, "f"s}},
+                {"date array", AnyVec{}},
+                {"object array", AnyVec{AnyDict{{"value", INT64_C(20)}}}},
+            }), update, update_only_diff);
+        };
+        r->commit_transaction();
+    }
+
+    SECTION("update object") {
+        auto table = r->read_group().get_table("class_all types");
+        r->begin_transaction();
+        ObjectSchema all_types = *r->schema().find("all types");
+        constexpr bool update = false;
+        constexpr bool update_only_diff = false;
+        auto obj = Object::create(d, r, all_types, util::Any(AnyDict{
+            {"pk", INT64_C(0)},
+            {"bool", true},
+            {"int", INT64_C(5)},
+            {"float", 2.2f},
+            {"double", 3.3},
+            {"string", "hello"s},
+            {"data", "olleh"s},
+            {"date", Timestamp(10, 20)},
+            {"object", AnyDict{{"value", INT64_C(10)}}},
+
+            {"bool array", AnyVec{true, false}},
+            {"int array", AnyVec{INT64_C(5), INT64_C(6)}},
+            {"float array", AnyVec{1.1f, 2.2f}},
+            {"double array", AnyVec{3.3, 4.4}},
+            {"string array", AnyVec{"a"s, "b"s, "c"s}},
+            {"data array", AnyVec{"d"s, "e"s, "f"s}},
+            {"date array", AnyVec{}},
+            {"object array", AnyVec{AnyDict{{"value", INT64_C(20)}}}},
+        }), update, update_only_diff);
+        r->commit_transaction();
+
+        Results result(r, *table);
+        size_t num_modifications = 0;
+        auto token = result.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
+            num_modifications += c.modifications.count();
+        });
+
+        advance_and_notify(*r);
+        int64_t update_int = 1;
+        BENCHMARK_ADVANCED("update object")(Catch::Benchmark::Chronometer meter) {
+            r->begin_transaction();
+            meter.measure([&d, &all_types, &update_int, &r] {
+                auto shadow = Object::create(d, r, all_types, util::Any(AnyDict{
+                    {"pk", INT64_C(0)},
+                    {"int", update_int},
+                }), true, true);
+            });
+            r->commit_transaction();
+            advance_and_notify(*r);
+            REQUIRE(result.size() == 1);
+            REQUIRE(result.get(0).get_int(2) == update_int);
+            update_int++;
+        };
+    }
+
+    SECTION("change notifications reporting") {
+        auto table = r->read_group().get_table("class_person");
+        Results result(r, *table);
+        size_t num_calls = 0;
+        size_t num_insertions = 0;
+        auto token = result.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
+            num_insertions += c.insertions.count();
+            ++num_calls;
+        });
+
+        advance_and_notify(*r);
+        int64_t pk = 0;
+        BENCHMARK_ADVANCED("create notifications")(Catch::Benchmark::Chronometer meter) {
+            std::stringstream name;
+            name << "person_" << pk++;
+            AnyDict person {
+                {"name", name.str()},
+                {"age", pk},
+            };
+            create_person(person, true, false);
+            meter.measure([&r] {
+                advance_and_notify(*r);
+            });
+            REQUIRE(static_cast<int64_t>(num_calls) == pk + 1);
+            REQUIRE(static_cast<int64_t>(num_insertions) == pk);
+        };
+    }
+}
+

--- a/tests/benchmarks/results.cpp
+++ b/tests/benchmarks/results.cpp
@@ -1,0 +1,125 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2019 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#define CATCH_CONFIG_ENABLE_BENCHMARKING
+
+#include "util/test_file.hpp"
+#include "util/test_utils.hpp"
+
+#include "binding_context.hpp"
+#include "object_schema.hpp"
+#include "property.hpp"
+#include "results.hpp"
+#include "schema.hpp"
+
+#include <realm/group_shared.hpp>
+#include <realm/query_engine.hpp>
+#include <realm/query_expression.hpp>
+
+using namespace realm;
+
+TEST_CASE("Benchmark results", "[benchmark]") {
+    InMemoryTestFile config;
+    config.cache = false;
+    config.schema = Schema{
+        {"object", {
+            {"value", PropertyType::Int},
+            {"bool", PropertyType::Bool},
+            {"data prop", PropertyType::Data},
+            {"link", PropertyType::Object|PropertyType::Nullable, "object 2"},
+            {"array", PropertyType::Object|PropertyType::Array, "object 2"},
+        }},
+        {"object 2", {
+            {"value", PropertyType::Int},
+            {"link", PropertyType::Object|PropertyType::Nullable, "object"},
+        }},
+    };
+
+    auto realm = Realm::get_shared_realm(config);
+    auto table = realm->read_group().get_table("class_object");
+    auto table2 = realm->read_group().get_table("class_object 2");
+    Results r(realm, *table);
+
+    realm->begin_transaction();
+    table->add_empty_row(4);
+    table2->add_empty_row(4);
+    for (int i = 0; i < 4; ++i) {
+        table->set_int(0, i, (i + 2) % 4);
+        table->set_bool(1, i, i % 2);
+        table->set_link(3, i, 3 - i);
+
+        table2->set_int(0, i, (i + 1) % 4);
+        table2->set_link(1, i, i);
+    }
+    realm->commit_transaction();
+    /*
+     | index | value | bool | link.value | link.link.value |
+     |-------|-------|------|------------|-----------------|
+     | 0     | 2     | 0    | 0          | 1               |
+     | 1     | 3     | 1    | 3          | 0               |
+     | 2     | 0     | 0    | 2          | 3               |
+     | 3     | 1     | 1    | 1          | 2               |
+     */
+
+    #define REQUIRE_ORDER(sort, ...) do { \
+        std::vector<size_t> expected = {__VA_ARGS__}; \
+        auto results = sort; \
+        REQUIRE(results.size() == expected.size()); \
+        for (size_t i = 0; i < expected.size(); ++i) \
+            REQUIRE(results.get(i).get_index() == expected[i]); \
+    } while (0)
+
+    SECTION("basics") {
+
+        REQUIRE(r.filter(Query(table->where().less(0, 2))).size() == 2);
+        BENCHMARK("basic filter") {
+            return r.filter(Query(table->where().less(0, 2))).size();
+        };
+
+        REQUIRE_ORDER((r.sort({{"value", true}})), 2, 3, 0, 1);
+        BENCHMARK("sort simple ints") {
+            return r.sort({{"value", true}});
+        };
+
+        REQUIRE_ORDER((r.sort({{"bool", true}, {"value", true}})), 2, 0, 3, 1);
+        BENCHMARK("sort over two properties") {
+            return r.sort({{"bool", true}, {"value", true}});
+        };
+
+        REQUIRE_ORDER((r.sort({{"link.value", true}})), 0, 3, 2, 1);
+        BENCHMARK("sort over link") {
+            return r.sort({{"link.value", true}});
+        };
+
+        REQUIRE_ORDER((r.sort({{"link.link.value", true}})), 1, 0, 3, 2);
+        BENCHMARK("sort over two links") {
+            return r.sort({{"link.link.value", true}});
+        };
+
+        REQUIRE(r.distinct({{"value"}}).size() == 4);
+        BENCHMARK("distinct ints") {
+            return r.distinct({{"value"}});
+        };
+
+        REQUIRE(r.distinct({{"bool"}}).size() == 2);
+        BENCHMARK("distinct bool") {
+            return r.distinct({{"bool"}});
+        };
+    }
+}
+


### PR DESCRIPTION
This is mostly to set up the benchmarking framework with some examples.

Although Catch2 supports intermixing benchmarks and unit tests, I chose to separate out the benchmarks into a different target. This separation means no increase in compile times for the unit tests, and no mixed output between tests and benchmarks.

The benchmark documentation is [here](https://github.com/catchorg/Catch2/blob/master/docs/benchmarks.md#top)