### PR TITLE
Properly propagate update_only_diff through List::assign()

### DIFF
--- a/src/object.hpp
+++ b/src/object.hpp
@@ -32,6 +32,18 @@ namespace _impl {
     class ObjectNotifier;
 }
 
+enum class CreatePolicy : int8_t {
+    // Do not create objects if given something that could be converted to a
+    // Realm object but isn't. Used for things like find().
+    Skip,
+    // Throw an exception if an object with the same PK already exists.
+    ForceCreate,
+    // If an object with the same PK already exists, set all fields in the input.
+    UpdateAll,
+    // If an object with the same PK already exists, only set fields which have changed.
+    UpdateModified
+};
+
 class Object {
 public:
     Object();
@@ -65,7 +77,7 @@ public:
     // property getter/setter
     template<typename ValueType, typename ContextType>
     void set_property_value(ContextType& ctx, StringData prop_name,
-                            ValueType value, bool try_update);
+                            ValueType value, CreatePolicy policy = CreatePolicy::ForceCreate);
 
     template<typename ValueType, typename ContextType>
     ValueType get_property_value(ContextType& ctx, StringData prop_name);
@@ -77,13 +89,13 @@ public:
     template<typename ValueType, typename ContextType>
     static Object create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
                          const ObjectSchema &object_schema, ValueType value,
-                         bool try_update = false, bool update_only_diff = false,
+                         CreatePolicy policy = CreatePolicy::ForceCreate,
                          size_t current_row = size_t(-1), Row* = nullptr);
 
     template<typename ValueType, typename ContextType>
     static Object create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
                          StringData object_type, ValueType value,
-                         bool try_update = false, bool update_only_diff = false,
+                         CreatePolicy policy = CreatePolicy::ForceCreate,
                          size_t current_row = size_t(-1), Row* = nullptr);
 
     template<typename ValueType, typename ContextType>
@@ -109,7 +121,7 @@ private:
 
     template<typename ValueType, typename ContextType>
     void set_property_value_impl(ContextType& ctx, const Property &property,
-                                 ValueType value, bool try_update, bool update_only_diff, bool is_default);
+                                 ValueType value, CreatePolicy policy, bool is_default);
     template<typename ValueType, typename ContextType>
     ValueType get_property_value_impl(ContextType& ctx, const Property &property);
 

