### PR TITLE
Fix a rare notification-related deadlock

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -732,6 +732,7 @@ void RealmCoordinator::run_async_notifiers()
     clean_up_dead_notifiers();
 
     if (m_notifiers.empty() && m_new_notifiers.empty()) {
+        m_notifier_cv.notify_all();
         return;
     }
 
@@ -742,6 +743,7 @@ void RealmCoordinator::run_async_notifiers()
     if (m_async_error) {
         std::move(m_new_notifiers.begin(), m_new_notifiers.end(), std::back_inserter(m_notifiers));
         m_new_notifiers.clear();
+        m_notifier_cv.notify_all();
         return;
     }
 


### PR DESCRIPTION
The following sequence of events would hang forever:

1. Main thread creates notifier and adds callback.
2. Background thread performs a write.
3. Main thread calls refresh() and waits on the notifier condition variable.
4. Background thread removes callback.
5. Notification worker thread wakes up, cleans up the zombie notifier, then returns since there's no notifications to run.
6. Main thread blocks forever because no one ever signals the notifier condition variable.

The fix for this is to just signal the condition variable even if there are no live notifiers.

I *think* this is what has been causing the Cocoa sync tests to sometimes hang forever on CI. It's unlikely that any actual users have hit it, as the problematic timing window is pretty tight and you have to do somewhat weird things.