### PR TITLE
Upgrade Catch2 to 2.10.0

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -149,7 +149,6 @@ stage('prepare') {
     sh 'git clean -ffdx -e .????????'
     sshagent(['realm-ci-ssh']) {
       sh 'git submodule update --init --recursive'
-      sh 'cd external/catch && python scripts/generateSingleHeader.py' // FIXME: remove after upgrading to catch > 2.9.2
     }
 
     gitTag = readGitTag()


### PR DESCRIPTION
Catch2 was released this weekend with a workaround for old compilers (aka our ancient android ndk r10e) missing support for `std::nextafter` by using a config `CATCH_CONFIG_GLOBAL_NEXTAFTER`. The release just means we no longer have to manually generate the header file.

[Release notes.](https://github.com/catchorg/Catch2/blob/master/docs/release-notes.md#2100)