--- a/src/object_accessor.hpp
+++ b/src/object_accessor.hpp
@@ -41,7 +41,7 @@
 
 namespace realm {
 template <typename ValueType, typename ContextType>
-void Object::set_property_value(ContextType& ctx, StringData prop_name, ValueType value, bool try_update)
+void Object::set_property_value(ContextType& ctx, StringData prop_name, ValueType value, CreatePolicy policy)
 {
     verify_attached();
     m_realm->verify_in_write();
@@ -53,7 +53,7 @@ void Object::set_property_value(ContextType& ctx, StringData prop_name, ValueTyp
     if (property.is_primary && !m_realm->is_in_migration())
         throw ModifyPrimaryKeyException(m_object_schema->name, property.name);
 
-    set_property_value_impl(ctx, property, value, try_update, false, false);
+    set_property_value_impl(ctx, property, value, policy, false);
 }
 
 template <typename ValueType, typename ContextType>
@@ -76,16 +76,15 @@ struct ValueUpdater {
     ValueType& value;
     RowExpr row;
     size_t col;
-    bool try_update;
-    bool update_only_diff;
+    CreatePolicy policy;
     bool is_default;
 
     void operator()(RowExpr*)
     {
         ContextType child_ctx(ctx, property);
         auto curr_link = row.get_link(col);
-        auto link = child_ctx.template unbox<RowExpr>(value, true, try_update, update_only_diff, curr_link);
-        if (!update_only_diff || curr_link != link.get_index()) {
+        auto link = child_ctx.template unbox<RowExpr>(value, policy, curr_link);
+        if (policy != CreatePolicy::UpdateModified || curr_link != link.get_index()) {
             row.set_link(col, link.get_index());
         }
     }
@@ -94,7 +93,7 @@ struct ValueUpdater {
     void operator()(T*)
     {
         auto new_val = ctx.template unbox<T>(value);
-        if (!update_only_diff || row.get<T>(col) != new_val) {
+        if (policy != CreatePolicy::UpdateModified || row.get<T>(col) != new_val) {
             row.set(col, new_val, is_default);
         }
     }
@@ -103,7 +102,7 @@ struct ValueUpdater {
 
 template <typename ValueType, typename ContextType>
 void Object::set_property_value_impl(ContextType& ctx, const Property &property,
-                                     ValueType value, bool try_update, bool update_only_diff, bool is_default)
+                                     ValueType value, CreatePolicy policy, bool is_default)
 {
     ctx.will_change(*this, property);
 
@@ -111,7 +110,7 @@ void Object::set_property_value_impl(ContextType& ctx, const Property &property,
     size_t col = property.table_column;
     size_t row = m_row.get_index();
     if (is_nullable(property.type) && ctx.is_null(value)) {
-        if (!update_only_diff || !table.is_null(col, row)) {
+        if (policy != CreatePolicy::UpdateModified || !table.is_null(col, row)) {
             if (property.type == PropertyType::Object) {
                 if (!is_default)
                     table.nullify_link(col, row);
@@ -131,13 +130,13 @@ void Object::set_property_value_impl(ContextType& ctx, const Property &property,
 
         ContextType child_ctx(ctx, property);
         List list(m_realm, table, col, m_row.get_index());
-        list.assign(child_ctx, value, try_update, update_only_diff);
+        list.assign(child_ctx, value, policy);
         ctx.did_change();
         return;
     }
 
     ValueUpdater<ValueType, ContextType> updater{ctx, property, value,
-        table.get(row),col, try_update, update_only_diff, is_default};
+        table.get(row),col, policy, is_default};
     switch_on_type(property.type, updater);
     ctx.did_change();
 }
@@ -181,17 +180,17 @@ ValueType Object::get_property_value_impl(ContextType& ctx, const Property &prop
 template<typename ValueType, typename ContextType>
 Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
                       StringData object_type, ValueType value,
-                      bool try_update, bool update_only_diff, size_t current_row, Row* out_row)
+                      CreatePolicy policy, size_t current_row, Row* out_row)
 {
     auto object_schema = realm->schema().find(object_type);
     REALM_ASSERT(object_schema != realm->schema().end());
-    return create(ctx, realm, *object_schema, value, try_update, update_only_diff, current_row, out_row);
+    return create(ctx, realm, *object_schema, value, policy, current_row, out_row);
 }
 
 template<typename ValueType, typename ContextType>
 Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
                       ObjectSchema const& object_schema, ValueType value,
-                      bool try_update, bool update_only_diff, size_t current_row, Row* out_row)
+                      CreatePolicy policy, size_t current_row, Row* out_row)
 {
     realm->verify_in_write();
 
@@ -242,7 +241,7 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
                 REALM_TERMINATE("Unsupported primary key type.");
             }
         }
-        else if (!try_update) {
+        else if (policy == CreatePolicy::ForceCreate) {
             if (realm->is_in_migration()) {
                 // Creating objects with duplicate primary keys is allowed in migrations
                 // as long as there are no duplicates at the end, as adding an entirely
@@ -258,7 +257,7 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
         }
     }
     else {
-        if (update_only_diff && current_row != realm::not_found) {
+        if (policy == CreatePolicy::UpdateModified && current_row != realm::not_found) {
             row_index = current_row;
         }
         else {
@@ -294,7 +293,7 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
                 throw MissingPropertyValueException(object_schema.name, prop.name);
         }
         if (v)
-            object.set_property_value_impl(ctx, prop, *v, try_update, update_only_diff, is_default);
+            object.set_property_value_impl(ctx, prop, *v, policy, is_default);
     }
 #if REALM_ENABLE_SYNC
     if (realm->is_partial() && object_schema.name == "__User") {

--- a/src/results.hpp
+++ b/src/results.hpp
@@ -328,7 +328,9 @@ auto Results::last(Context& ctx)
 template<typename Context, typename T>
 size_t Results::index_of(Context& ctx, T value)
 {
-    return dispatch([&](auto t) { return this->index_of(ctx.template unbox<std::decay_t<decltype(*t)>>(value)); });
+    return dispatch([&](auto t) {
+        return this->index_of(ctx.template unbox<std::decay_t<decltype(*t)>>(value, CreatePolicy::Skip));
+    });
 }
 
 template <typename ValueType, typename ContextType>
@@ -352,7 +354,7 @@ void Results::set_property_value(ContextType& ctx, StringData prop_name, ValueTy
     size_t size = snapshot.size();
     for (size_t i = 0; i < size; ++i) {
         Object obj(m_realm, *m_object_schema, snapshot.get(i));
-        obj.set_property_value_impl(ctx, *prop, value, true, false, false);
+        obj.set_property_value_impl(ctx, *prop, value, CreatePolicy::ForceCreate, false);
     }
 }
 

--- a/src/sync/sync_permission.cpp
+++ b/src/sync/sync_permission.cpp
@@ -258,7 +258,7 @@ void Permissions::perform_async_operation(const std::string& object_type,
 
     // Write the permission object.
     realm->begin_transaction();
-    auto raw = Object::create<util::Any>(context, realm, *realm->schema().find(object_type), std::move(props), false);
+    auto raw = Object::create<util::Any>(context, realm, *realm->schema().find(object_type), std::move(props));
     auto object = std::make_shared<_impl::NotificationWrapper<Object>>(std::move(raw));
     realm->commit_transaction();
 

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -746,7 +746,7 @@ TEST_CASE("migration: Automatic") {
             {"array", AnyVector{AnyDict{{"value", INT64_C(20)}}}},
         };
         realm->begin_transaction();
-        Object::create(ctx, realm, *realm->schema().find("all types"), values, false);
+        Object::create(ctx, realm, *realm->schema().find("all types"), values);
         realm->commit_transaction();
 
         SECTION("read values from old realm") {
@@ -795,7 +795,7 @@ TEST_CASE("migration: Automatic") {
                 Object obj = Object::get_for_primary_key(ctx, old_realm, "all types",
                                                          util::Any(INT64_C(1)));
                 REQUIRE(obj.is_valid());
-                REQUIRE_THROWS(obj.set_property_value(ctx, "bool", util::Any(false), false));
+                REQUIRE_THROWS(obj.set_property_value(ctx, "bool", util::Any(false)));
                 REQUIRE_THROWS(old_realm->begin_transaction());
             });
         }
@@ -847,31 +847,31 @@ TEST_CASE("migration: Automatic") {
                 REQUIRE(obj.is_valid());
 
                 REQUIRE(any_cast<bool>(obj.get_property_value<util::Any>(ctx, "bool")) == true);
-                obj.set_property_value(ctx, "bool", util::Any(false), false);
+                obj.set_property_value(ctx, "bool", util::Any(false));
                 REQUIRE(any_cast<bool>(obj.get_property_value<util::Any>(ctx, "bool")) == false);
 
                 REQUIRE(any_cast<int64_t>(obj.get_property_value<util::Any>(ctx, "int")) == 5);
-                obj.set_property_value(ctx, "int", util::Any(INT64_C(6)), false);
+                obj.set_property_value(ctx, "int", util::Any(INT64_C(6)));
                 REQUIRE(any_cast<int64_t>(obj.get_property_value<util::Any>(ctx, "int")) == 6);
 
                 REQUIRE(any_cast<float>(obj.get_property_value<util::Any>(ctx, "float")) == 2.2f);
-                obj.set_property_value(ctx, "float", util::Any(1.23f), false);
+                obj.set_property_value(ctx, "float", util::Any(1.23f));
                 REQUIRE(any_cast<float>(obj.get_property_value<util::Any>(ctx, "float")) == 1.23f);
 
                 REQUIRE(any_cast<double>(obj.get_property_value<util::Any>(ctx, "double")) == 3.3);
-                obj.set_property_value(ctx, "double", util::Any(1.23), false);
+                obj.set_property_value(ctx, "double", util::Any(1.23));
                 REQUIRE(any_cast<double>(obj.get_property_value<util::Any>(ctx, "double")) == 1.23);
 
                 REQUIRE(any_cast<std::string>(obj.get_property_value<util::Any>(ctx, "string")) == "hello");
-                obj.set_property_value(ctx, "string", util::Any("abc"s), false);
+                obj.set_property_value(ctx, "string", util::Any("abc"s));
                 REQUIRE(any_cast<std::string>(obj.get_property_value<util::Any>(ctx, "string")) == "abc");
 
                 REQUIRE(any_cast<std::string>(obj.get_property_value<util::Any>(ctx, "data")) == "olleh");
-                obj.set_property_value(ctx, "data", util::Any("abc"s), false);
+                obj.set_property_value(ctx, "data", util::Any("abc"s));
                 REQUIRE(any_cast<std::string>(obj.get_property_value<util::Any>(ctx, "data")) == "abc");
 
                 REQUIRE(any_cast<Timestamp>(obj.get_property_value<util::Any>(ctx, "date")) == Timestamp(10, 20));
-                obj.set_property_value(ctx, "date", util::Any(Timestamp(1, 2)), false);
+                obj.set_property_value(ctx, "date", util::Any(Timestamp(1, 2)));
                 REQUIRE(any_cast<Timestamp>(obj.get_property_value<util::Any>(ctx, "date")) == Timestamp(1, 2));
 
                 Object linked_obj(new_realm, "link target", 0);
@@ -882,7 +882,7 @@ TEST_CASE("migration: Automatic") {
 
                 REQUIRE(any_cast<Object>(obj.get_property_value<util::Any>(ctx, "object")).row().get_index()
                         == linked_obj.row().get_index());
-                obj.set_property_value(ctx, "object", util::Any(new_obj), false);
+                obj.set_property_value(ctx, "object", util::Any(new_obj));
                 REQUIRE(any_cast<Object>(obj.get_property_value<util::Any>(ctx, "object")).row().get_index()
                         == new_obj.row().get_index());
 
@@ -896,7 +896,7 @@ TEST_CASE("migration: Automatic") {
 
                 CppContext ctx(new_realm);
                 any_cast<AnyDict&>(values)["pk"] = INT64_C(2);
-                Object obj = Object::create(ctx, new_realm, "all types", values, false);
+                Object obj = Object::create(ctx, new_realm, "all types", values);
 
                 REQUIRE(get_table(new_realm, "all types")->size() == 2);
                 REQUIRE(get_table(new_realm, "link target")->size() == 2);
@@ -910,7 +910,7 @@ TEST_CASE("migration: Automatic") {
                 REQUIRE(new_realm->is_in_transaction());
                 CppContext ctx(new_realm);
                 any_cast<AnyDict&>(values)["bool"] = false;
-                Object obj = Object::create(ctx, new_realm, "all types", values, true);
+                Object obj = Object::create(ctx, new_realm, "all types", values, CreatePolicy::UpdateAll);
                 REQUIRE(get_table(new_realm, "all types")->size() == 1);
                 REQUIRE(get_table(new_realm, "link target")->size() == 2);
                 REQUIRE(get_table(new_realm, "array target")->size() == 2);
@@ -924,14 +924,14 @@ TEST_CASE("migration: Automatic") {
                 Object obj(new_realm, "all types", 0);
 
                 CppContext ctx(new_realm);
-                obj.set_property_value(ctx, "pk", util::Any("1"s), false);
+                obj.set_property_value(ctx, "pk", util::Any("1"s));
             });
         }
 
         SECTION("set primary key to duplicate values in migration") {
             auto bad_migration = [&](auto, auto new_realm, Schema&) {
                 // shoud be able to create a new object with the same PK
-                REQUIRE_NOTHROW(Object::create(ctx, new_realm, "all types", values, false));
+                REQUIRE_NOTHROW(Object::create(ctx, new_realm, "all types", values));
                 REQUIRE(get_table(new_realm, "all types")->size() == 2);
 
                 // but it'll fail at the end
@@ -940,12 +940,12 @@ TEST_CASE("migration: Automatic") {
             REQUIRE(get_table(realm, "all types")->size() == 1);
 
             auto good_migration = [&](auto, auto new_realm, Schema&) {
-                REQUIRE_NOTHROW(Object::create(ctx, new_realm, "all types", values, false));
+                REQUIRE_NOTHROW(Object::create(ctx, new_realm, "all types", values));
 
                 // Change the old object's PK to elminate the duplication
                 Object old_obj(new_realm, "all types", 0);
                 CppContext ctx(new_realm);
-                old_obj.set_property_value(ctx, "pk", util::Any(INT64_C(5)), false);
+                old_obj.set_property_value(ctx, "pk", util::Any(INT64_C(5)));
             };
             REQUIRE_NOTHROW(realm->update_schema(schema, 2, good_migration));
             REQUIRE(get_table(realm, "all types")->size() == 2);

--- a/tests/object.cpp
+++ b/tests/object.cpp
@@ -297,21 +297,21 @@ TEST_CASE("object") {
     }
 
     TestContext d(r);
-    auto create = [&](util::Any&& value, bool update, bool update_only_diff = false) {
+    auto create = [&](util::Any&& value, CreatePolicy policy = CreatePolicy::ForceCreate) {
         r->begin_transaction();
-        auto obj = Object::create(d, r, *r->schema().find("all types"), value, update, update_only_diff);
+        auto obj = Object::create(d, r, *r->schema().find("all types"), value, policy);
         r->commit_transaction();
         return obj;
     };
-    auto create_sub = [&](util::Any&& value, bool update, bool update_only_diff = false) {
+    auto create_sub = [&](util::Any&& value, CreatePolicy policy = CreatePolicy::ForceCreate) {
         r->begin_transaction();
-        auto obj = Object::create(d, r, *r->schema().find("link target"), value, update, update_only_diff);
+        auto obj = Object::create(d, r, *r->schema().find("link target"), value, policy);
         r->commit_transaction();
         return obj;
     };
-    auto create_company = [&](util::Any&& value, bool update, bool update_only_diff = false) {
+    auto create_company = [&](util::Any&& value, CreatePolicy policy = CreatePolicy::ForceCreate) {
         r->begin_transaction();
-        auto obj = Object::create(d, r, *r->schema().find("person"), value, update, update_only_diff);
+        auto obj = Object::create(d, r, *r->schema().find("person"), value, policy);
         r->commit_transaction();
         return obj;
     };
@@ -336,7 +336,7 @@ TEST_CASE("object") {
             {"data array", AnyVec{"d"s, "e"s, "f"s}},
             {"date array", AnyVec{}},
             {"object array", AnyVec{AnyDict{{"value", INT64_C(20)}}}},
-        }, false);
+        });
 
         auto row = obj.row();
         REQUIRE(row.get_int(0) == 1);
@@ -398,7 +398,7 @@ TEST_CASE("object") {
         auto obj = create(AnyDict{
             {"pk", INT64_C(1)},
             {"float", 6.6f},
-        }, false);
+        });
 
         auto row = obj.row();
         REQUIRE(row.get_int(0) == 1);
@@ -434,7 +434,7 @@ TEST_CASE("object") {
             {"date", Timestamp(10, 20)},
             {"object", AnyDict{{"value", INT64_C(10)}}},
             {"array", AnyVector{AnyDict{{"value", INT64_C(20)}}}},
-        }, false);
+        });
 
         auto row = obj.row();
         REQUIRE(row.get_int(0) == 10);
@@ -443,7 +443,7 @@ TEST_CASE("object") {
     SECTION("create does not complain about missing values for nullable fields") {
         r->begin_transaction();
         realm::Object obj;
-        REQUIRE_NOTHROW(obj = Object::create(d, r, *r->schema().find("all optional types"), util::Any(AnyDict{}), false));
+        REQUIRE_NOTHROW(obj = Object::create(d, r, *r->schema().find("all optional types"), util::Any(AnyDict{})));
         r->commit_transaction();
 
         REQUIRE_FALSE(obj.get_property_value<util::Any>(d, "pk").has_value());
@@ -468,7 +468,7 @@ TEST_CASE("object") {
         REQUIRE_THROWS(create(AnyDict{
             {"pk", INT64_C(1)},
             {"float", 6.6f},
-        }, false));
+        }));
     }
 
     SECTION("create always sets the PK first") {
@@ -481,7 +481,7 @@ TEST_CASE("object") {
         };
         // Core will throw if the list is populated before the PK is set
         r->begin_transaction();
-        REQUIRE_NOTHROW(Object::create(d, r, *r->schema().find("pk after list"), util::Any(value), false));
+        REQUIRE_NOTHROW(Object::create(d, r, *r->schema().find("pk after list"), util::Any(value)));
     }
 
     SECTION("create with update") {
@@ -506,7 +506,7 @@ TEST_CASE("object") {
             {"data array", AnyVec{"d"s, "e"s, "f"s}},
             {"date array", AnyVec{}},
             {"object array", AnyVec{AnyDict{{"value", INT64_C(20)}}}},
-        }, false);
+        });
 
         auto token = obj.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
             change = c;
@@ -518,7 +518,7 @@ TEST_CASE("object") {
             {"pk", INT64_C(1)},
             {"int", INT64_C(6)},
             {"string", "a"s},
-        }, true);
+        }, CreatePolicy::UpdateAll);
 
         callback_called = false;
         advance_and_notify(*r);
@@ -563,7 +563,7 @@ TEST_CASE("object") {
             {"assistant", donald},
             {"team", AnyVec{donald, charley}}
         };
-        Object obj = create_company(eddie, true);
+        Object obj = create_company(eddie, CreatePolicy::UpdateAll);
 
         auto table = r->read_group().get_table("class_person");
         REQUIRE(table->size() == 5);
@@ -575,7 +575,7 @@ TEST_CASE("object") {
         advance_and_notify(*r);
 
         // First update unconditionally
-        create_company(eddie, true, false);
+        create_company(eddie, CreatePolicy::UpdateAll);
 
         callback_called = false;
         advance_and_notify(*r);
@@ -583,7 +583,7 @@ TEST_CASE("object") {
         REQUIRE_INDICES(change.modifications, 0, 1, 2, 3, 4);
 
         // Now, only update where differences (there should not be any diffs - so no update)
-        create_company(eddie, true, true);
+        create_company(eddie, CreatePolicy::UpdateModified);
 
         REQUIRE(table->size() == 5);
         callback_called = false;
@@ -594,7 +594,7 @@ TEST_CASE("object") {
         donald["scores"] = AnyVec{INT64_C(3), INT64_C(4), INT64_C(5)};
         // Insert the new donald
         eddie["assistant"] = donald;
-        create_company(eddie, true, true);
+        create_company(eddie, CreatePolicy::UpdateModified);
 
         REQUIRE(table->size() == 5);
         callback_called = false;
@@ -605,7 +605,7 @@ TEST_CASE("object") {
         // Shorten list
         donald["scores"] = AnyVec{INT64_C(3), INT64_C(4)};
         eddie["assistant"] = donald;
-        create_company(eddie, true, true);
+        create_company(eddie, CreatePolicy::UpdateModified);
 
         REQUIRE(table->size() == 5);
         callback_called = false;
@@ -615,9 +615,7 @@ TEST_CASE("object") {
     }
 
     SECTION("create with update - identical sub-object") {
-        bool callback_called;
-        bool sub_callback_called;
-        Object sub_obj = create_sub(AnyDict{{"value", INT64_C(10)}}, false);
+        Object sub_obj = create_sub(AnyDict{{"value", INT64_C(10)}});
         Object obj = create(AnyDict{
             {"pk", INT64_C(1)},
             {"bool", true},
@@ -628,12 +626,20 @@ TEST_CASE("object") {
             {"data", "olleh"s},
             {"date", Timestamp(10, 20)},
             {"object", sub_obj},
-        }, false);
+        });
 
+        auto obj_table = r->read_group().get_table("class_all types");
+        Results result(r, *obj_table);
+        bool callback_called;
+        bool results_callback_called;
+        bool sub_callback_called;
         auto token1 = obj.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
             callback_called = true;
         });
-        auto token2 = sub_obj.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+        auto token2 = result.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+            results_callback_called = true;
+        });
+        auto token3 = sub_obj.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
             sub_callback_called = true;
         });
         advance_and_notify(*r);
@@ -651,13 +657,15 @@ TEST_CASE("object") {
             {"data", "olleh"s},
             {"date", Timestamp(10, 20)},
             {"object", AnyDict{{"value", INT64_C(10)}}},
-        }, true, true);
+        }, CreatePolicy::UpdateModified);
 
         REQUIRE(table->size() == 1);
         callback_called = false;
