### PR TITLE
[Windows] submit external commit notifications on a threadpool

### DIFF
--- a/src/impl/windows/external_commit_helper.cpp
+++ b/src/impl/windows/external_commit_helper.cpp
@@ -68,7 +68,8 @@ void ExternalCommitHelper::notify_others()
 
 void ExternalCommitHelper::listen()
 {
-    SetThreadDescription(GetCurrentThread(), L"Realm ExternalCommitHelper listener");
+    // uncomment for debugging purposes
+    //SetThreadDescription(GetCurrentThread(), L"Realm ExternalCommitHelper listener");
     std::lock_guard<InterprocessMutex> lock(m_mutex);
     while (m_keep_listening) {
         m_commit_available->wait(m_mutex, nullptr);

--- a/src/impl/windows/external_commit_helper.hpp
+++ b/src/impl/windows/external_commit_helper.hpp
@@ -84,11 +84,11 @@ private:
     RealmCoordinator& m_parent;
 
     // The listener thread
-    std::future<void> m_thread;
+    std::thread m_thread;
 
     win32::SharedMemory<InterprocessCondVar::SharedPart, InterprocessCondVar::init_shared_part> m_condvar_shared;
 
-    InterprocessCondVar m_commit_available;
+    std::shared_ptr<InterprocessCondVar> m_commit_available;
     InterprocessMutex m_mutex;
     bool m_keep_listening = true;
 };


### PR DESCRIPTION
Fixes #872 and #684 

On Windows, our implementation of the `ExternalCommitHelper` relies on an interprocess condition variable. In some cases this implementation is susceptible to deadlocks, specifically in tight producer-consumer loops with one or more notifiers.

The issue is that `ExternalCommitHelper::notify_others()` calls `InterprocessCondVar::notify_all()` which internally waits on all the condition variable subscribers to process the notification event before continuing, which results in a deadlock if `ExternalCommitHelper::listen()` triggered `RealmCoordinator::on_change()` and it hasn't returned yet because it's processing async notifiers.

The fix is to make `ExternalCommitHelper::notify_others()` signal the condition variable on a thread pool so that it doesn't need to wait for other instances waiting on the condition variable to process the notification. This matches the behavior of our POSIX-based implementations of `ExternalCommitHelper` where `notify_others()` simply signals a named pipe file descriptor without waiting for any remote instances to react to the event.