### PR TITLE
Add support for creating a sync session manually

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -345,7 +345,7 @@ std::shared_ptr<AsyncOpenTask> RealmCoordinator::get_synchronized_realm(Realm::C
     return std::make_shared<AsyncOpenTask>(shared_from_this(), m_sync_session);
 }
 
-void RealmCoordinator::create_session(Realm::Config config)
+void RealmCoordinator::create_session(const Realm::Config& config)
 {
     REALM_ASSERT(config.sync_config);
     std::unique_lock<std::mutex> lock(m_realm_mutex);

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -344,6 +344,15 @@ std::shared_ptr<AsyncOpenTask> RealmCoordinator::get_synchronized_realm(Realm::C
     create_sync_session(!config.sync_config->is_partial && !exists, exists);
     return std::make_shared<AsyncOpenTask>(shared_from_this(), m_sync_session);
 }
+
+void RealmCoordinator::create_session(Realm::Config config)
+{
+    REALM_ASSERT(config.sync_config);
+    std::unique_lock<std::mutex> lock(m_realm_mutex);
+    set_config(config);
+    bool exists = File::exists(m_config.path);
+    create_sync_session(!config.sync_config->is_partial && !exists, exists);
+}
 #endif
 
 bool RealmCoordinator::get_cached_schema(Schema& schema, uint64_t& schema_version,

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -64,6 +64,11 @@ public:
     // If the Realm is already on disk, it will be fully synchronized before being returned.
     // Timeouts and interruptions are not handled by this method and must be handled by upper layers.
     std::shared_ptr<AsyncOpenTask> get_synchronized_realm(Realm::Config config);
+
+    // Creates the underlying sync session if it doesn't already exists.
+    // This is also created as part of opening a Realm, so only use this
+    // method if the session needs to exist before the Realm does.
+    void create_session(Realm::Config config);
 #endif
 
     // Get a Realm which is not bound to the current execution context

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -68,7 +68,7 @@ public:
     // Creates the underlying sync session if it doesn't already exists.
     // This is also created as part of opening a Realm, so only use this
     // method if the session needs to exist before the Realm does.
-    void create_session(Realm::Config config);
+    void create_session(const Realm::Config& config);
 #endif
 
     // Get a Realm which is not bound to the current execution context


### PR DESCRIPTION
Adding some public functionality for creating sessions before the Realm is opened.

Due to how Java has implemented Async Open and how the Java APIs are, we have a hard time using the OS AsyncOpenTask for download progress listeners. 

Instead, we need to use our SyncSession wrapper which previously was only available after the Realm was fully opened. So by making this change, we are able to create the wrapper before the Realm is opened and allow users to add progress listeners for async open.