+        results_callback_called = false;
         sub_callback_called = false;
         advance_and_notify(*r);
         REQUIRE(!callback_called);
+        REQUIRE(!results_callback_called);
         REQUIRE(!sub_callback_called);
 
         // Now change sub object
@@ -671,12 +679,14 @@ TEST_CASE("object") {
             {"data", "olleh"s},
             {"date", Timestamp(10, 20)},
             {"object", AnyDict{{"value", INT64_C(11)}}},
-        }, true, true);
+        }, CreatePolicy::UpdateModified);
 
         callback_called = false;
+        results_callback_called = false;
         sub_callback_called = false;
         advance_and_notify(*r);
         REQUIRE(!callback_called);
+        REQUIRE(results_callback_called);
         REQUIRE(sub_callback_called);
     }
 
@@ -691,16 +701,18 @@ TEST_CASE("object") {
             {"string", "hello"s},
             {"data", "olleh"s},
             {"date", Timestamp(10, 20)},
-            {"object array", AnyVec{ AnyDict{{"value", INT64_C(20)}}, AnyDict{{"value", INT64_C(21)}} } },
+            {"object array", AnyVec{AnyDict{{"value", INT64_C(20)}}, AnyDict{{"value", INT64_C(21)}}}},
         };
-        Object obj = create(dict, false);
+        Object obj = create(dict);
 
