### PR TITLE
Expose additional sync client configuration options

### DIFF
--- a/src/sync/impl/sync_client.hpp
+++ b/src/sync/impl/sync_client.hpp
@@ -39,26 +39,47 @@ namespace _impl {
 using ReconnectMode = sync::Client::ReconnectMode;
 
 struct SyncClient {
-    SyncClient(std::unique_ptr<util::Logger> logger, ReconnectMode reconnect_mode, bool multiplex_sessions, const std::string& user_agent_application_info)
-        : m_client(make_client(*logger, reconnect_mode, multiplex_sessions, user_agent_application_info)) // Throws
-        , m_logger(std::move(logger))
-        , m_thread([this] {
-            if (g_binding_callback_thread_observer) {
-                g_binding_callback_thread_observer->did_create_thread();
-                auto will_destroy_thread = util::make_scope_exit([&]() noexcept {
-                    g_binding_callback_thread_observer->will_destroy_thread();
-                });
-                try {
-                    m_client.run(); // Throws
-                }
-                catch (std::exception const& e) {
-                    g_binding_callback_thread_observer->handle_error(e);
-                }
-            }
-            else {
+    SyncClient(std::unique_ptr<util::Logger> logger, SyncClientConfig const& config)
+    : m_client([&] {
+        sync::Client::Config c;
+        c.logger = logger.get();
+        c.reconnect_mode = config.reconnect_mode;
+        c.one_connection_per_session = !config.multiplex_sessions;
+        c.user_agent_application_info = util::format("%1 %2", config.user_agent_binding_info,
+                                                     config.user_agent_application_info);
+
+        // Only set the timeouts if they have sensible values
+        if (config.timeouts.connect_timeout >= 1000)
+            c.connect_timeout = config.timeouts.connect_timeout;
+        if (config.timeouts.connection_linger_time > 0)
+            c.connection_linger_time = config.timeouts.connection_linger_time;
+        if (config.timeouts.ping_keepalive_period > 5000)
+            c.ping_keepalive_period = config.timeouts.ping_keepalive_period;
+        if (config.timeouts.pong_keepalive_timeout > 5000)
+            c.pong_keepalive_timeout = config.timeouts.pong_keepalive_timeout;
+        if (config.timeouts.fast_reconnect_limit > 1000)
+            c.fast_reconnect_limit = config.timeouts.fast_reconnect_limit;
+
+        return c;
+    }())
+    , m_logger(std::move(logger))
+    , m_thread([this] {
+        if (g_binding_callback_thread_observer) {
+            g_binding_callback_thread_observer->did_create_thread();
+            auto will_destroy_thread = util::make_scope_exit([&]() noexcept {
+                g_binding_callback_thread_observer->will_destroy_thread();
+            });
+            try {
                 m_client.run(); // Throws
             }
-        }) // Throws
+            catch (std::exception const& e) {
+                g_binding_callback_thread_observer->handle_error(e);
+            }
+        }
+        else {
+            m_client.run(); // Throws
+        }
+    }) // Throws
 #if NETWORK_REACHABILITY_AVAILABLE
     , m_reachability_observer(none, [=](const NetworkReachabilityStatus status) {
         if (status != NotReachable)
@@ -89,23 +110,12 @@ struct SyncClient {
         return std::make_unique<sync::Session>(m_client, std::move(path), std::move(config));
     }
 
-
     ~SyncClient()
     {
         stop();
     }
 
 private:
-    static sync::Client make_client(util::Logger& logger, ReconnectMode reconnect_mode, bool multiplex_sessions, const std::string& user_agent_application_info)
-    {
-        sync::Client::Config config;
-        config.logger = &logger;
-        config.reconnect_mode = std::move(reconnect_mode);
-        config.one_connection_per_session = !multiplex_sessions;
-        config.user_agent_application_info = user_agent_application_info;
-        return sync::Client(std::move(config)); // Throws
-    }
-
     sync::Client m_client;
     const std::unique_ptr<util::Logger> m_logger;
     std::thread m_thread;

--- a/src/sync/sync_config.hpp
+++ b/src/sync/sync_config.hpp
@@ -143,6 +143,9 @@ struct SyncConfig {
     bool is_partial = false;
     util::Optional<std::string> custom_partial_sync_identifier;
 
+    // If true, upload/download waits are canceled on any sync error and not just fatal ones
+    bool cancel_waits_on_nonfatal_error = false;
+
     bool validate_sync_history = true;
 
     util::Optional<std::string> authorization_header_name;

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -37,12 +37,15 @@ SyncManager& SyncManager::shared()
     return manager;
 }
 
-void SyncManager::configure(const std::string& base_file_path,
-                                        MetadataMode metadata_mode,
-                                        const std::string& user_agent_binding_info,
-                                        util::Optional<std::vector<char>> custom_encryption_key,
-                                        bool reset_metadata_on_error)
+void SyncManager::configure(SyncClientConfig config)
 {
+    {
+        std::lock_guard<std::mutex> lock(m_mutex);
+        m_config = std::move(config);
+        if (m_sync_client)
+            return;
+    }
+
     struct UserCreationData {
         std::string identity;
         std::string user_token;
@@ -50,51 +53,44 @@ void SyncManager::configure(const std::string& base_file_path,
         bool is_admin;
     };
 
-    m_user_agent_binding_info = user_agent_binding_info;
-
     std::vector<UserCreationData> users_to_add;
     {
         std::lock_guard<std::mutex> lock(m_file_system_mutex);
 
         // Set up the file manager.
         if (m_file_manager) {
-            REALM_ASSERT(m_file_manager->base_path() == base_file_path);
+            // Changing the base path for tests requires calling reset_for_testing()
+            // first, and otherwise isn't supported
+            REALM_ASSERT(m_file_manager->base_path() == m_config.base_file_path);
         } else {
-            m_file_manager = std::make_unique<SyncFileManager>(base_file_path);
+            m_file_manager = std::make_unique<SyncFileManager>(m_config.base_file_path);
         }
 
         // Set up the metadata manager, and perform initial loading/purging work.
-        if (m_metadata_manager) {
+        if (m_metadata_manager || m_config.metadata_mode == MetadataMode::NoMetadata) {
             return;
         }
-        switch (metadata_mode) {
-            case MetadataMode::NoEncryption:
+
+        bool encrypt = m_config.metadata_mode == MetadataMode::Encryption;
+        try {
+            m_metadata_manager = std::make_unique<SyncMetadataManager>(m_file_manager->metadata_path(),
+                                                                       encrypt,
+                                                                       m_config.custom_encryption_key);
+        } catch (RealmFileException const& ex) {
+            if (m_config.reset_metadata_on_error && m_file_manager->remove_metadata_realm()) {
                 m_metadata_manager = std::make_unique<SyncMetadataManager>(m_file_manager->metadata_path(),
-                                                                           false);
-                break;
-            case MetadataMode::Encryption:
-                try {
-                    m_metadata_manager = std::make_unique<SyncMetadataManager>(m_file_manager->metadata_path(),
-                                                                               true,
-                                                                               custom_encryption_key);
-                } catch (RealmFileException const& ex) {
-                    if (reset_metadata_on_error && m_file_manager->remove_metadata_realm()) {
-                        m_metadata_manager = std::make_unique<SyncMetadataManager>(m_file_manager->metadata_path(),
-                                                                                   true,
-                                                                                   std::move(custom_encryption_key));
-                    } else {
-                        throw;
-                    }
-                }
-                break;
-            case MetadataMode::NoMetadata:
-                return;
+                                                                           encrypt,
+                                                                           std::move(m_config.custom_encryption_key));
+            } else {
+                throw;
+            }
         }
 
         REALM_ASSERT(m_metadata_manager);
         m_client_uuid = m_metadata_manager->client_uuid();
 
-        // Perform any necessary file actions.
+        // Perform our "on next startup" actions such as deleting Realm files
+        // which we couldn't delete immediately due to them being in use
         std::vector<SyncFileActionMetadata> completed_actions;
         SyncFileActionMetadataResults file_actions = m_metadata_manager->all_pending_actions();
         for (size_t i = 0; i < file_actions.size(); i++) {
@@ -106,25 +102,22 @@ void SyncManager::configure(const std::string& base_file_path,
         for (auto& action : completed_actions) {
             action.remove();
         }
+
         // Load persisted users into the users map.
         SyncUserMetadataResults users = m_metadata_manager->all_unmarked_users();
         for (size_t i = 0; i < users.size(); i++) {
             // Note that 'admin' style users are not persisted.
             auto user_data = users.get(i);
-            auto user_token = user_data.user_token();
-            auto identity = user_data.identity();
-            auto server_url = user_data.auth_server_url();
-            bool is_admin = user_data.is_admin();
-            if (user_token) {
-                UserCreationData data = {
-                    std::move(identity),
+            if (auto user_token = user_data.user_token()) {
+                users_to_add.push_back(UserCreationData{
+                    user_data.identity(),
                     std::move(*user_token),
-                    std::move(server_url),
-                    is_admin,
-                };
-                users_to_add.emplace_back(std::move(data));
+                    user_data.auth_server_url(),
+                    user_data.is_admin()
+                });
             }
         }
+
         // Delete any users marked for death.
         std::vector<SyncUserMetadata> dead_users;
         SyncUserMetadataResults users_to_remove = m_metadata_manager->all_users_marked_for_removal();
@@ -235,41 +228,43 @@ void SyncManager::reset_for_testing()
         m_sync_client = nullptr;
 
         // Reset even more state.
-        // NOTE: these should always match the defaults.
-        m_log_level = util::Logger::Level::info;
-        m_logger_factory = nullptr;
-        m_client_reconnect_mode = ReconnectMode::normal;
-        m_multiplex_sessions = false;
+        m_config = {};
     }
 }
 
 void SyncManager::set_log_level(util::Logger::Level level) noexcept
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-    m_log_level = level;
+    m_config.log_level = level;
 }
 
 void SyncManager::set_logger_factory(SyncLoggerFactory& factory) noexcept
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-    m_logger_factory = &factory;
+    m_config.logger_factory = &factory;
 }
 
 std::unique_ptr<util::Logger> SyncManager::make_logger() const
 {
-    if (m_logger_factory) {
-        return m_logger_factory->make_logger(m_log_level); // Throws
+    if (m_config.logger_factory) {
+        return m_config.logger_factory->make_logger(m_config.log_level); // Throws
     }
 
     auto stderr_logger = std::make_unique<util::StderrLogger>(); // Throws
-    stderr_logger->set_level_threshold(m_log_level);
+    stderr_logger->set_level_threshold(m_config.log_level);
     return std::unique_ptr<util::Logger>(stderr_logger.release());
 }
 
 void SyncManager::set_user_agent(std::string user_agent)
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-    m_user_agent_application_info = std::move(user_agent);
+    m_config.user_agent_application_info = std::move(user_agent);
+}
+
+void SyncManager::set_timeouts(SyncClientTimeouts timeouts)
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    m_config.timeouts = timeouts;
 }
 
 void SyncManager::reconnect()
@@ -283,7 +278,7 @@ void SyncManager::reconnect()
 util::Logger::Level SyncManager::log_level() const noexcept
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-    return m_log_level;
+    return m_config.log_level;
 }
 
 bool SyncManager::perform_metadata_update(std::function<void(const SyncMetadataManager&)> update_function) const
@@ -509,13 +504,13 @@ void SyncManager::unregister_session(const std::string& path)
 void SyncManager::enable_session_multiplexing()
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-    if (m_multiplex_sessions)
+    if (m_config.multiplex_sessions)
         return; // Already enabled, we can ignore
 
     if (m_sync_client)
         throw std::logic_error("Cannot enable session multiplexing after creating the sync client");
 
-    m_multiplex_sessions = true;
+    m_config.multiplex_sessions = true;
 }
 
 SyncClient& SyncManager::get_sync_client() const
@@ -529,8 +524,7 @@ SyncClient& SyncManager::get_sync_client() const
 std::unique_ptr<SyncClient> SyncManager::create_sync_client() const
 {
     REALM_ASSERT(!m_mutex.try_lock());
-    return std::make_unique<SyncClient>(make_logger(), m_client_reconnect_mode, m_multiplex_sessions,
-                                        util::format("%1 %2", m_user_agent_binding_info, m_user_agent_application_info));
+    return std::make_unique<SyncClient>(make_logger(), m_config);
 }
 
 std::string SyncManager::client_uuid() const

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -371,9 +371,9 @@ struct sync_session_states::Inactive : public SyncSession::State {
 
         // Inform any queued-up completion handlers that they were cancelled.
         for (auto& callback : download_waits)
-            callback(util::error::operation_aborted);
+            callback(make_error_code(util::error::operation_aborted));
         for (auto& callback : upload_waits)
-            callback(util::error::operation_aborted);
+            callback(make_error_code(util::error::operation_aborted));
     }
 
     bool revive_if_needed(std::unique_lock<std::mutex>& lock, SyncSession& session) const override
@@ -557,7 +557,7 @@ void SyncSession::handle_error(SyncError error)
                 {
                     std::unique_lock<std::mutex> lock(m_state_mutex);
                     user_to_invalidate = user();
-                    cancel_pending_waits(lock);
+                    cancel_pending_waits(lock, error.error_code);
                 }
                 if (user_to_invalidate)
                     user_to_invalidate->invalidate();
@@ -638,7 +638,7 @@ void SyncSession::handle_error(SyncError error)
         }
         case NextStateAfterError::error: {
             std::unique_lock<std::mutex> lock(m_state_mutex);
-            cancel_pending_waits(lock);
+            cancel_pending_waits(lock, error.error_code);
             break;
         }
     }
@@ -647,7 +647,7 @@ void SyncSession::handle_error(SyncError error)
     }
 }
 
-void SyncSession::cancel_pending_waits(std::unique_lock<std::mutex>& lock)
+void SyncSession::cancel_pending_waits(std::unique_lock<std::mutex>& lock, std::error_code error)
 {
     auto download = std::move(m_download_completion_callbacks);
     auto upload = std::move(m_upload_completion_callbacks);
@@ -655,9 +655,9 @@ void SyncSession::cancel_pending_waits(std::unique_lock<std::mutex>& lock)
 
     // Inform any queued-up completion handlers that they were cancelled.
     for (auto& callback : download)
-        callback(util::error::operation_aborted);
+        callback(error);
     for (auto& callback : upload)
-        callback(util::error::operation_aborted);
+        callback(error);
 }
 
 void SyncSession::handle_progress_update(uint64_t downloaded, uint64_t downloadable,

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -630,6 +630,10 @@ void SyncSession::handle_error(SyncError error)
     }
     switch (next_state) {
         case NextStateAfterError::none:
+            if (m_config.cancel_waits_on_nonfatal_error) {
+                std::unique_lock<std::mutex> lock(m_state_mutex);
+                cancel_pending_waits(lock, error.error_code);
+            }
             break;
         case NextStateAfterError::inactive: {
             std::unique_lock<std::mutex> lock(m_state_mutex);

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -332,7 +332,7 @@ private:
     SyncSession(_impl::SyncClient&, std::string realm_path, SyncConfig, bool force_client_resync);
 
     void handle_error(SyncError);
-    void cancel_pending_waits(std::unique_lock<std::mutex>&);
+    void cancel_pending_waits(std::unique_lock<std::mutex>&, std::error_code);
     enum class ShouldBackup { yes, no };
     void update_error_and_mark_file_for_deletion(SyncError&, ShouldBackup);
     std::string get_recovery_file_path();

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -461,8 +461,7 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
     if (!util::EventLoop::has_implementation())
         return;
 
-    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
-    SyncManager::shared().configure(tmp_dir(), SyncManager::MetadataMode::NoEncryption);
+    TestSyncManager init_sync_manager;
 
     SyncServer server;
     SyncTestFile config(server, "default");

--- a/tests/sync/file.cpp
+++ b/tests/sync/file.cpp
@@ -18,6 +18,7 @@
 
 #include "sync_test_utils.hpp"
 #include "util/test_utils.hpp"
+#include "util/test_file.hpp"
 
 #include "shared_realm.hpp"
 #include "sync/sync_manager.hpp"
@@ -182,8 +183,7 @@ TEST_CASE("sync_file: SyncFileManager APIs", "[sync]") {
             const std::string& server_url = "https://realm.example.org:9090/realm";
             const std::string& token = "fake-token";
             prepare_sync_manager_test();
-            auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
-            SyncManager::shared().configure(base_path + "syncmanager/", SyncManager::MetadataMode::NoEncryption);
+            TestSyncManager init_sync_manager(base_path + "syncmanager/");
 
             SECTION("migrating a user directory if an old identity is specified") {
                 // Create the "old directory"

--- a/tests/sync/partial_sync.cpp
+++ b/tests/sync/partial_sync.cpp
@@ -384,7 +384,7 @@ TEST_CASE("Query-based Sync", "[sync]") {
     if (!EventLoop::has_implementation())
         return;
 
-    SyncManager::shared().configure(tmp_dir(), SyncManager::MetadataMode::NoEncryption);
+    TestSyncManager init_sync_manager;
 
     SyncServer server;
     SyncTestFile config(server, "test");
@@ -883,7 +883,7 @@ TEST_CASE("Query-based Sync link behaviour", "[sync]") {
     if (!EventLoop::has_implementation())
         return;
 
-    SyncManager::shared().configure(tmp_dir(), SyncManager::MetadataMode::NoEncryption);
+    TestSyncManager init_sync_manager;
 
     SyncServer server;
     SyncTestFile config(server, "test");
@@ -1003,7 +1003,7 @@ TEST_CASE("Query-based Sync link behaviour", "[sync]") {
 }
 
 TEST_CASE("Query-based Sync error checking", "[sync]") {
-    SyncManager::shared().configure(tmp_dir(), SyncManager::MetadataMode::NoEncryption);
+    TestSyncManager init_sync_manager;
 
     SECTION("API misuse throws an exception from `subscribe`") {
         SECTION("non-synced Realm") {
@@ -1093,7 +1093,7 @@ TEST_CASE("Creating/Updating subscriptions synchronously", "[sync]") {
 
     using namespace std::string_literals;
 
-    SyncManager::shared().configure(tmp_dir(), SyncManager::MetadataMode::NoEncryption);
+    TestSyncManager init_sync_manager;
 
     SyncServer server;
     SyncTestFile config(server, "test");

--- a/tests/sync/permission.cpp
+++ b/tests/sync/permission.cpp
@@ -116,7 +116,7 @@ static void subscribe_to_all(std::shared_ptr<Realm> const& r)
 }
 
 TEST_CASE("Object-level Permissions") {
-    SyncManager::shared().configure(tmp_dir(), SyncManager::MetadataMode::NoEncryption);
+    TestSyncManager init_sync_manager;
 
     SyncServer server{StartImmediately{false}};
 

--- a/tests/sync/session/connection_change_notifications.cpp
+++ b/tests/sync/session/connection_change_notifications.cpp
@@ -46,9 +46,8 @@ TEST_CASE("sync: Connection state changes", "[sync]") {
     if (!EventLoop::has_implementation())
         return;
 
-    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
-    SyncManager::shared().configure(tmp_dir(), SyncManager::MetadataMode::NoEncryption);
+    TestSyncManager init_sync_manager;
     const std::string realm_base_url = server.base_url();
     auto user = SyncManager::shared().get_user({ "user", dummy_auth_url }, "not_a_real_token");
 

--- a/tests/sync/session/session.cpp
+++ b/tests/sync/session/session.cpp
@@ -46,9 +46,8 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
     if (!EventLoop::has_implementation())
         return;
 
-    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     SyncServer server;
-    SyncManager::shared().configure(tmp_dir(), SyncManager::MetadataMode::NoEncryption);
+    TestSyncManager init_sync_manager;
     const std::string realm_base_url = server.base_url();
 
     SECTION("a SyncUser can properly retrieve its owned sessions") {
@@ -192,7 +191,7 @@ TEST_CASE("sync: log-in", "[sync]") {
 
     SyncServer server;
     // Disable file-related functionality and metadata functionality for testing purposes.
-    SyncManager::shared().configure(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
+    TestSyncManager init_sync_manager;
     auto user = SyncManager::shared().get_user({ "user", dummy_auth_url }, "not_a_real_token");
 
     SECTION("Can log in") {
@@ -230,7 +229,7 @@ TEST_CASE("sync: token refreshing", "[sync]") {
 
     SyncServer server;
     // Disable file-related functionality and metadata functionality for testing purposes.
-    SyncManager::shared().configure(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
+    TestSyncManager init_sync_manager;
     auto user = SyncManager::shared().get_user({ "user-token-refreshing", dummy_auth_url }, "not_a_real_token");
 
     SECTION("Can preemptively refresh token while session is active.") {
@@ -311,7 +310,7 @@ TEST_CASE("SyncSession: close() API", "[sync]") {
 }
 
 TEST_CASE("SyncSession: update_configuration()", "[sync]") {
-    SyncManager::shared().configure(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
+    TestSyncManager init_sync_manager;
 
     SyncServer server{false};
 
@@ -350,10 +349,9 @@ TEST_CASE("SyncSession: update_configuration()", "[sync]") {
 }
 
 TEST_CASE("sync: error handling", "[sync]") {
-    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     using ProtocolError = realm::sync::ProtocolError;
     SyncServer server;
-    SyncManager::shared().configure(tmp_dir(), SyncManager::MetadataMode::NoEncryption);
+    TestSyncManager init_sync_manager;
 
     // Create a valid session.
     std::function<void(std::shared_ptr<SyncSession>, SyncError)> error_handler = [](auto, auto) { };
@@ -538,7 +536,7 @@ TEST_CASE("sync: encrypt local realm file", "[sync]") {
 
     SyncServer server;
     // Disable file-related functionality and metadata functionality for testing purposes.
-    SyncManager::shared().configure(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
+    TestSyncManager init_sync_manager;
 
     std::array<char, 64> encryption_key;
     encryption_key.fill(12);
@@ -598,7 +596,7 @@ TEST_CASE("sync: non-synced metadata table doesn't result in non-additive schema
 
     SyncServer server;
     // Disable file-related functionality and metadata functionality for testing purposes.
-    SyncManager::shared().configure(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
+    TestSyncManager init_sync_manager;
 
     // Create a synced Realm containing a class with two properties.
     {
@@ -648,7 +646,7 @@ TEST_CASE("sync: stable IDs", "[sync]") {
 
     SyncServer server;
     // Disable file-related functionality and metadata functionality for testing purposes.
-    SyncManager::shared().configure(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
+    TestSyncManager init_sync_manager;
 
     SECTION("ID column isn't visible in schema read from Group") {
         SyncTestFile config(server, "schema-test");
@@ -673,7 +671,7 @@ TEST_CASE("sync: Migration from Sync 1.x to Sync 2.x", "[sync]") {
 
     SyncServer server;
     // Disable file-related functionality and metadata functionality for testing purposes.
-    SyncManager::shared().configure(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
+    TestSyncManager init_sync_manager;
 
 
     SyncTestFile config(server, "migration-test");
@@ -738,7 +736,7 @@ TEST_CASE("sync: client resync") {
     if (!EventLoop::has_implementation())
         return;
 
-    SyncManager::shared().configure(tmp_dir(), SyncManager::MetadataMode::NoMetadata);
+    TestSyncManager init_sync_manager;
 
     SyncServer server;
     SyncTestFile config(server, "default");

--- a/tests/sync/user.cpp
+++ b/tests/sync/user.cpp
@@ -20,7 +20,10 @@
 
 #include "sync/sync_manager.hpp"
 #include "sync/sync_user.hpp"
+
 #include "util/test_utils.hpp"
+#include "util/test_file.hpp"
+
 #include <realm/util/file.hpp>
 #include <realm/util/scope_exit.hpp>
 
@@ -31,9 +34,8 @@ using File = realm::util::File;
 static const std::string base_path = tmp_dir() + "/realm_objectstore_sync_user/";
 
 TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
-    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     reset_test_directory(base_path);
-    SyncManager::shared().configure(base_path, SyncManager::MetadataMode::NoEncryption);
+    TestSyncManager init_sync_manager(base_path);
     const std::string identity = "sync_test_identity";
     const std::string token = "1234567890-fake-token";
     const std::string server_url = "https://realm.example.org";
@@ -86,9 +88,8 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
 }
 
 TEST_CASE("sync_user: SyncManager `get_admin_token_user()` APIs", "[sync]") {
-    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     reset_test_directory(base_path);
-    SyncManager::shared().configure(base_path, SyncManager::MetadataMode::NoEncryption);
+    TestSyncManager init_sync_manager(base_path, SyncManager::MetadataMode::NoMetadata);
     const std::string token = "1234567890-fake-token";
     const std::string server_url = "https://realm.example.org";
 
@@ -146,9 +147,8 @@ TEST_CASE("sync_user: SyncManager `get_admin_token_user()` APIs", "[sync]") {
 }
 
 TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API", "[sync]") {
-    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     reset_test_directory(base_path);
-    SyncManager::shared().configure(base_path, SyncManager::MetadataMode::NoEncryption);
+    TestSyncManager init_sync_manager(base_path, SyncManager::MetadataMode::NoMetadata);
     const std::string identity = "sync_test_identity";
     const std::string token = "1234567890-fake-token";
     const std::string server_url = "https://realm.example.org";
@@ -181,7 +181,7 @@ TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API", "[sync]"
 
 TEST_CASE("sync_user: logout", "[sync]") {
     reset_test_directory(base_path);
-    SyncManager::shared().configure(base_path, SyncManager::MetadataMode::NoEncryption);
+    TestSyncManager init_sync_manager(base_path, SyncManager::MetadataMode::NoMetadata);
     const std::string identity = "sync_test_identity";
     const std::string token = "1234567890-fake-token";
     const std::string server_url = "https://realm.example.org";
@@ -195,9 +195,8 @@ TEST_CASE("sync_user: logout", "[sync]") {
 }
 
 TEST_CASE("sync_user: user persistence", "[sync]") {
-    auto cleanup = util::make_scope_exit([=]() noexcept { SyncManager::shared().reset_for_testing(); });
     reset_test_directory(base_path);
-    SyncManager::shared().configure(base_path, SyncManager::MetadataMode::NoEncryption);
+    TestSyncManager init_sync_manager(base_path, SyncManager::MetadataMode::NoEncryption);
     auto file_manager = SyncFileManager(base_path);
     // Open the metadata separately, so we can investigate it ourselves.
     SyncMetadataManager manager(file_manager.metadata_path(), false);

--- a/tests/util/test_file.cpp
+++ b/tests/util/test_file.cpp
@@ -18,6 +18,8 @@
 
 #include "util/test_file.hpp"
 
+#include "test_utils.hpp"
+
 #include "impl/realm_coordinator.hpp"
 
 #if REALM_ENABLE_SYNC
@@ -219,6 +221,28 @@ void wait_for_download(Realm& realm)
     wait_for_session(realm, &SyncSession::wait_for_download_completion);
 }
 
+TestSyncManager::TestSyncManager(std::string const& base_path, SyncManager::MetadataMode mode)
+{
+    configure(base_path, mode);
+}
+
+TestSyncManager::~TestSyncManager()
+{
+    SyncManager::shared().reset_for_testing();
+}
+
+void TestSyncManager::configure(std::string const& base_path, SyncManager::MetadataMode mode)
+{
+    SyncClientConfig config;
+    config.base_file_path = base_path.empty() ? tmp_dir() : base_path;
+    config.metadata_mode = mode;
+#if TEST_ENABLE_SYNC_LOGGING
+    config.log_level = util::Logger::Level::all;
+#else
+    config.log_level = util::Logger::Level::off;
+#endif
+    SyncManager::shared().configure(config);
+}
 
 #endif // REALM_ENABLE_SYNC
 

--- a/tests/util/test_file.hpp
+++ b/tests/util/test_file.hpp
@@ -133,6 +133,12 @@ struct SyncTestFile : TestFile {
                  std::string user_name="test");
 };
 
+struct TestSyncManager {
+    TestSyncManager(std::string const& base_path="", realm::SyncManager::MetadataMode = realm::SyncManager::MetadataMode::NoEncryption);
+    ~TestSyncManager();
+    static void configure(std::string const& base_path, realm::SyncManager::MetadataMode);
+};
+
 void wait_for_upload(realm::Realm& realm);
 void wait_for_download(realm::Realm& realm);
 


### PR DESCRIPTION
This does a few things:

1. Change SyncManager::configure() to take a struct because the number of arguments it took was getting unwieldy, and then fiddle with how SyncManager stores the config settings internally.
2. Expose more of the options in sync::Client::Config to be customized via SyncManager. `ping_keepalive_period`/`pong_keepalive_timeout` were specifically requested by customers who wanted more responsive connection state updates and `connect_timeout` is made interesting by the next change; the other two probably aren't interesting to customize.
3. Pass the actual error code to download wait callbacks rather than "operation aborted", which indirectly makes asyncOpen() report actual error codes.
4. Add an option to cancel async waits on non-fatal errors in addition to fatal errors. The motivation for this is to be able to have a separate timeouts for an async open connecting to the server and for the download to complete after it has connected (presumably for the former being much shorter than the latter).

Required for https://github.com/realm/realm-cocoa/pull/6375.