### PR TITLE
Store the table key on ObjectSchema

### DIFF
--- a/src/keypath_helpers.hpp
+++ b/src/keypath_helpers.hpp
@@ -32,7 +32,7 @@ static void populate_keypath_mapping(parser::KeyPathMapping& mapping, Realm& rea
         TableRef table;
         auto get_table = [&] {
             if (!table)
-                table = ObjectStore::table_for_object_type(realm.read_group(), object_schema.name);
+                table = realm.read_group().get_table(object_schema.table_key);
             return table;
         };
 
@@ -59,7 +59,7 @@ inline IncludeDescriptor generate_include_from_keypaths(std::vector<StringData> 
                                                         Realm& realm, ObjectSchema const& object_schema,
                                                         parser::KeyPathMapping& mapping)
 {
-    auto base_table = ObjectStore::table_for_object_type(realm.read_group(), object_schema.name);
+    auto base_table = realm.read_group().get_table(object_schema.table_key);
     REALM_ASSERT(base_table);
     // FIXME: the following is mostly copied from core's query_builder::apply_ordering
     std::vector<std::vector<LinkPathPart>> properties;

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -84,6 +84,7 @@ ObjectSchema::ObjectSchema(Group const& group, StringData name, TableKey key)
     else {
         table = ObjectStore::table_for_object_type(group, name);
     }
+    table_key = table->get_key();
 
     size_t count = table->get_column_count();
     persisted_properties.reserve(count);
@@ -112,7 +113,7 @@ ObjectSchema::ObjectSchema(Group const& group, StringData name, TableKey key)
         persisted_properties.push_back(std::move(property));
     }
 
-    primary_key = realm::ObjectStore::get_primary_key_for_object(group, name);
+    primary_key = ObjectStore::get_primary_key_for_object(group, name);
     set_primary_key_property();
 }
 

--- a/src/object_schema.hpp
+++ b/src/object_schema.hpp
@@ -19,6 +19,7 @@
 #ifndef REALM_OBJECT_SCHEMA_HPP
 #define REALM_OBJECT_SCHEMA_HPP
 
+#include <realm/keys.hpp>
 #include <realm/string_data.hpp>
 
 #include <string>