-        auto token1 = obj.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
+        auto obj_table = r->read_group().get_table("class_all types");
+        Results result(r, *obj_table);
+        auto token1 = result.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
             callback_called = true;
         });
         advance_and_notify(*r);
 
-        create(dict, true, true);
+        create(dict, CreatePolicy::UpdateModified);
 
         callback_called = false;
         advance_and_notify(*r);
@@ -708,15 +720,15 @@ TEST_CASE("object") {
 
         // Now change list
         dict["object array"] = AnyVec{AnyDict{{"value", INT64_C(23)}}};
-        create(dict, true, true);
+        create(dict, CreatePolicy::UpdateModified);
 
         callback_called = false;
         advance_and_notify(*r);
         REQUIRE(callback_called);
     }
 
-    for (auto diffed_update : {false, true}) {
-        SECTION("set existing fields to null with update "s + (diffed_update ? "(diffed)" : "(all)")) {
+    for (auto policy : {CreatePolicy::UpdateAll, CreatePolicy::UpdateModified}) {
+        SECTION("set existing fields to null with update "s + (policy == CreatePolicy::UpdateModified ? "(diffed)" : "(all)")) {
             AnyDict initial_values{
                 {"pk", INT64_C(1)},
                 {"bool", true},
@@ -741,7 +753,7 @@ TEST_CASE("object") {
 
             // Missing fields in dictionary do not update anything
             Object::create(d, r, *r->schema().find("all optional types"),
-                           util::Any(AnyDict{{"pk", INT64_C(1)}}), true, diffed_update);
+                           util::Any(AnyDict{{"pk", INT64_C(1)}}), policy);
 
             REQUIRE(any_cast<bool>(obj.get_property_value<util::Any>(d, "bool")) == true);
             REQUIRE(any_cast<int64_t>(obj.get_property_value<util::Any>(d, "int")) == 5);
@@ -776,7 +788,7 @@ TEST_CASE("object") {
                 {"data array", AnyVec{util::Any()}},
                 {"date array", AnyVec{Timestamp()}},
             };
-            Object::create(d, r, *r->schema().find("all optional types"), util::Any(null_values), true, diffed_update);
+            Object::create(d, r, *r->schema().find("all optional types"), util::Any(null_values), policy);
 
             REQUIRE_FALSE(obj.get_property_value<util::Any>(d, "bool").has_value());
             REQUIRE_FALSE(obj.get_property_value<util::Any>(d, "int").has_value());
@@ -795,7 +807,7 @@ TEST_CASE("object") {
             REQUIRE(any_cast<List&&>(obj.get_property_value<util::Any>(d, "date array")).get<Timestamp>(0) == Timestamp());
 
             // Set all properties back to non-null
-            Object::create(d, r, *r->schema().find("all optional types"), util::Any(initial_values), true, diffed_update);
+            Object::create(d, r, *r->schema().find("all optional types"), util::Any(initial_values), policy);
             REQUIRE(any_cast<bool>(obj.get_property_value<util::Any>(d, "bool")) == true);
             REQUIRE(any_cast<int64_t>(obj.get_property_value<util::Any>(d, "int")) == 5);
             REQUIRE(any_cast<float>(obj.get_property_value<util::Any>(d, "float")) == 2.2f);
@@ -824,7 +836,7 @@ TEST_CASE("object") {
             {"date", Timestamp(10, 20)},
             {"object", AnyDict{{"value", INT64_C(10)}}},
             {"array", AnyVector{AnyDict{{"value", INT64_C(20)}}}},
-        }, false);
+        });
         REQUIRE_THROWS(create(AnyDict{
             {"pk", INT64_C(1)},
             {"bool", true},
@@ -836,7 +848,7 @@ TEST_CASE("object") {
             {"date", Timestamp(10, 20)},
             {"object", AnyDict{{"value", INT64_C(10)}}},
             {"array", AnyVector{AnyDict{{"value", INT64_C(20)}}}},
-        }, false));
+        }));
     }
 
     SECTION("create with explicit null pk does not fall back to default") {
@@ -848,7 +860,7 @@ TEST_CASE("object") {
         };
         auto create = [&](util::Any&& value, StringData type) {
             r->begin_transaction();
-            auto obj = Object::create(d, r, *r->schema().find(type), value, false);
+            auto obj = Object::create(d, r, *r->schema().find(type), value);
             r->commit_transaction();
             return obj;
         };
@@ -875,41 +887,41 @@ TEST_CASE("object") {
         link_table.add_empty_row();
         Object linkobj(r, *r->schema().find("link target"), link_table[0]);
 
-        obj.set_property_value(d, "bool", util::Any(true), false);
+        obj.set_property_value(d, "bool", util::Any(true));
         REQUIRE(any_cast<bool>(obj.get_property_value<util::Any>(d, "bool")) == true);
 
-        obj.set_property_value(d, "int", util::Any(INT64_C(5)), false);
+        obj.set_property_value(d, "int", util::Any(INT64_C(5)));
         REQUIRE(any_cast<int64_t>(obj.get_property_value<util::Any>(d, "int")) == 5);
 
-        obj.set_property_value(d, "float", util::Any(1.23f), false);
+        obj.set_property_value(d, "float", util::Any(1.23f));
         REQUIRE(any_cast<float>(obj.get_property_value<util::Any>(d, "float")) == 1.23f);
 
-        obj.set_property_value(d, "double", util::Any(1.23), false);
+        obj.set_property_value(d, "double", util::Any(1.23));
         REQUIRE(any_cast<double>(obj.get_property_value<util::Any>(d, "double")) == 1.23);
 
-        obj.set_property_value(d, "string", util::Any("abc"s), false);
+        obj.set_property_value(d, "string", util::Any("abc"s));
         REQUIRE(any_cast<std::string>(obj.get_property_value<util::Any>(d, "string")) == "abc");
 
-        obj.set_property_value(d, "data", util::Any("abc"s), false);
+        obj.set_property_value(d, "data", util::Any("abc"s));
         REQUIRE(any_cast<std::string>(obj.get_property_value<util::Any>(d, "data")) == "abc");
 
-        obj.set_property_value(d, "date", util::Any(Timestamp(1, 2)), false);
+        obj.set_property_value(d, "date", util::Any(Timestamp(1, 2)));
         REQUIRE(any_cast<Timestamp>(obj.get_property_value<util::Any>(d, "date")) == Timestamp(1, 2));
 
         REQUIRE_FALSE(obj.get_property_value<util::Any>(d, "object").has_value());
-        obj.set_property_value(d, "object", util::Any(linkobj), false);
+        obj.set_property_value(d, "object", util::Any(linkobj));
         REQUIRE(any_cast<Object>(obj.get_property_value<util::Any>(d, "object")).row().get_index() == linkobj.row().get_index());
 
         auto linking = any_cast<Results>(linkobj.get_property_value<util::Any>(d, "origin"));
         REQUIRE(linking.size() == 1);
 
-        REQUIRE_THROWS(obj.set_property_value(d, "pk", util::Any(INT64_C(5)), false));
-        REQUIRE_THROWS(obj.set_property_value(d, "not a property", util::Any(INT64_C(5)), false));
+        REQUIRE_THROWS(obj.set_property_value(d, "pk", util::Any(INT64_C(5))));
+        REQUIRE_THROWS(obj.set_property_value(d, "not a property", util::Any(INT64_C(5))));
 
         r->commit_transaction();
 
         REQUIRE_THROWS(obj.get_property_value<util::Any>(d, "not a property"));
-        REQUIRE_THROWS(obj.set_property_value(d, "int", util::Any(INT64_C(5)), false));
+        REQUIRE_THROWS(obj.set_property_value(d, "int", util::Any(INT64_C(5))));
     }
 
     SECTION("list property self-assign is a no-op") {
@@ -925,14 +937,14 @@ TEST_CASE("object") {
 
             {"bool array", AnyVec{true, false}},
             {"object array", AnyVec{AnyDict{{"value", INT64_C(20)}}}},
-        }, false);
+        });
 
         REQUIRE(any_cast<List&&>(obj.get_property_value<util::Any>(d, "bool array")).size() == 2);
         REQUIRE(any_cast<List&&>(obj.get_property_value<util::Any>(d, "object array")).size() == 1);
 
         r->begin_transaction();
