### PR TITLE
Remove sync history validation

### DIFF
--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -68,7 +68,7 @@ public:
     // If the Realm is already on disk, it will be fully synchronized before being returned.
     // Timeouts and interruptions are not handled by this method and must be handled by upper layers.
     std::shared_ptr<AsyncOpenTask> get_synchronized_realm(Realm::Config config);
-    // Used from SyncSession constructor if config.validate_sync_history is set
+    // Used by GlobalNotifier to bypass the normal initialization path
     void open_with_config(Realm::Config config);
 
     // Creates the underlying sync session if it doesn't already exists.
@@ -235,7 +235,7 @@ private:
     void pin_version(VersionID version);
 
     void set_config(const Realm::Config&);
-    void create_sync_session(bool force_client_resync, bool validate_sync_history);
+    void create_sync_session(bool force_client_resync);
     void do_get_realm(Realm::Config config, std::shared_ptr<Realm>& realm,
                       util::Optional<VersionID> version,
                       std::unique_lock<std::mutex>& realm_lock, bool bind_to_context=true);

--- a/src/sync/sync_config.hpp
+++ b/src/sync/sync_config.hpp
@@ -146,8 +146,6 @@ struct SyncConfig {
     // If true, upload/download waits are canceled on any sync error and not just fatal ones
     bool cancel_waits_on_nonfatal_error = false;
 
-    bool validate_sync_history = true;
-
     util::Optional<std::string> authorization_header_name;
     std::map<std::string, std::string> custom_http_headers;
 

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -410,30 +410,6 @@ SyncSession::SyncSession(SyncClient& client, std::string realm_path, SyncConfig 
 , m_realm_path(std::move(realm_path))
 , m_client(client)
 {
-    // Sync history validation ensures that the history within the Realm file is in a format that can be used
-    // by the version of realm-sync that we're using. Validation is enabled by default when the binding manually
-    // opens a sync session (via `SyncManager::get_session`), but is disabled when the sync session is opened
-    // as a side effect of opening a `Realm`. In that case, the sync history has already been validated by the
-    // act of opening the `Realm` so it's not necessary to repeat it here.
-    if (m_config.validate_sync_history) {
-        DBOptions options;
-
-        if (m_config.realm_encryption_key) {
-            options.encryption_key = m_config.realm_encryption_key->data();
-        }
-#if REALM_ENABLE_SYNC
-        auto history = sync::make_client_replication(m_realm_path);
-#else
-        REALM_TERMINATE("Realm was not built with sync enabled");
-#endif
-
-        // FIXME: Opening a Realm only to discard it is relatively expensive. It may be preferable to have
-        // realm-sync open the Realm when the `sync::Session` is created since it can continue to use it.
-
-        // We use the core method directly as we don't want to modify the coordinator that might exist at this
-        // point (especially overwriting the config)
-        DB::create(*history, options);
-   }
 }
 
 std::string SyncSession::get_recovery_file_path()


### PR DESCRIPTION
This was part of the sync 1.x -> 2.0 migration, where we needed to discover that it was an old file being opened very early in the process to hit the correct error recovery path. That error recovery path no longer exists at all, so it's now just pointless.