@@ -27,12 +28,10 @@
 namespace realm {
 class Group;
 class Schema;
+class Table;
 enum class PropertyType: unsigned char;
 struct ObjectSchemaValidationException;
 struct Property;
-struct TableKey;
-struct ColKey;
-class Table;
 
 class ObjectSchema {
 public:
@@ -43,13 +42,14 @@ public:
     ~ObjectSchema();
 
     // create object schema from existing table
-    // if no table is provided it is looked up in the group
+    // if no table key is provided it is looked up in the group
     ObjectSchema(Group const& group, StringData name, TableKey key);
 
     std::string name;
     std::vector<Property> persisted_properties;
     std::vector<Property> computed_properties;
     std::string primary_key;
+    TableKey table_key;
 
     Property *property_for_public_name(StringData public_name);
     const Property *property_for_public_name(StringData public_name) const;

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -104,7 +104,7 @@ public:
     // NOTE: is_primary won't be set for the returned property.
     static util::Optional<Property> property_for_column_index(ConstTableRef& table, ColKey column_key);
 
-    static void set_schema_columns(Group const& group, Schema& schema);
+    static void set_schema_keys(Group const& group, Schema& schema);
 
     // deletes the table for the given type
     static void delete_data_for_object(Group& group, StringData object_type);

--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -205,12 +205,13 @@ std::vector<SchemaChange> Schema::compare(Schema const& target_schema, bool incl
     return changes;
 }
 
-void Schema::copy_table_columns_from(realm::Schema const& other)
+void Schema::copy_keys_from(realm::Schema const& other)
 {
     zip_matching(*this, other, [&](ObjectSchema* existing, const ObjectSchema* other) {
         if (!existing || !other)
             return;
 
+        existing->table_key = other->table_key;
         for (auto& current_prop : other->persisted_properties) {
             auto target_prop = existing->property_for_name(current_prop.name);
             if (target_prop) {

--- a/src/schema.hpp
+++ b/src/schema.hpp
@@ -60,7 +60,7 @@ public:
     // Get the changes which must be applied to this schema to produce the passed-in schema
     std::vector<SchemaChange> compare(Schema const&, bool include_removals=false) const;
 
-    void copy_table_columns_from(Schema const&);
+    void copy_keys_from(Schema const&);
 
     friend bool operator==(Schema const&, Schema const&);
     friend bool operator!=(Schema const& a, Schema const& b) { return !(a == b); }

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -168,7 +168,7 @@ std::shared_ptr<AsyncOpenTask> Realm::get_synchronized_realm(Config config)
 void Realm::set_schema(Schema const& reference, Schema schema)
 {
     m_dynamic_schema = false;
-    schema.copy_table_columns_from(reference);
+    schema.copy_keys_from(reference);
     m_schema = std::move(schema);
     notify_schema_changed();
 }
@@ -199,7 +199,7 @@ void Realm::read_schema_from_group_if_needed()
     if (m_dynamic_schema) {
         if (m_schema == schema) {
             // The structure of the schema hasn't changed. Bring the table column indices up to date.
-            m_schema.copy_table_columns_from(schema);
+            m_schema.copy_keys_from(schema);
         }
         else {
             // The structure of the schema has changed, so replace our copy of the schema.
@@ -208,7 +208,7 @@ void Realm::read_schema_from_group_if_needed()
     }
     else {
         ObjectStore::verify_valid_external_changes(m_schema.compare(schema));
-        m_schema.copy_table_columns_from(schema);
+        m_schema.copy_keys_from(schema);
     }
     notify_schema_changed();
 }
@@ -441,7 +441,7 @@ void Realm::add_schema_change_handler()
             m_schema = *m_new_schema;
         }
         else
-            m_schema.copy_table_columns_from(*m_new_schema);
+            m_schema.copy_keys_from(*m_new_schema);
 
         notify_schema_changed();
     });

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,7 +37,6 @@ if(REALM_ENABLE_SYNC)
     )
     list(APPEND SOURCES
         sync/file.cpp
-        sync/global_notifier.cpp
         sync/metadata.cpp
         sync/partial_sync.cpp
         sync/permission.cpp
@@ -48,6 +47,12 @@ if(REALM_ENABLE_SYNC)
         sync/sync_manager.cpp
         sync/sync_test_utils.cpp
         sync/user.cpp
+    )
+endif()
+
+if(REALM_ENABLE_SERVER)
+    list(APPEND SOURCES
+        sync/global_notifier.cpp
     )
 endif()
 

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -62,8 +62,9 @@ void verify_schema(Realm& r, int line, bool in_migration)
 {
     CAPTURE(line);
     for (auto&& object_schema : r.schema()) {
-        auto table = ObjectStore::table_for_object_type(r.read_group(), object_schema.name);
+        auto table = r.read_group().get_table(object_schema.table_key);
         REQUIRE(table);
+        REQUIRE(std::string(table->get_name()) == ObjectStore::table_name_for_object_type(object_schema.name));
         CAPTURE(object_schema.name);
         std::string primary_key;
         if (!in_migration) {

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -259,6 +259,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
         auto it = realm->schema().find("object");
         auto table = realm->read_group().get_table("class_object");
         REQUIRE(it != realm->schema().end());
+        REQUIRE(it->table_key == table->get_key());
         REQUIRE(it->persisted_properties.size() == 1);
         REQUIRE(it->persisted_properties[0].name == "value");
         REQUIRE(it->persisted_properties[0].column_key == table->get_column_key("value"));
@@ -326,6 +327,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
         auto it = realm->schema().find("object");
         auto table = realm->read_group().get_table("class_object");
         REQUIRE(it != realm->schema().end());
+        REQUIRE(it->table_key == table->get_key());
         REQUIRE(it->persisted_properties.size() == 1);
         REQUIRE(it->persisted_properties[0].name == "value");
         REQUIRE(it->persisted_properties[0].column_key == table->get_column_key("value"));
@@ -837,6 +839,7 @@ TEST_CASE("ShareRealm: in-memory mode from buffer") {
         auto it = realm->schema().find("object");
         auto table = realm->read_group().get_table("class_object");
         REQUIRE(it != realm->schema().end());
+        REQUIRE(it->table_key == table->get_key());
         REQUIRE(it->persisted_properties.size() == 1);
         REQUIRE(it->persisted_properties[0].name == "value");
         REQUIRE(it->persisted_properties[0].column_key == table->get_column_key("value"));

--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -170,6 +170,7 @@ TEST_CASE("ObjectSchema") {
             table->add_search_index(col);
 
         ObjectSchema os(g, "table", table->get_key());
+        REQUIRE(os.table_key == table->get_key());
 
 #define REQUIRE_PROPERTY(name, type, ...) do { \
     Property* prop; \


### PR DESCRIPTION
Similar to how is done for column keys on Property.

Cocoa has a parallel set of schema data structures which we cache various things on. One of these is the TableRef for each ObjectSchema which is lazily stored the first time it's used. This is pretty important for performance (disabling the caching doubles the runtime of some basic operations), but it doesn't work for frozen Realms. To be thread-safe, we'd need to either add locking or eagerly look up TableRefs for each ObjectSchema.

Fortunately with core 6 we can get away with storing a TableKey rather than a TableRef, and pushing the logic here makes populating the `table_key` property eagerly nearly free, as we're already doing the complicated and expensive parts for column keys. This also lets us eliminate a few places where we look up tables by name in the object store code, which probably gives a performance improvement (but I didn't bother trying to measure that).