-        obj.set_property_value(d, "bool array", obj.get_property_value<util::Any>(d, "bool array"), false);
-        obj.set_property_value(d, "object array", obj.get_property_value<util::Any>(d, "object array"), false);
+        obj.set_property_value(d, "bool array", obj.get_property_value<util::Any>(d, "bool array"));
+        obj.set_property_value(d, "object array", obj.get_property_value<util::Any>(d, "object array"));
         r->commit_transaction();
 
         REQUIRE(any_cast<List&&>(obj.get_property_value<util::Any>(d, "bool array")).size() == 2);
@@ -973,8 +985,8 @@ TEST_CASE("object") {
 
         r1->begin_transaction();
         r2->begin_transaction();
-        auto obj = Object::create(c1, r1, *r1->schema().find("pk after list"), util::Any(v1), false);
-        Object::create(c2, r2, *r2->schema().find("pk after list"), util::Any(v2), false);
+        auto obj = Object::create(c1, r1, *r1->schema().find("pk after list"), util::Any(v1));
+        Object::create(c2, r2, *r2->schema().find("pk after list"), util::Any(v2));
         r2->commit_transaction();
         r1->commit_transaction();
 

--- a/tests/sync/metadata.cpp
+++ b/tests/sync/metadata.cpp
@@ -96,12 +96,12 @@ TEST_CASE("sync_metadata: migration", "[sync]") {
                 { "identity", identity_1 },
                 { "marked_for_removal", false },
                 { "user_token", token }
-            }, false);
+            });
             Object::create<util::Any>(context, realm, user_metadata_schema, AnyDict{
                 { "identity", identity_2 },
                 { "marked_for_removal", false },
                 { "auth_server_url", auth_server_url }
-            }, false);
+            });
             realm->commit_transaction();
         }
         // Open v2 metadata
@@ -157,13 +157,13 @@ TEST_CASE("sync_metadata: migration", "[sync]") {
                 { "marked_for_removal", false },
                 { "user_token", token },
                 { "user_is_admin", false }
-            }, false);
+            });
             Object::create<util::Any>(context, realm, user_metadata_schema, AnyDict{
                 { "identity", identity_2 },
                 { "marked_for_removal", false },
                 { "auth_server_url", auth_server_url },
                 { "user_is_admin", true }
-            }, false);
+            });
             realm->commit_transaction();
         }
         // Open v2 metadata

--- a/tests/sync/permission.cpp
+++ b/tests/sync/permission.cpp
@@ -105,7 +105,7 @@ static void subscribe_to_all(std::shared_ptr<Realm> const& r)
         {"updated_at", Timestamp(0, 0)},
         {"expires_at", Timestamp()},
         {"time_to_live", {}},
-    }, false);
+    });
 
     r->commit_transaction();
 


### PR DESCRIPTION
Calling Object::create(update_only_diff=true) on an object type which had a List of objects would fail to propagate update_only_diff=true to the sub-calls of Object::create(), resulting it those objects not being diffed and incorrect change notifications being generated.

Because passing around 3 booleans all over the place is incredibly awkward and error-prone, I turned create/update/update_only_diff into a single enum that represents all of the valid combinations of those. This should make it impossible to have a similar bug elsewhere, as it'd have to fail to propagate the policy entirely and that's much more likely to be caught by tests.

See https://github.com/realm/realm-cocoa/issues/6321.