### PR TITLE
Fix thread-safety issues with frozen Results

### DIFF
--- a/CMake/CompilerFlags.cmake
+++ b/CMake/CompilerFlags.cmake
@@ -72,11 +72,13 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
         -Wconditional-uninitialized
         -Wconstant-conversion
         -Wenum-conversion
+        -Wimplicit-fallthrough
         -Wint-conversion
         -Wmissing-prototypes
         -Wnewline-eof
         -Wshorten-64-to-32
-        -Wimplicit-fallthrough
+        -Wthread-safety
+        -Wthread-safety-negative
     )
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -65,6 +65,7 @@ set(HEADERS
 
     util/aligned_union.hpp
     util/atomic_shared_ptr.hpp
+    util/checked_mutex.hpp
     util/event_loop_dispatcher.hpp
     util/event_loop_signal.hpp
     util/tagged_bool.hpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -66,6 +66,7 @@ set(HEADERS
     util/aligned_union.hpp
     util/atomic_shared_ptr.hpp
     util/checked_mutex.hpp
+    util/copyable_atomic.hpp
     util/event_loop_dispatcher.hpp
     util/event_loop_signal.hpp
     util/tagged_bool.hpp

--- a/src/execution_context_id.hpp
+++ b/src/execution_context_id.hpp
@@ -54,7 +54,7 @@ public:
     // Convert from the representation used by Realm::Config, where the absence of an
     // explicit abstract execution context indicates that the current thread's identifier
     // should be used.
-    AnyExecutionContextID(util::Optional<AbstractExecutionContextID> maybe_abstract_id)
+    AnyExecutionContextID(util::Optional<AbstractExecutionContextID> maybe_abstract_id) noexcept
     {
         if (maybe_abstract_id)
             *this = AnyExecutionContextID(*maybe_abstract_id);
@@ -62,35 +62,37 @@ public:
             *this = AnyExecutionContextID(std::this_thread::get_id());
     }
 
-    AnyExecutionContextID(std::thread::id thread_id) : AnyExecutionContextID(Type::Thread, std::move(thread_id)) { }
-    AnyExecutionContextID(AbstractExecutionContextID abstract_id) : AnyExecutionContextID(Type::Abstract, abstract_id) { }
+    AnyExecutionContextID(std::thread::id thread_id) noexcept
+    : AnyExecutionContextID(Type::Thread, std::move(thread_id)) { }
+    AnyExecutionContextID(AbstractExecutionContextID abstract_id) noexcept
+    : AnyExecutionContextID(Type::Abstract, abstract_id) { }
 
     template <typename StorageType>
-    bool contains() const
+    bool contains() const noexcept
     {
         return TypeForStorageType<StorageType>::value == m_type;
     }
 
     template <typename StorageType>
-    StorageType get() const
+    StorageType get() const noexcept
     {
         REALM_ASSERT_DEBUG(contains<StorageType>());
         return *reinterpret_cast<const StorageType*>(&m_storage);
     }
 
-    bool operator==(const AnyExecutionContextID& other) const
+    bool operator==(const AnyExecutionContextID& other) const noexcept
     {
         return m_type == other.m_type && std::memcmp(&m_storage, &other.m_storage, sizeof(m_storage)) == 0;
     }
 
-    bool operator!=(const AnyExecutionContextID& other) const
+    bool operator!=(const AnyExecutionContextID& other) const noexcept
     {
         return !(*this == other);
     }
 
 private:
     template <typename T>
-    AnyExecutionContextID(Type type, T value) : m_type(type)
+    AnyExecutionContextID(Type type, T value) noexcept : m_type(type)
     {
         // operator== relies on being able to compare the raw bytes of m_storage,
         // so zero everything before intializing the portion in use.

--- a/src/impl/collection_notifier.cpp
+++ b/src/impl/collection_notifier.cpp
@@ -441,7 +441,8 @@ NotifierPackage::NotifierPackage(std::exception_ptr error,
 {
 }
 
-void NotifierPackage::package_and_wait(util::Optional<VersionID::version_type> target_version)
+// Clang TSE seems to not like returning a unique_lock from a function
+void NotifierPackage::package_and_wait(util::Optional<VersionID::version_type> target_version) NO_THREAD_SAFETY_ANALYSIS
 {
     if (!m_coordinator || m_error || !*this)
         return;

--- a/src/impl/collection_notifier.cpp
+++ b/src/impl/collection_notifier.cpp
@@ -208,7 +208,7 @@ uint64_t CollectionNotifier::add_callback(CollectionChangeCallback callback)
 {
     m_realm->verify_thread();
 
-    std::lock_guard<std::mutex> lock(m_callback_mutex);
+    util::CheckedLockGuard lock(m_callback_mutex);
     auto token = m_next_token++;
     m_callbacks.push_back({std::move(callback), {}, {}, token, false, false});
     if (m_callback_index == npos) { // Don't need to wake up if we're already sending notifications
@@ -224,7 +224,7 @@ void CollectionNotifier::remove_callback(uint64_t token)
     // it could cause user code to be called
     Callback old;
     {
-        std::lock_guard<std::mutex> lock(m_callback_mutex);
+        util::CheckedLockGuard lock(m_callback_mutex);
         auto it = find_callback(token);
         if (it == end(m_callbacks)) {
             return;
@@ -253,7 +253,7 @@ void CollectionNotifier::suppress_next_notification(uint64_t token)
         m_realm->verify_in_write();
     }
 
-    std::lock_guard<std::mutex> lock(m_callback_mutex);
+    util::CheckedLockGuard lock(m_callback_mutex);
     auto it = find_callback(token);
     if (it != end(m_callbacks)) {
         it->skip_next = true;
@@ -315,7 +315,7 @@ void CollectionNotifier::prepare_handover()
     m_has_run = true;
 
 #ifdef REALM_DEBUG
-    std::lock_guard<std::mutex> lock(m_callback_mutex);
+    util::CheckedLockGuard lock(m_callback_mutex);
     for (auto& callback : m_callbacks)
         REALM_ASSERT(!callback.skip_next);
 #endif
@@ -332,7 +332,7 @@ void CollectionNotifier::before_advance()
         // acquire a local reference to the callback so that removing the
         // callback from within it can't result in a dangling pointer
         auto cb = callback.fn;
-        lock.unlock();
+        lock.unlock_unchecked();
         cb.before(changes);
     });
 }
@@ -349,7 +349,7 @@ void CollectionNotifier::after_advance()
         // acquire a local reference to the callback so that removing the
         // callback from within it can't result in a dangling pointer
         auto cb = callback.fn;
-        lock.unlock();
+        lock.unlock_unchecked();
         cb.after(changes);
     });
 }
@@ -365,7 +365,7 @@ void CollectionNotifier::deliver_error(std::exception_ptr error)
         // callback from within it can't result in a dangling pointer
         auto cb = std::move(callback.fn);
         auto token = callback.token;
-        lock.unlock();
+        lock.unlock_unchecked();
         cb.error(error);
 
         // We never want to call the callback again after this, so just remove it
@@ -383,7 +383,7 @@ bool CollectionNotifier::package_for_delivery()
 {
     if (!prepare_to_deliver())
         return false;
-    std::lock_guard<std::mutex> l(m_callback_mutex);
+    util::CheckedLockGuard lock(m_callback_mutex);
     for (auto& callback : m_callbacks)
         callback.changes_to_deliver = std::move(callback.accumulated_changes).finalize();
     m_callback_count = m_callbacks.size();
@@ -393,12 +393,12 @@ bool CollectionNotifier::package_for_delivery()
 template<typename Fn>
 void CollectionNotifier::for_each_callback(Fn&& fn)
 {
-    std::unique_lock<std::mutex> callback_lock(m_callback_mutex);
+    util::CheckedUniqueLock callback_lock(m_callback_mutex);
     REALM_ASSERT_DEBUG(m_callback_count <= m_callbacks.size());
     for (++m_callback_index; m_callback_index < m_callback_count; ++m_callback_index) {
         fn(callback_lock, m_callbacks[m_callback_index]);
         if (!callback_lock.owns_lock())
-            callback_lock.lock();
+            callback_lock.lock_unchecked();
     }
 
     m_callback_index = npos;
@@ -417,7 +417,7 @@ Transaction& CollectionNotifier::source_shared_group()
 
 void CollectionNotifier::add_changes(CollectionChangeBuilder change)
 {
-    std::lock_guard<std::mutex> lock(m_callback_mutex);
+    util::CheckedLockGuard lock(m_callback_mutex);
     for (auto& callback : m_callbacks) {
         if (callback.skip_next) {
             REALM_ASSERT_DEBUG(callback.accumulated_changes.empty());

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -963,10 +963,9 @@ void RealmCoordinator::run_async_notifiers()
         for (auto& notifier : notifiers)
             notifier->run();
 
-        lock.lock();
+        util::CheckedLockGuard lock(m_notifier_mutex);
         for (auto& notifier : notifiers)
             notifier->prepare_handover();
-        lock.unlock();
     }
 
     // Advance the non-new notifiers to the same version as we advanced the new
@@ -991,7 +990,7 @@ void RealmCoordinator::run_async_notifiers()
 
     // Reacquire the lock while updating the fields that are actually read on
     // other threads
-    lock.lock();
+    util::CheckedLockGuard lock2(m_notifier_mutex);
     for (auto& notifier : new_notifiers) {
         notifier->prepare_handover();
     }

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -67,10 +67,10 @@ std::shared_ptr<RealmCoordinator> RealmCoordinator::get_coordinator(StringData p
     return coordinator;
 }
 
-std::shared_ptr<RealmCoordinator> RealmCoordinator::get_coordinator(const Realm::Config& config)
+std::shared_ptr<RealmCoordinator> RealmCoordinator::get_coordinator(const Realm::Config& config) NO_THREAD_SAFETY_ANALYSIS
 {
     auto coordinator = get_coordinator(config.path);
-    std::lock_guard<std::mutex> lock(coordinator->m_realm_mutex);
+    util::CheckedLockGuard lock(coordinator->m_realm_mutex);
     coordinator->set_config(config);
     return coordinator;
 }
@@ -109,8 +109,11 @@ void RealmCoordinator::create_sync_session(bool force_client_resync)
     SyncSession::Internal::set_sync_transact_callback(*m_sync_session,
                                                       [weak_self](VersionID old_version, VersionID new_version) {
         if (auto self = weak_self.lock()) {
-            if (self->m_transaction_callback)
-                self->m_transaction_callback(old_version, new_version);
+            util::CheckedUniqueLock lock(self->m_transaction_callback_mutex);
+            if (auto transaction_callback = self->m_transaction_callback) {
+                lock.unlock();
+                transaction_callback(old_version, new_version);
+            }
             if (self->m_notifier)
                 self->m_notifier->notify_others();
         }
@@ -165,6 +168,7 @@ void RealmCoordinator::set_config(const Realm::Config& config)
         if (m_config.schema_mode != config.schema_mode) {
             throw MismatchedConfigException("Realm at path '%1' already opened with a different schema mode.", config.path);
         }
+        util::CheckedLockGuard lock(m_schema_cache_mutex);
         if (config.schema && m_schema_version != ObjectStore::NotVersioned && m_schema_version != config.schema_version) {
             throw MismatchedConfigException("Realm at path '%1' already opened with different schema version.", config.path);
         }
@@ -200,7 +204,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config, util::O
     // we release the strong reference to realm, as Realm's destructor may want
     // to acquire the same lock
     std::shared_ptr<Realm> realm;
-    std::unique_lock<std::mutex> lock(m_realm_mutex);
+    util::CheckedUniqueLock lock(m_realm_mutex);
     set_config(config);
     do_get_realm(std::move(config), realm, version, lock);
     return realm;
@@ -209,7 +213,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config, util::O
 std::shared_ptr<Realm> RealmCoordinator::get_realm()
 {
     std::shared_ptr<Realm> realm;
-    std::unique_lock<std::mutex> lock(m_realm_mutex);
+    util::CheckedUniqueLock lock(m_realm_mutex);
     do_get_realm(m_config, realm, none, lock);
     return realm;
 }
@@ -217,14 +221,14 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm()
 ThreadSafeReference RealmCoordinator::get_unbound_realm()
 {
     std::shared_ptr<Realm> realm;
-    std::unique_lock<std::mutex> lock(m_realm_mutex);
+    util::CheckedUniqueLock lock(m_realm_mutex);
     do_get_realm(m_config, realm, none, lock, false);
     return ThreadSafeReference(realm);
 }
 
 void RealmCoordinator::do_get_realm(Realm::Config config, std::shared_ptr<Realm>& realm,
                                     util::Optional<VersionID> version,
-                                    std::unique_lock<std::mutex>& realm_lock, bool bind_to_context)
+                                    CheckedUniqueLock& realm_lock, bool bind_to_context)
 {
     open_db();
 
@@ -252,7 +256,7 @@ void RealmCoordinator::do_get_realm(Realm::Config config, std::shared_ptr<Realm>
     if (!m_audit_context && audit_factory)
         m_audit_context = audit_factory();
 
-    realm_lock.unlock();
+    realm_lock.unlock_unchecked();
     if (schema) {
 #if REALM_ENABLE_SYNC && REALM_PLATFORM_JAVA
         // Workaround for https://github.com/realm/realm-java/issues/6619
@@ -296,7 +300,7 @@ void RealmCoordinator::do_get_realm(Realm::Config config, std::shared_ptr<Realm>
 
 void RealmCoordinator::bind_to_context(Realm& realm, AnyExecutionContextID execution_context)
 {
-    std::unique_lock<std::mutex> lock(m_realm_mutex);
+    util::CheckedLockGuard lock(m_realm_mutex);
     for (auto& cached_realm : m_weak_realm_notifiers) {
         if (!cached_realm.is_for_realm(&realm))
             continue;
@@ -312,7 +316,7 @@ std::shared_ptr<AsyncOpenTask> RealmCoordinator::get_synchronized_realm(Realm::C
     if (!config.sync_config)
         throw std::logic_error("This method is only available for fully synchronized Realms.");
 
-    std::unique_lock<std::mutex> lock(m_realm_mutex);
+    util::CheckedLockGuard lock(m_realm_mutex);
     set_config(config);
     bool exists = File::exists(m_config.path);
     create_sync_session(!config.sync_config->is_partial && !exists);
@@ -322,7 +326,7 @@ std::shared_ptr<AsyncOpenTask> RealmCoordinator::get_synchronized_realm(Realm::C
 void RealmCoordinator::create_session(const Realm::Config& config)
 {
     REALM_ASSERT(config.sync_config);
-    std::unique_lock<std::mutex> lock(m_realm_mutex);
+    util::CheckedLockGuard lock(m_realm_mutex);
     set_config(config);
     bool exists = File::exists(m_config.path);
     create_sync_session(!config.sync_config->is_partial && !exists);
@@ -330,6 +334,7 @@ void RealmCoordinator::create_session(const Realm::Config& config)
 
 void RealmCoordinator::open_with_config(Realm::Config config)
 {
+    CheckedLockGuard lock(m_realm_mutex);
     set_config(config);
     open_db();
 }
@@ -491,10 +496,16 @@ std::shared_ptr<Group> RealmCoordinator::begin_read(VersionID version, bool froz
     return (frozen_transaction) ? m_db->start_frozen(version) : m_db->start_read(version);
 }
 
+uint64_t RealmCoordinator::get_schema_version() const noexcept
+{
+    util::CheckedLockGuard lock(m_schema_cache_mutex);
+    return m_schema_version;
+}
+
 bool RealmCoordinator::get_cached_schema(Schema& schema, uint64_t& schema_version,
                                          uint64_t& transaction) const noexcept
 {
-    std::lock_guard<std::mutex> lock(m_schema_cache_mutex);
+    util::CheckedLockGuard lock(m_schema_cache_mutex);
     if (!m_cached_schema)
         return false;
     schema = *m_cached_schema;
@@ -506,7 +517,7 @@ bool RealmCoordinator::get_cached_schema(Schema& schema, uint64_t& schema_versio
 void RealmCoordinator::cache_schema(Schema const& new_schema, uint64_t new_schema_version,
                                     uint64_t transaction_version)
 {
-    std::lock_guard<std::mutex> lock(m_schema_cache_mutex);
+    util::CheckedLockGuard lock(m_schema_cache_mutex);
     if (transaction_version < m_schema_transaction_version_max)
         return;
     if (new_schema.empty() || new_schema_version == ObjectStore::NotVersioned)
@@ -520,14 +531,14 @@ void RealmCoordinator::cache_schema(Schema const& new_schema, uint64_t new_schem
 
 void RealmCoordinator::clear_schema_cache_and_set_schema_version(uint64_t new_schema_version)
 {
-    std::lock_guard<std::mutex> lock(m_schema_cache_mutex);
+    util::CheckedLockGuard lock(m_schema_cache_mutex);
     m_cached_schema = util::none;
     m_schema_version = new_schema_version;
 }
 
 void RealmCoordinator::advance_schema_cache(uint64_t previous, uint64_t next)
 {
-    std::lock_guard<std::mutex> lock(m_schema_cache_mutex);
+    util::CheckedLockGuard lock(m_schema_cache_mutex);
     if (!m_cached_schema)
         return;
     REALM_ASSERT(previous <= m_schema_transaction_version_max);
@@ -575,18 +586,20 @@ void RealmCoordinator::unregister_realm(Realm* realm)
     // but if that's disabled we need to ensure that any notifiers from this
     // Realm get cleaned up
     if (!m_config.automatic_change_notifications) {
-        std::unique_lock<std::mutex> lock(m_notifier_mutex);
+        util::CheckedLockGuard lock(m_notifier_mutex);
         clean_up_dead_notifiers();
     }
     {
-        std::lock_guard<std::mutex> lock(m_realm_mutex);
+        util::CheckedLockGuard lock(m_realm_mutex);
         auto new_end = remove_if(begin(m_weak_realm_notifiers), end(m_weak_realm_notifiers),
                                  [=](auto& notifier) { return notifier.expired() || notifier.is_for_realm(realm); });
         m_weak_realm_notifiers.erase(new_end, end(m_weak_realm_notifiers));
     }
 }
 
-void RealmCoordinator::clear_cache()
+// Thread-safety analsys doesn't reasonably handle calling functions on different
+// instances of this type
+void RealmCoordinator::clear_cache() NO_THREAD_SAFETY_ANALYSIS
 {
     std::vector<WeakRealm> realms_to_close;
     {
@@ -601,6 +614,7 @@ void RealmCoordinator::clear_cache()
             coordinator->m_notifier = nullptr;
 
             // Gather a list of all of the realms which will be removed
+            CheckedLockGuard lock(coordinator->m_realm_mutex);
             for (auto& weak_realm_notifier : coordinator->m_weak_realm_notifiers) {
                 if (auto realm = weak_realm_notifier.realm()) {
                     realms_to_close.push_back(realm);
@@ -663,7 +677,7 @@ void RealmCoordinator::commit_write(Realm& realm)
         // Need to acquire this lock before committing or another process could
         // perform a write and notify us before we get the chance to set the
         // skip version
-        std::lock_guard<std::mutex> l(m_notifier_mutex);
+        util::CheckedLockGuard l(m_notifier_mutex);
 
         tr.commit_and_continue_as_read();
 
@@ -708,19 +722,20 @@ void RealmCoordinator::wait_for_change_release()
 
 void RealmCoordinator::pin_version(VersionID versionid)
 {
-    REALM_ASSERT_DEBUG(!m_notifier_mutex.try_lock());
     if (m_async_error)
         return;
     if (!m_advancer_sg || versionid < m_advancer_sg->get_version_of_current_transaction())
         m_advancer_sg = m_db->start_read(versionid);
 }
 
-void RealmCoordinator::register_notifier(std::shared_ptr<CollectionNotifier> notifier)
+// Thread-safety analsys doesn't reasonably handle calling functions on different
+// instances of this type
+void RealmCoordinator::register_notifier(std::shared_ptr<CollectionNotifier> notifier) NO_THREAD_SAFETY_ANALYSIS
 {
     auto version = notifier->version();
     auto& self = Realm::Internal::get_coordinator(*notifier->get_realm());
     {
-        std::lock_guard<std::mutex> lock(self.m_notifier_mutex);
+        util::CheckedLockGuard lock(self.m_notifier_mutex);
         self.pin_version(version);
         self.m_new_notifiers.push_back(std::move(notifier));
     }
@@ -760,7 +775,7 @@ void RealmCoordinator::on_change()
 {
     run_async_notifiers();
 
-    std::lock_guard<std::mutex> lock(m_realm_mutex);
+    util::CheckedLockGuard lock(m_realm_mutex);
     for (auto& realm : m_weak_realm_notifiers) {
         realm.notify();
     }
@@ -862,7 +877,7 @@ private:
 
 void RealmCoordinator::run_async_notifiers()
 {
-    std::unique_lock<std::mutex> lock(m_notifier_mutex);
+    util::CheckedUniqueLock lock(m_notifier_mutex);
 
     clean_up_dead_notifiers();
 
@@ -995,7 +1010,7 @@ bool RealmCoordinator::can_advance(Realm& realm)
 
 void RealmCoordinator::advance_to_ready(Realm& realm)
 {
-    std::unique_lock<std::mutex> lock(m_notifier_mutex);
+    util::CheckedUniqueLock lock(m_notifier_mutex);
     _impl::NotifierPackage notifiers(m_async_error, notifiers_for_realm(realm), this);
     lock.unlock();
     notifiers.package_and_wait(util::none);
@@ -1046,7 +1061,7 @@ bool RealmCoordinator::advance_to_latest(Realm& realm)
     // FIXME: we probably won't actually want a strong pointer here
     auto self = shared_from_this();
     auto sg = Realm::Internal::get_transaction_ref(realm);
-    std::unique_lock<std::mutex> lock(m_notifier_mutex);
+    util::CheckedUniqueLock lock(m_notifier_mutex);
     _impl::NotifierPackage notifiers(m_async_error, notifiers_for_realm(realm), this);
     lock.unlock();
     notifiers.package_and_wait(sg->get_version_of_latest_snapshot());
@@ -1065,7 +1080,7 @@ void RealmCoordinator::promote_to_write(Realm& realm)
 {
     REALM_ASSERT(!realm.is_in_transaction());
 
-    std::unique_lock<std::mutex> lock(m_notifier_mutex);
+    util::CheckedUniqueLock lock(m_notifier_mutex);
     _impl::NotifierPackage notifiers(m_async_error, notifiers_for_realm(realm), this);
     lock.unlock();
 
@@ -1078,7 +1093,7 @@ void RealmCoordinator::process_available_async(Realm& realm)
 {
     REALM_ASSERT(!realm.is_in_transaction());
 
-    std::unique_lock<std::mutex> lock(m_notifier_mutex);
+    util::CheckedUniqueLock lock(m_notifier_mutex);
     auto notifiers = notifiers_for_realm(realm);
     if (notifiers.empty())
         return;
@@ -1125,6 +1140,7 @@ void RealmCoordinator::process_available_async(Realm& realm)
 void RealmCoordinator::set_transaction_callback(std::function<void(VersionID, VersionID)> fn)
 {
     create_sync_session(false);
+    util::CheckedLockGuard lock(m_transaction_callback_mutex);
     m_transaction_callback = std::move(fn);
 }
 

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -21,6 +21,8 @@
 
 #include "shared_realm.hpp"
 
+#include "util/checked_mutex.hpp"
+
 #include <realm/version_id.hpp>
 
 #include <condition_variable>
@@ -60,33 +62,34 @@ public:
     // If no version is provided a live thread-confined Realm is returned.
     // Otherwise, a frozen Realm at the given version is returned. This
     // can be read from any thread.
-    std::shared_ptr<Realm> get_realm(Realm::Config config, util::Optional<VersionID> version);
-    std::shared_ptr<Realm> get_realm();
+    std::shared_ptr<Realm> get_realm(Realm::Config config, util::Optional<VersionID> version) REQUIRES(!m_realm_mutex, !m_schema_cache_mutex);
+    std::shared_ptr<Realm> get_realm() REQUIRES(!m_realm_mutex, !m_schema_cache_mutex);
 #if REALM_ENABLE_SYNC
     // Get a thread-local shared Realm with the given configuration
     // If the Realm is not already present, it will be fully downloaded before being returned.
     // If the Realm is already on disk, it will be fully synchronized before being returned.
     // Timeouts and interruptions are not handled by this method and must be handled by upper layers.
-    std::shared_ptr<AsyncOpenTask> get_synchronized_realm(Realm::Config config);
+    std::shared_ptr<AsyncOpenTask> get_synchronized_realm(Realm::Config config)
+        REQUIRES(!m_realm_mutex, !m_schema_cache_mutex);
     // Used by GlobalNotifier to bypass the normal initialization path
-    void open_with_config(Realm::Config config);
+    void open_with_config(Realm::Config config) REQUIRES(!m_realm_mutex, !m_schema_cache_mutex);
 
     // Creates the underlying sync session if it doesn't already exists.
     // This is also created as part of opening a Realm, so only use this
     // method if the session needs to exist before the Realm does.
-    void create_session(const Realm::Config& config);
+    void create_session(const Realm::Config& config) REQUIRES(!m_realm_mutex, !m_schema_cache_mutex);
 #endif
 
     // Get a Realm which is not bound to the current execution context
-    ThreadSafeReference get_unbound_realm();
+    ThreadSafeReference get_unbound_realm() REQUIRES(!m_realm_mutex);
 
     // Bind an unbound Realm to a specific execution context. The Realm must
     // be managed by this coordinator.
-    void bind_to_context(Realm& realm, AnyExecutionContextID);
+    void bind_to_context(Realm& realm, AnyExecutionContextID) REQUIRES(!m_realm_mutex);
 
     Realm::Config get_config() const { return m_config; }
 
-    uint64_t get_schema_version() const noexcept { return m_schema_version; }
+    uint64_t get_schema_version() const noexcept REQUIRES(!m_schema_cache_mutex);
     const std::string& get_path() const noexcept { return m_config.path; }
     const std::vector<char>& get_encryption_key() const noexcept { return m_config.encryption_key; }
     bool is_in_memory() const noexcept { return m_config.in_memory; }
@@ -102,15 +105,15 @@ public:
 
     // Get the latest cached schema and the transaction version which it applies
     // to. Returns false if there is no cached schema.
-    bool get_cached_schema(Schema& schema, uint64_t& schema_version, uint64_t& transaction) const noexcept;
+    bool get_cached_schema(Schema& schema, uint64_t& schema_version, uint64_t& transaction) const noexcept REQUIRES(!m_schema_cache_mutex);
 
     // Cache the state of the schema at the given transaction version
     void cache_schema(Schema const& new_schema, uint64_t new_schema_version,
-                      uint64_t transaction_version);
+                      uint64_t transaction_version) REQUIRES(!m_schema_cache_mutex);
     // If there is a schema cached for transaction version `previous`, report
     // that it is still valid at transaction version `next`
-    void advance_schema_cache(uint64_t previous, uint64_t next);
-    void clear_schema_cache_and_set_schema_version(uint64_t new_schema_version);
+    void advance_schema_cache(uint64_t previous, uint64_t next) REQUIRES(!m_schema_cache_mutex);
+    void clear_schema_cache_and_set_schema_version(uint64_t new_schema_version) REQUIRES(!m_schema_cache_mutex);
 
 
     // Asynchronously call notify() on every Realm instance for this coordinator's
@@ -135,10 +138,10 @@ public:
 
     // Called by Realm's destructor to ensure the cache is cleaned up promptly
     // Do not call directly
-    void unregister_realm(Realm* realm);
+    void unregister_realm(Realm* realm) REQUIRES(!m_realm_mutex, !m_notifier_mutex);
 
     // Called by m_notifier when there's a new commit to send notifications for
-    void on_change();
+    void on_change() REQUIRES(!m_realm_mutex, !m_notifier_mutex);
 
     static void register_notifier(std::shared_ptr<CollectionNotifier> notifier);
 
@@ -149,26 +152,26 @@ public:
 
     // Advance the Realm to the most recent transaction version which all async
     // work is complete for
-    void advance_to_ready(Realm& realm);
+    void advance_to_ready(Realm& realm) REQUIRES(!m_notifier_mutex);
 
     // Advance the Realm to the most recent transaction version, blocking if
     // async notifiers are not yet ready for that version
     // returns whether it actually changed the version
-    bool advance_to_latest(Realm& realm);
+    bool advance_to_latest(Realm& realm) REQUIRES(!m_notifier_mutex);
 
     // Deliver any notifications which are ready for the Realm's version
-    void process_available_async(Realm& realm);
+    void process_available_async(Realm& realm) REQUIRES(!m_notifier_mutex);
 
     // Register a function which is called whenever sync makes a write to the Realm
-    void set_transaction_callback(std::function<void(VersionID, VersionID)>);
+    void set_transaction_callback(std::function<void(VersionID, VersionID)>) REQUIRES(!m_transaction_callback_mutex);
 
     // Deliver notifications for the Realm, blocking if some aren't ready yet
     // The calling Realm must be in a write transaction
-    void promote_to_write(Realm& realm);
+    void promote_to_write(Realm& realm) REQUIRES(!m_notifier_mutex);
 
     // Commit a Realm's current write transaction and send notifications to all
     // other Realm instances for that path, including in other processes
-    void commit_write(Realm& realm);
+    void commit_write(Realm& realm) REQUIRES(!m_notifier_mutex);
 
     void enable_wait_for_change();
     bool wait_for_change(std::shared_ptr<Transaction> tr);
@@ -178,7 +181,7 @@ public:
     bool compact();
 
     template<typename Pred>
-    std::unique_lock<std::mutex> wait_for_notifiers(Pred&& wait_predicate);
+    util::CheckedUniqueLock wait_for_notifiers(Pred&& wait_predicate) REQUIRES(!m_notifier_mutex);
 
 #if REALM_ENABLE_SYNC
     // A work queue that can be used to perform background work related to partial sync.
@@ -194,20 +197,20 @@ private:
     std::shared_ptr<DB> m_db;
     std::shared_ptr<Group> m_read_only_group;
 
-    mutable std::mutex m_schema_cache_mutex;
-    util::Optional<Schema> m_cached_schema;
-    uint64_t m_schema_version = -1;
-    uint64_t m_schema_transaction_version_min = 0;
-    uint64_t m_schema_transaction_version_max = 0;
+    mutable util::CheckedMutex m_schema_cache_mutex;
+    util::Optional<Schema> m_cached_schema GUARDED_BY(m_schema_cache_mutex);
+    uint64_t m_schema_version GUARDED_BY(m_schema_cache_mutex) = -1;
+    uint64_t m_schema_transaction_version_min GUARDED_BY(m_schema_cache_mutex) = 0;
+    uint64_t m_schema_transaction_version_max GUARDED_BY(m_schema_cache_mutex) = 0;
 
-    std::mutex m_realm_mutex;
-    std::vector<WeakRealmNotifier> m_weak_realm_notifiers;
+    util::CheckedMutex m_realm_mutex;
+    std::vector<WeakRealmNotifier> m_weak_realm_notifiers GUARDED_BY(m_realm_mutex);
 
-    std::mutex m_notifier_mutex;
+    util::CheckedMutex m_notifier_mutex;
     std::condition_variable m_notifier_cv;
-    std::vector<std::shared_ptr<_impl::CollectionNotifier>> m_new_notifiers;
-    std::vector<std::shared_ptr<_impl::CollectionNotifier>> m_notifiers;
-    VersionID m_notifier_skip_version = {0, 0};
+    std::vector<std::shared_ptr<_impl::CollectionNotifier>> m_new_notifiers GUARDED_BY(m_notifier_mutex);
+    std::vector<std::shared_ptr<_impl::CollectionNotifier>> m_notifiers GUARDED_BY(m_notifier_mutex);
+    VersionID m_notifier_skip_version GUARDED_BY(m_notifier_mutex) = {0, 0};
 
     // Transaction used for actually running async notifiers
     // Will have a read transaction iff m_notifiers is non-empty
@@ -220,7 +223,8 @@ private:
     std::exception_ptr m_async_error;
 
     std::unique_ptr<_impl::ExternalCommitHelper> m_notifier;
-    std::function<void(VersionID, VersionID)> m_transaction_callback;
+    util::CheckedMutex m_transaction_callback_mutex;
+    std::function<void(VersionID, VersionID)> m_transaction_callback GUARDED_BY(m_transaction_callback_mutex);
 
 #if REALM_ENABLE_SYNC
     std::shared_ptr<SyncSession> m_sync_session;
@@ -231,29 +235,28 @@ private:
 
     void open_db();
 
-    // must be called with m_notifier_mutex locked
-    void pin_version(VersionID version);
+    void pin_version(VersionID version) REQUIRES(m_notifier_mutex);
 
-    void set_config(const Realm::Config&);
+    void set_config(const Realm::Config&) REQUIRES(m_realm_mutex, !m_schema_cache_mutex);
     void create_sync_session(bool force_client_resync);
     void do_get_realm(Realm::Config config, std::shared_ptr<Realm>& realm,
                       util::Optional<VersionID> version,
-                      std::unique_lock<std::mutex>& realm_lock, bool bind_to_context=true);
-    void run_async_notifiers();
+                      util::CheckedUniqueLock& realm_lock, bool bind_to_context=true) REQUIRES(m_realm_mutex);
+    void run_async_notifiers() REQUIRES(!m_notifier_mutex);
     void advance_helper_shared_group_to_latest();
-    void clean_up_dead_notifiers();
+    void clean_up_dead_notifiers() REQUIRES(m_notifier_mutex);
 
-    std::vector<std::shared_ptr<_impl::CollectionNotifier>> notifiers_for_realm(Realm&);
+    std::vector<std::shared_ptr<_impl::CollectionNotifier>> notifiers_for_realm(Realm&) REQUIRES(m_notifier_mutex);
 };
 
 void translate_file_exception(StringData path, bool immutable=false);
 
 template<typename Pred>
-std::unique_lock<std::mutex> RealmCoordinator::wait_for_notifiers(Pred&& wait_predicate)
+util::CheckedUniqueLock RealmCoordinator::wait_for_notifiers(Pred&& wait_predicate)
 {
-    std::unique_lock<std::mutex> lock(m_notifier_mutex);
+    util::CheckedUniqueLock lock(m_notifier_mutex);
     bool first = true;
-    m_notifier_cv.wait(lock, [&] {
+    m_notifier_cv.wait(lock.native_handle(), [&] {
         if (wait_predicate())
             return true;
         if (first) {

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -76,13 +76,14 @@ ObjectSchema const& List::get_object_schema() const
     verify_attached();
 
     REALM_ASSERT(get_type() == PropertyType::Object);
-    if (!m_object_schema) {
+    auto object_schema = m_object_schema.load();
+    if (!object_schema) {
         auto object_type = object_name(*static_cast<LnkLst&>(*m_list_base).get_target_table());
         auto it = m_realm->schema().find(object_type);
         REALM_ASSERT(it != m_realm->schema().end());
-        m_object_schema = &*it;
+        m_object_schema = object_schema = &*it;
     }
-    return *m_object_schema;
+    return *object_schema;
 }
 
 Query List::get_query() const

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -371,7 +371,7 @@ struct If<false> {
     static auto call(T, Then&&, Else&& fn) { return fn(); }
 };
 
-util::Optional<Mixed> List::max(ColKey col)
+util::Optional<Mixed> List::max(ColKey col) const
 {
     if (get_type() == PropertyType::Object)
         return as_results().max(col);
@@ -383,7 +383,7 @@ util::Optional<Mixed> List::max(ColKey col)
     return out_ndx == not_found ? none : make_optional(result);
 }
 
-util::Optional<Mixed> List::min(ColKey col)
+util::Optional<Mixed> List::min(ColKey col) const
 {
     if (get_type() == PropertyType::Object)
         return as_results().min(col);
@@ -396,7 +396,7 @@ util::Optional<Mixed> List::min(ColKey col)
     return out_ndx == not_found ? none : make_optional(result);
 }
 
-Mixed List::sum(ColKey col)
+Mixed List::sum(ColKey col) const
 {
     if (get_type() == PropertyType::Object)
         return *as_results().sum(col);
@@ -408,7 +408,7 @@ Mixed List::sum(ColKey col)
     return result;
 }
 
-util::Optional<double> List::average(ColKey col)
+util::Optional<double> List::average(ColKey col) const
 {
     if (get_type() == PropertyType::Object)
         return as_results().average(col);
@@ -446,12 +446,12 @@ NotificationToken List::add_notification_callback(CollectionChangeCallback cb) &
     return {m_notifier, m_notifier->add_callback(std::move(cb))};
 }
 
-List List::freeze(std::shared_ptr<Realm> frozen_realm)
+List List::freeze(std::shared_ptr<Realm> frozen_realm) const
 {
     return List(frozen_realm, *frozen_realm->transaction().import_copy_of(*m_list_base));
 }
 
-bool List::is_frozen()
+bool List::is_frozen() const noexcept
 {
     return m_realm->is_frozen();
 }

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -23,6 +23,7 @@
 #include "impl/collection_notifier.hpp"
 #include "object.hpp"
 #include "property.hpp"
+#include "util/copyable_atomic.hpp"
 
 #include <realm/mixed.hpp>
 #include <realm/list.hpp>
@@ -162,7 +163,7 @@ public:
 private:
     std::shared_ptr<Realm> m_realm;
     PropertyType m_type;
-    mutable const ObjectSchema* m_object_schema = nullptr;
+    mutable util::CopyableAtomic<const ObjectSchema*> m_object_schema = nullptr;
     _impl::CollectionNotifier::Handle<_impl::ListNotifier> m_notifier;
     std::shared_ptr<LstBase> m_list_base;
 

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -110,20 +110,20 @@ public:
     Results snapshot() const;
 
     // Returns a frozen copy of this result
-    List freeze(std::shared_ptr<Realm> realm);
+    List freeze(std::shared_ptr<Realm> realm) const;
 
     // Returns whether or not this List is frozen.
-    bool is_frozen();
+    bool is_frozen() const noexcept;
 
     // Get the min/max/average/sum of the given column
     // All but sum() returns none when there are zero matching rows
     // sum() returns 0,
     // Throws UnsupportedColumnTypeException for sum/average on timestamp or non-numeric column
     // Throws OutOfBoundsIndexException for an out-of-bounds column
-    util::Optional<Mixed> max(ColKey column={});
-    util::Optional<Mixed> min(ColKey column={});
-    util::Optional<double> average(ColKey column={});
-    Mixed sum(ColKey column={});
+    util::Optional<Mixed> max(ColKey column={}) const;
+    util::Optional<Mixed> min(ColKey column={}) const;
+    util::Optional<double> average(ColKey column={}) const;
+    Mixed sum(ColKey column={}) const;
 
     bool operator==(List const& rgt) const noexcept;
 
@@ -176,8 +176,6 @@ private:
 
     template<typename T, typename Context>
     void set_if_different(Context&, size_t row_ndx, T&& value, CreatePolicy);
-
-    size_t to_table_ndx(size_t row) const noexcept;
 
     friend struct std::hash<List>;
 };

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -27,11 +27,12 @@
 
 using namespace realm;
 
-Object Object::freeze(std::shared_ptr<Realm> frozen_realm) {
+Object Object::freeze(std::shared_ptr<Realm> frozen_realm) const
+{
     return Object(frozen_realm, frozen_realm->transaction().import_copy_of(m_obj));
 }
 
-bool Object::is_frozen()
+bool Object::is_frozen() const noexcept
 {
     return m_realm->is_frozen();
 }
@@ -61,8 +62,8 @@ ReadOnlyPropertyException::ReadOnlyPropertyException(const std::string& object_t
 , object_type(object_type), property_name(property_name) {}
 
 ModifyPrimaryKeyException::ModifyPrimaryKeyException(const std::string& object_type, const std::string& property_name)
-        : std::logic_error(util::format("Cannot modify primary key after creation: '%1.%2'", object_type, property_name))
-        , object_type(object_type), property_name(property_name) {}
+: std::logic_error(util::format("Cannot modify primary key after creation: '%1.%2'", object_type, property_name))
+, object_type(object_type), property_name(property_name) {}
 
 Object::Object(SharedRealm r, ObjectSchema const& s, Obj const& o)
 : m_realm(std::move(r)), m_object_schema(&s), m_obj(o) { }

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -66,10 +66,10 @@ public:
     bool is_valid() const { return m_obj.is_valid(); }
 
     // Returns a frozen copy of this object.
-    Object freeze(std::shared_ptr<Realm> frozen_realm);
+    Object freeze(std::shared_ptr<Realm> frozen_realm) const;
 
     // Returns whether or not this Object is frozen.
-    bool is_frozen();
+    bool is_frozen() const noexcept;
 
     NotificationToken add_notification_callback(CollectionChangeCallback callback) &;
 
@@ -80,7 +80,7 @@ public:
     void set_column_value(StringData prop_name, ValueType&& value) { m_obj.set(prop_name, value); }
 
     template<typename ValueType>
-    ValueType get_column_value(StringData prop_name) { return m_obj.get<ValueType>(prop_name); }
+    ValueType get_column_value(StringData prop_name) const { return m_obj.get<ValueType>(prop_name); }
 
     // The following functions require an accessor context which converts from
     // the binding's native data types to the core data types. See CppContext
@@ -94,10 +94,10 @@ public:
                             ValueType value, CreatePolicy policy = CreatePolicy::ForceCreate);
 
     template<typename ValueType, typename ContextType>
-    ValueType get_property_value(ContextType& ctx, StringData prop_name);
+    ValueType get_property_value(ContextType& ctx, StringData prop_name) const;
 
     template<typename ValueType, typename ContextType>
-    ValueType get_property_value(ContextType& ctx, const Property& property);
+    ValueType get_property_value(ContextType& ctx, const Property& property) const;
 
     // create an Object from a native representation
     template<typename ValueType, typename ContextType>
@@ -137,7 +137,7 @@ private:
     void set_property_value_impl(ContextType& ctx, const Property &property,
                                  ValueType value, CreatePolicy policy, bool is_default);
     template<typename ValueType, typename ContextType>
-    ValueType get_property_value_impl(ContextType& ctx, const Property &property);
+    ValueType get_property_value_impl(ContextType& ctx, const Property &property) const;
 
     template<typename ValueType, typename ContextType>
     static ObjKey get_for_primary_key_impl(ContextType& ctx, Table const& table,

--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -117,7 +117,7 @@ ObjectSchema::ObjectSchema(Group const& group, StringData name, TableKey key)
     set_primary_key_property();
 }
 
-Property *ObjectSchema::property_for_name(StringData name)
+Property *ObjectSchema::property_for_name(StringData name) noexcept
 {
     for (auto& prop : persisted_properties) {
         if (StringData(prop.name) == name) {
@@ -132,7 +132,7 @@ Property *ObjectSchema::property_for_name(StringData name)
     return nullptr;
 }
 
-Property *ObjectSchema::property_for_public_name(StringData public_name)
+Property *ObjectSchema::property_for_public_name(StringData public_name) noexcept
 {
     // If no `public_name` is defined, the internal `name` is also considered the public name.
     for (auto& prop : persisted_properties) {
@@ -144,29 +144,29 @@ Property *ObjectSchema::property_for_public_name(StringData public_name)
     // are a bit pointless since the internal name is already the "public name", but since
     // this distinction isn't visible in the Property struct we allow it anyway.
     for (auto& prop : computed_properties) {
-        if ((prop.public_name.empty() ? StringData(prop.name) :  StringData(prop.public_name)) == public_name)
+        if (StringData(prop.public_name.empty() ? prop.name : prop.public_name) == public_name)
             return &prop;
     }
     return nullptr;
 }
 
-const Property *ObjectSchema::property_for_public_name(StringData public_name) const
+const Property *ObjectSchema::property_for_public_name(StringData public_name) const noexcept
 {
     return const_cast<ObjectSchema *>(this)->property_for_public_name(public_name);
 }
 
-const Property *ObjectSchema::property_for_name(StringData name) const
+const Property *ObjectSchema::property_for_name(StringData name) const noexcept
 {
     return const_cast<ObjectSchema *>(this)->property_for_name(name);
 }
 
-bool ObjectSchema::property_is_computed(Property const& property) const
+bool ObjectSchema::property_is_computed(Property const& property) const noexcept
 {
     auto end = computed_properties.end();
     return std::find(computed_properties.begin(), end, property) != end;
 }
 
-void ObjectSchema::set_primary_key_property()
+void ObjectSchema::set_primary_key_property() noexcept
 {
     if (primary_key.length()) {
         if (auto primary_key_prop = primary_key_property()) {
@@ -334,7 +334,7 @@ void ObjectSchema::validate(Schema const& schema, std::vector<ObjectSchemaValida
 }
 
 namespace realm {
-bool operator==(ObjectSchema const& a, ObjectSchema const& b)
+bool operator==(ObjectSchema const& a, ObjectSchema const& b) noexcept
 {
     return std::tie(a.name, a.primary_key, a.persisted_properties, a.computed_properties)
         == std::tie(b.name, b.primary_key, b.persisted_properties, b.computed_properties);

--- a/src/object_schema.hpp
+++ b/src/object_schema.hpp
@@ -41,6 +41,11 @@ public:
                  std::initializer_list<Property> computed_properties);
     ~ObjectSchema();
 
+    ObjectSchema(ObjectSchema const&) = default;
+    ObjectSchema(ObjectSchema&&) noexcept = default;
+    ObjectSchema& operator=(ObjectSchema const&) = default;
+    ObjectSchema& operator=(ObjectSchema&&) noexcept = default;
+
     // create object schema from existing table
     // if no table key is provided it is looked up in the group
     ObjectSchema(Group const& group, StringData name, TableKey key);
@@ -51,26 +56,26 @@ public:
     std::string primary_key;
     TableKey table_key;
 
-    Property *property_for_public_name(StringData public_name);
-    const Property *property_for_public_name(StringData public_name) const;
-    Property *property_for_name(StringData name);
-    const Property *property_for_name(StringData name) const;
-    Property *primary_key_property() {
+    Property *property_for_public_name(StringData public_name) noexcept;
+    const Property *property_for_public_name(StringData public_name) const noexcept;
+    Property *property_for_name(StringData name) noexcept;
+    const Property *property_for_name(StringData name) const noexcept;
+    Property *primary_key_property() noexcept {
         return property_for_name(primary_key);
     }
-    const Property *primary_key_property() const {
+    const Property *primary_key_property() const noexcept {
         return property_for_name(primary_key);
     }
-    bool property_is_computed(Property const& property) const;
+    bool property_is_computed(Property const& property) const noexcept;
 
     void validate(Schema const& schema, std::vector<ObjectSchemaValidationException>& exceptions) const;
 
-    friend bool operator==(ObjectSchema const& a, ObjectSchema const& b);
+    friend bool operator==(ObjectSchema const& a, ObjectSchema const& b) noexcept;
 
     static PropertyType from_core_type(Table const& table, ColKey col);
 
 private:
-    void set_primary_key_property();
+    void set_primary_key_property() noexcept;
 };
 }
 

--- a/src/property.hpp
+++ b/src/property.hpp
@@ -90,20 +90,21 @@ struct Property {
 
     Property() = default;
 
-    Property(std::string name, PropertyType type, IsPrimary primary = false, IsIndexed indexed = false, std::string public_name = "");
+    Property(std::string name, PropertyType type, IsPrimary primary = false,
+             IsIndexed indexed = false, std::string public_name = "");
 
     Property(std::string name, PropertyType type, std::string object_type,
              std::string link_origin_property_name = "", std::string public_name = "");
 
     Property(Property const&) = default;
-    Property(Property&&) = default;
+    Property(Property&&) noexcept = default;
     Property& operator=(Property const&) = default;
-    Property& operator=(Property&&) = default;
+    Property& operator=(Property&&) noexcept = default;
 
     bool requires_index() const { return is_primary || is_indexed; }
 
-    bool type_is_indexable() const;
-    bool type_is_nullable() const;
+    bool type_is_indexable() const noexcept;
+    bool type_is_nullable() const noexcept;
 
     std::string type_string() const;
 };
@@ -235,7 +236,7 @@ inline Property::Property(std::string name, PropertyType type,
 {
 }
 
-inline bool Property::type_is_indexable() const
+inline bool Property::type_is_indexable() const noexcept
 {
     return type == PropertyType::Int
         || type == PropertyType::Bool
@@ -243,7 +244,7 @@ inline bool Property::type_is_indexable() const
         || type == PropertyType::String;
 }
 
-inline bool Property::type_is_nullable() const
+inline bool Property::type_is_nullable() const noexcept
 {
     return !(is_array(type) && type == PropertyType::Object) && type != PropertyType::LinkingObjects;
 }

--- a/src/results.cpp
+++ b/src/results.cpp
@@ -38,6 +38,7 @@ Results::Results(SharedRealm r, Query q, DescriptorOrdering o)
 , m_table(m_query.get_table())
 , m_descriptor_ordering(std::move(o))
 , m_mode(Mode::Query)
+, m_mutex(m_realm && m_realm->is_frozen())
 {
 }
 
@@ -45,6 +46,7 @@ Results::Results(SharedRealm r, ConstTableRef table)
 : m_realm(std::move(r))
 , m_table(table)
 , m_mode(Mode::Table)
+, m_mutex(m_realm && m_realm->is_frozen())
 {
 }
 
@@ -52,6 +54,7 @@ Results::Results(std::shared_ptr<Realm> r, std::shared_ptr<LstBase> list)
 : m_realm(std::move(r))
 , m_list(list)
 , m_mode(Mode::List)
+, m_mutex(m_realm && m_realm->is_frozen())
 {
 }
 
@@ -60,6 +63,7 @@ Results::Results(std::shared_ptr<Realm> r, std::shared_ptr<LstBase> list, Descri
 , m_descriptor_ordering(std::move(o))
 , m_list(std::move(list))
 , m_mode(Mode::List)
+, m_mutex(m_realm && m_realm->is_frozen())
 {
 }
 
@@ -68,6 +72,7 @@ Results::Results(std::shared_ptr<Realm> r, TableView tv, DescriptorOrdering o)
 , m_table_view(std::move(tv))
 , m_descriptor_ordering(std::move(o))
 , m_mode(Mode::TableView)
+, m_mutex(m_realm && m_realm->is_frozen())
 {
     m_table = m_table_view.get_parent();
 }
@@ -76,6 +81,7 @@ Results::Results(std::shared_ptr<Realm> r, std::shared_ptr<LnkLst> lv, util::Opt
 : m_realm(std::move(r))
 , m_link_list(std::move(lv))
 , m_mode(Mode::LinkList)
+, m_mutex(m_realm && m_realm->is_frozen())
 {
     m_table = m_link_list->get_target_table();
     if (q) {
@@ -89,6 +95,12 @@ Results::Results(const Results&) = default;
 Results& Results::operator=(const Results&) = default;
 Results::Results(Results&&) = default;
 Results& Results::operator=(Results&&) = default;
+
+Results::Mode Results::get_mode() const noexcept
+{
+    CheckedUniqueLock lock(m_mutex);
+    return m_mode;
+}
 
 bool Results::is_valid() const
 {
@@ -124,6 +136,12 @@ void Results::validate_write() const
 
 size_t Results::size()
 {
+    util::CheckedUniqueLock lock(m_mutex);
+    return do_size();
+}
+
+size_t Results::do_size()
+{
     validate_read();
     switch (m_mode) {
         case Mode::Empty:    return 0;
@@ -138,7 +156,7 @@ size_t Results::size()
                 return m_query.count(m_descriptor_ordering);
             REALM_FALLTHROUGH;
         case Mode::TableView:
-            evaluate_query_if_needed();
+            do_evaluate_query_if_needed();
             return m_table_view.size();
     }
     REALM_COMPILER_HINT_UNREACHABLE();
@@ -146,6 +164,7 @@ size_t Results::size()
 
 const ObjectSchema& Results::get_object_schema() const
 {
+    util::CheckedUniqueLock lock(m_mutex);
     validate_read();
 
     if (!m_object_schema) {
@@ -157,7 +176,6 @@ const ObjectSchema& Results::get_object_schema() const
 
     return *m_object_schema;
 }
-
 
 StringData Results::get_object_type() const noexcept
 {
@@ -282,7 +300,7 @@ util::Optional<Obj> Results::try_get(size_t row_ndx)
             REALM_FALLTHROUGH;
         case Mode::Query:
         case Mode::TableView:
-            evaluate_query_if_needed();
+            do_evaluate_query_if_needed();
             if (row_ndx >= m_table_view.size())
                 break;
             if (m_update_policy == UpdatePolicy::Never && !m_table_view.is_obj_valid(row_ndx))
@@ -295,24 +313,28 @@ util::Optional<Obj> Results::try_get(size_t row_ndx)
 template<typename T>
 T Results::get(size_t row_ndx)
 {
-    if (auto row = try_get<T>(row_ndx))
+    util::CheckedUniqueLock lock(m_mutex);
+    if (auto row = try_get<T>(row_ndx)) {
         return *row;
-    throw OutOfBoundsIndexException{row_ndx, size()};
+    }
+    throw OutOfBoundsIndexException{row_ndx, do_size()};
 }
 
 template<typename T>
 util::Optional<T> Results::first()
 {
+    util::CheckedUniqueLock lock(m_mutex);
     return try_get<T>(0);
 }
 
 template<typename T>
 util::Optional<T> Results::last()
 {
+    util::CheckedUniqueLock lock(m_mutex);
     validate_read();
     if (m_mode == Mode::Query)
-        evaluate_query_if_needed(); // avoid running the query twice (for size() and for get())
-    return try_get<T>(size() - 1);
+        do_evaluate_query_if_needed(); // avoid running the query twice (for size() and for get())
+    return try_get<T>(do_size() - 1);
 }
 
 bool Results::update_linklist()
@@ -320,15 +342,22 @@ bool Results::update_linklist()
     REALM_ASSERT(m_update_policy == UpdatePolicy::Auto);
 
     if (!m_descriptor_ordering.is_empty()) {
-        m_query = get_query();
+        m_query = do_get_query();
         m_mode = Mode::Query;
-        evaluate_query_if_needed();
+        do_evaluate_query_if_needed();
         return false;
     }
     return true;
 }
 
 void Results::evaluate_query_if_needed(bool wants_notifications)
+{
+    util::CheckedUniqueLock lock(m_mutex);
+    validate_read();
+    do_evaluate_query_if_needed(wants_notifications);
+}
+
+void Results::do_evaluate_query_if_needed(bool wants_notifications)
 {
     if (m_update_policy == UpdatePolicy::Never) {
         REALM_ASSERT(m_mode == Mode::TableView);
@@ -367,6 +396,7 @@ void Results::evaluate_query_if_needed(bool wants_notifications)
 template<>
 size_t Results::index_of(Obj const& row)
 {
+    util::CheckedUniqueLock lock(m_mutex);
     validate_read();
     if (!row.is_valid()) {
         throw DetatchedAccessorException{};
@@ -391,7 +421,7 @@ size_t Results::index_of(Obj const& row)
             REALM_FALLTHROUGH;
         case Mode::Query:
         case Mode::TableView:
-            evaluate_query_if_needed();
+            do_evaluate_query_if_needed();
             return m_table_view.find_by_source_ndx(row.get_key());
     }
     REALM_COMPILER_HINT_UNREACHABLE();
@@ -400,6 +430,7 @@ size_t Results::index_of(Obj const& row)
 template<typename T>
 size_t Results::index_of(T const& value)
 {
+    util::CheckedUniqueLock lock(m_mutex);
     validate_read();
     if (m_mode != Mode::List)
         return not_found; // Non-List results can only ever contain Objects
@@ -417,7 +448,9 @@ size_t Results::index_of(T const& value)
 size_t Results::index_of(Query&& q)
 {
     if (m_descriptor_ordering.will_apply_sort()) {
-        auto first = filter(std::move(q)).first();
+        Results filtered(filter(std::move(q)));
+        filtered.assert_unlocked();
+        auto first = filtered.first();
         return first ? index_of(*first) : not_found;
     }
 
@@ -438,12 +471,12 @@ DataType Results::prepare_for_aggregate(ColKey column, const char* name)
             type = m_list->get_table()->get_column_type(m_list->get_col_key());
             break;
         case Mode::LinkList:
-            m_query = this->get_query();
+            m_query = do_get_query();
             m_mode = Mode::Query;
             REALM_FALLTHROUGH;
         case Mode::Query:
         case Mode::TableView:
-            evaluate_query_if_needed();
+            do_evaluate_query_if_needed();
             type = m_table->get_column_type(column);
             break;
         default:
@@ -543,6 +576,7 @@ template<typename AggregateFunction>
 util::Optional<Mixed> Results::aggregate(ColKey column, const char* name,
                                          AggregateFunction&& func)
 {
+    util::CheckedUniqueLock lock(m_mutex);
     validate_read();
     if (!m_table && !m_list)
         return none;
@@ -592,13 +626,14 @@ util::Optional<double> Results::average(ColKey column)
 
 void Results::clear()
 {
+    util::CheckedUniqueLock lock(m_mutex);
     switch (m_mode) {
         case Mode::Empty:
             return;
         case Mode::Table:
             validate_write();
             if (m_realm->is_partial())
-                Results(m_realm, m_table->where()).clear();
+                m_table->where().find_all().clear();
             else
                 const_cast<Table&>(*m_table).clear();
             break;
@@ -607,7 +642,7 @@ void Results::clear()
             // clearing it is actually significantly faster
         case Mode::TableView:
             validate_write();
-            evaluate_query_if_needed();
+            do_evaluate_query_if_needed();
 
             switch (m_update_policy) {
                 case UpdatePolicy::Auto:
@@ -635,6 +670,12 @@ void Results::clear()
 
 PropertyType Results::get_type() const
 {
+    util::CheckedUniqueLock lock(m_mutex);
+    return do_get_type();
+}
+
+PropertyType Results::do_get_type() const
+{
     validate_read();
     switch (m_mode) {
         case Mode::Empty:
@@ -651,6 +692,12 @@ PropertyType Results::get_type() const
 }
 
 Query Results::get_query() const
+{
+    util::CheckedUniqueLock lock(m_mutex);
+    return do_get_query();
+}
+
+Query Results::do_get_query() const
 {
     validate_read();
     switch (m_mode) {
@@ -686,6 +733,7 @@ Query Results::get_query() const
 
 TableView Results::get_tableview()
 {
+    util::CheckedUniqueLock lock(m_mutex);
     validate_read();
     switch (m_mode) {
         case Mode::Empty:
@@ -697,7 +745,7 @@ TableView Results::get_tableview()
             REALM_FALLTHROUGH;
         case Mode::Query:
         case Mode::TableView:
-            evaluate_query_if_needed();
+            do_evaluate_query_if_needed();
             return m_table_view;
         case Mode::Table:
             return m_table->where().find_all();
@@ -751,14 +799,15 @@ Results Results::sort(std::vector<std::pair<std::string, bool>> const& keypaths)
 {
     if (keypaths.empty())
         return *this;
-    if (get_type() != PropertyType::Object) {
+    auto type = get_type();
+    if (type != PropertyType::Object) {
         if (keypaths.size() != 1)
             throw std::invalid_argument(util::format("Cannot sort array of '%1' on more than one key path",
-                                                     string_for_property_type(get_type() & ~PropertyType::Flags)));
+                                                     string_for_property_type(type & ~PropertyType::Flags)));
         if (keypaths[0].first != "self")
             throw std::invalid_argument(
                 util::format("Cannot sort on key path '%1': arrays of '%2' can only be sorted on 'self'",
-                             keypaths[0].first, string_for_property_type(get_type() & ~PropertyType::Flags)));
+                             keypaths[0].first, string_for_property_type(type & ~PropertyType::Flags)));
         return sort({{{}}, {keypaths[0].second}});
     }
 
@@ -777,13 +826,14 @@ Results Results::sort(std::vector<std::pair<std::string, bool>> const& keypaths)
 
 Results Results::sort(SortDescriptor&& sort) const
 {
+    util::CheckedUniqueLock lock(m_mutex);
     DescriptorOrdering new_order = m_descriptor_ordering;
     new_order.append_sort(std::move(sort));
     if (m_mode == Mode::LinkList)
         return Results(m_realm, m_link_list, util::none, std::move(sort));
     else if (m_mode == Mode::List)
         return Results(m_realm, m_list, std::move(new_order));
-    return Results(m_realm, get_query(), std::move(new_order));
+    return Results(m_realm, do_get_query(), std::move(new_order));
 }
 
 Results Results::filter(Query&& q) const
@@ -834,23 +884,25 @@ Results Results::distinct(DistinctDescriptor&& uniqueness) const
 {
     DescriptorOrdering new_order = m_descriptor_ordering;
     new_order.append_distinct(std::move(uniqueness));
+    util::CheckedUniqueLock lock(m_mutex);
     if (m_mode == Mode::List)
         return Results(m_realm, m_list, std::move(new_order));
-    return Results(m_realm, get_query(), std::move(new_order));
+    return Results(m_realm, do_get_query(), std::move(new_order));
 }
 
 Results Results::distinct(std::vector<std::string> const& keypaths) const
 {
     if (keypaths.empty())
         return *this;
-    if (get_type() != PropertyType::Object) {
+    auto type = get_type();
+    if (type != PropertyType::Object) {
         if (keypaths.size() != 1)
             throw std::invalid_argument(util::format("Cannot sort array of '%1' on more than one key path",
-                                                     string_for_property_type(get_type() & ~PropertyType::Flags)));
+                                                     string_for_property_type(type & ~PropertyType::Flags)));
         if (keypaths[0] != "self")
             throw std::invalid_argument(
                 util::format("Cannot sort on key path '%1': arrays of '%2' can only be sorted on 'self'", keypaths[0],
-                             string_for_property_type(get_type() & ~PropertyType::Flags)));
+                             string_for_property_type(type & ~PropertyType::Flags)));
         return distinct(DistinctDescriptor({{ColKey()}}));
     }
 
@@ -861,14 +913,17 @@ Results Results::distinct(std::vector<std::string> const& keypaths) const
     return distinct({std::move(column_keys)});
 }
 
-Results Results::snapshot() const &
+Results Results::snapshot() const&
 {
     validate_read();
-    return Results(*this).snapshot();
+    auto clone = *this;
+    clone.assert_unlocked();
+    return static_cast<Results&&>(clone).snapshot();
 }
 
 Results Results::snapshot() &&
 {
+    util::CheckedUniqueLock lock(m_mutex);
     validate_read();
     switch (m_mode) {
         case Mode::Empty:
@@ -876,14 +931,14 @@ Results Results::snapshot() &&
 
         case Mode::Table:
         case Mode::LinkList:
-            m_query = get_query();
+            m_query = do_get_query();
             m_mode = Mode::Query;
 
             REALM_FALLTHROUGH;
         case Mode::Query:
         case Mode::TableView:
         case Mode::List: // FIXME Correct?
-            evaluate_query_if_needed(false);
+            do_evaluate_query_if_needed(false);
             m_notifier.reset();
             m_update_policy = UpdatePolicy::Never;
             return std::move(*this);
@@ -891,8 +946,10 @@ Results Results::snapshot() &&
     REALM_COMPILER_HINT_UNREACHABLE();
 }
 
-void Results::prepare_async(ForCallback force)
+// This function cannot be called on frozen results and so does not require locking
+void Results::prepare_async(ForCallback force) NO_THREAD_SAFETY_ANALYSIS
 {
+    REALM_ASSERT(m_realm);
     if (m_notifier)
         return;
     if (!m_realm->verify_notifications_available(force))
@@ -903,6 +960,7 @@ void Results::prepare_async(ForCallback force)
         return;
     }
 
+    REALM_ASSERT(!force || !m_realm->is_frozen());
     if (!force) {
         // Don't do implicit background updates if we can't actually deliver them
         if (!m_realm->can_deliver_notifications())
@@ -923,8 +981,10 @@ NotificationToken Results::add_notification_callback(CollectionChangeCallback cb
     return {m_notifier, m_notifier->add_callback(std::move(cb))};
 }
 
-bool Results::is_in_table_order() const
+// This function cannot be called on frozen results and so does not require locking
+bool Results::is_in_table_order() const NO_THREAD_SAFETY_ANALYSIS
 {
+    REALM_ASSERT(!m_realm || !m_realm->is_frozen());
     switch (m_mode) {
         case Mode::Empty:
         case Mode::Table:
@@ -971,34 +1031,39 @@ REALM_RESULTS_TYPE(util::Optional<double>)
 
 Results Results::freeze(SharedRealm frozen_realm)
 {
+    util::CheckedUniqueLock lock(m_mutex);
+    if (m_mode == Mode::Empty)
+        return *this;
+    auto& transaction = frozen_realm->transaction();
+    REALM_ASSERT(transaction.get_version() == m_realm->read_transaction_version().version);
     switch (m_mode) {
-        case Mode::Empty:
-            return Results();
         case Mode::Table:
-            return Results(frozen_realm, frozen_realm->transaction().import_copy_of(m_table));
-        case Mode::List: {
-            return Results(frozen_realm, frozen_realm->transaction().import_copy_of(*m_list), m_descriptor_ordering);
-        }
+            return Results(std::move(frozen_realm), transaction.import_copy_of(m_table));
+        case Mode::List:
+            return Results(std::move(frozen_realm), transaction.import_copy_of(*m_list), m_descriptor_ordering);
         case Mode::LinkList: {
-            std::shared_ptr<LnkLst> frozen_ll(frozen_realm->transaction().import_copy_of(std::make_unique<LnkLst>(*m_link_list)).release());
+            std::shared_ptr<LnkLst> frozen_ll(transaction.import_copy_of(std::make_unique<LnkLst>(*m_link_list)).release());
 
             // If query/sort was provided for the original Results, mode would have changed to Query, so no need
             // include them here.
-            return Results(frozen_realm, frozen_ll);
+            return Results(std::move(frozen_realm), std::move(frozen_ll));
         }
         case Mode::Query:
-            return Results(frozen_realm, *frozen_realm->transaction().import_copy_of(m_query, PayloadPolicy::Copy), m_descriptor_ordering);
-        case Mode::TableView:
-            auto results = Results(frozen_realm, *frozen_realm->transaction().import_copy_of(m_table_view, PayloadPolicy::Copy), m_descriptor_ordering);
-            results.m_table_view.sync_if_needed();
+            return Results(std::move(frozen_realm), *transaction.import_copy_of(m_query, PayloadPolicy::Copy), m_descriptor_ordering);
+        case Mode::TableView: {
+            Results results(std::move(frozen_realm), *transaction.import_copy_of(m_table_view, PayloadPolicy::Copy), m_descriptor_ordering);
+            results.assert_unlocked();
+            results.evaluate_query_if_needed(false);
             return results;
+        }
+        default:
+            REALM_COMPILER_HINT_UNREACHABLE();
     }
-    REALM_COMPILER_HINT_UNREACHABLE();
 }
 
 bool Results::is_frozen()
 {
-    return (m_realm) ? m_realm->is_frozen() : true;
+    return !m_realm || m_realm->is_frozen();
 }
 
 Results::OutOfBoundsIndexException::OutOfBoundsIndexException(size_t r, size_t c)

--- a/src/results.cpp
+++ b/src/results.cpp
@@ -164,17 +164,17 @@ size_t Results::do_size()
 
 const ObjectSchema& Results::get_object_schema() const
 {
-    util::CheckedUniqueLock lock(m_mutex);
     validate_read();
 
-    if (!m_object_schema) {
+    auto object_schema = m_object_schema.load();
+    if (!object_schema) {
         REALM_ASSERT(m_realm);
         auto it = m_realm->schema().find(get_object_type());
         REALM_ASSERT(it != m_realm->schema().end());
-        m_object_schema = &*it;
+        m_object_schema = object_schema = &*it;
     }
 
-    return *m_object_schema;
+    return *object_schema;
 }
 
 StringData Results::get_object_type() const noexcept

--- a/src/results.hpp
+++ b/src/results.hpp
@@ -27,6 +27,7 @@
 #include "property.hpp"
 #include "shared_realm.hpp"
 #include "util/checked_mutex.hpp"
+#include "util/copyable_atomic.hpp"
 
 #include <realm/table_view.hpp>
 #include <realm/util/optional.hpp>
@@ -263,7 +264,7 @@ public:
 
 private:
     std::shared_ptr<Realm> m_realm;
-    mutable const ObjectSchema *m_object_schema GUARDED_BY(m_mutex) = nullptr;
+    mutable util::CopyableAtomic<const ObjectSchema*> m_object_schema = nullptr;
     Query m_query GUARDED_BY(m_mutex);
     TableView m_table_view GUARDED_BY(m_mutex);
     ConstTableRef m_table;
@@ -380,7 +381,7 @@ void Results::set_property_value(ContextType& ctx, StringData prop_name, ValueTy
         throw InvalidPropertyException(object_schema.name, prop_name);
     }
     if (prop->is_primary && !m_realm->is_in_migration()) {
-        throw ModifyPrimaryKeyException(m_object_schema->name, prop->name);
+        throw ModifyPrimaryKeyException(object_schema.name, prop->name);
     }
 
     // Update all objects in this ResultSets. Use snapshot to avoid correctness problems if the

--- a/src/results.hpp
+++ b/src/results.hpp
@@ -26,6 +26,7 @@
 #include "object_schema.hpp"
 #include "property.hpp"
 #include "shared_realm.hpp"
+#include "util/checked_mutex.hpp"
 
 #include <realm/table_view.hpp>
 #include <realm/util/optional.hpp>
@@ -62,11 +63,11 @@ public:
     std::shared_ptr<Realm> get_realm() const { return m_realm; }
 
     // Object schema describing the vendored object type
-    const ObjectSchema &get_object_schema() const;
+    const ObjectSchema &get_object_schema() const REQUIRES(!m_mutex);
 
     // Get a query which will match the same rows as is contained in this Results
     // Returned query will not be valid if the current mode is Empty
-    Query get_query() const;
+    Query get_query() const REQUIRES(!m_mutex);
 
     // Get the Lst this Results is derived from, if any
     const LstBase* get_list() const { return m_list.get(); }
@@ -75,87 +76,87 @@ public:
     DescriptorOrdering const& get_descriptor_ordering() const noexcept { return m_descriptor_ordering; }
 
     // Get a tableview containing the same rows as this Results
-    TableView get_tableview();
+    TableView get_tableview() REQUIRES(!m_mutex);
 
     // Get the object type which will be returned by get()
     StringData get_object_type() const noexcept;
 
-    PropertyType get_type() const;
+    PropertyType get_type() const REQUIRES(!m_mutex);
 
     // Get the size of this results
     // Can be either O(1) or O(N) depending on the state of things
-    size_t size();
+    size_t size() REQUIRES(!m_mutex);
 
     // Get the row accessor for the given index
     // Throws OutOfBoundsIndexException if index >= size()
     template<typename T = Obj>
-    T get(size_t index);
+    T get(size_t index) REQUIRES(!m_mutex);
 
     // Get the boxed row accessor for the given index
     // Throws OutOfBoundsIndexException if index >= size()
     template<typename Context>
-    auto get(Context&, size_t index);
+    auto get(Context&, size_t index) REQUIRES(!m_mutex);
 
     // Get a row accessor for the first/last row, or none if the results are empty
     // More efficient than calling size()+get()
     template<typename T = Obj>
-    util::Optional<T> first();
+    util::Optional<T> first() REQUIRES(!m_mutex);
     template<typename T = Obj>
-    util::Optional<T> last();
+    util::Optional<T> last() REQUIRES(!m_mutex);
 
     // Get the index of the first row matching the query in this table
-    size_t index_of(Query&& q);
+    size_t index_of(Query&& q) REQUIRES(!m_mutex);
 
     // Get the first index of the given value in this results, or not_found
     // Throws DetachedAccessorException if row is not attached
     // Throws IncorrectTableException if row belongs to a different table
     template<typename T>
-    size_t index_of(T const& value);
+    size_t index_of(T const& value) REQUIRES(!m_mutex);
 
     // Delete all of the rows in this Results from the Realm
     // size() will always be zero afterwards
     // Throws InvalidTransactionException if not in a write transaction
-    void clear();
+    void clear() REQUIRES(!m_mutex);
 
     // Create a new Results by further filtering or sorting this Results
-    Results filter(Query&& q) const;
-    Results sort(SortDescriptor&& sort) const;
-    Results sort(std::vector<std::pair<std::string, bool>> const& keypaths) const;
+    Results filter(Query&& q) const REQUIRES(!m_mutex);
+    Results sort(SortDescriptor&& sort) const REQUIRES(!m_mutex);
+    Results sort(std::vector<std::pair<std::string, bool>> const& keypaths) const REQUIRES(!m_mutex);
 
     // Create a new Results by removing duplicates
-    Results distinct(DistinctDescriptor&& uniqueness) const;
-    Results distinct(std::vector<std::string> const& keypaths) const;
+    Results distinct(DistinctDescriptor&& uniqueness) const REQUIRES(!m_mutex);
+    Results distinct(std::vector<std::string> const& keypaths) const REQUIRES(!m_mutex);
 
     // Create a new Results with only the first `max_count` entries
-    Results limit(size_t max_count) const;
+    Results limit(size_t max_count) const REQUIRES(!m_mutex);
 
     // Create a new Results by adding sort and distinct combinations
-    Results apply_ordering(DescriptorOrdering&& ordering);
+    Results apply_ordering(DescriptorOrdering&& ordering) REQUIRES(!m_mutex);
 
     // Return a snapshot of this Results that never updates to reflect changes in the underlying data.
-    Results snapshot() const &;
-    Results snapshot() &&;
+    Results snapshot() const& REQUIRES(!m_mutex);
+    Results snapshot() && REQUIRES(!m_mutex);
 
     // Returns a frozen copy of this result
-    Results freeze(SharedRealm realm);
+    Results freeze(SharedRealm realm) REQUIRES(!m_mutex);
 
     // Returns whether or not this Results is frozen.
-    bool is_frozen();
+    bool is_frozen() REQUIRES(!m_mutex);
 
     // Get the min/max/average/sum of the given column
     // All but sum() returns none when there are zero matching rows
     // sum() returns 0, except for when it returns none
     // Throws UnsupportedColumnTypeException for sum/average on timestamp or non-numeric column
     // Throws OutOfBoundsIndexException for an out-of-bounds column
-    util::Optional<Mixed> max(ColKey column={});
-    util::Optional<Mixed> min(ColKey column={});
-    util::Optional<double> average(ColKey column={});
-    util::Optional<Mixed> sum(ColKey column={});
+    util::Optional<Mixed> max(ColKey column={}) REQUIRES(!m_mutex);
+    util::Optional<Mixed> min(ColKey column={}) REQUIRES(!m_mutex);
+    util::Optional<double> average(ColKey column={}) REQUIRES(!m_mutex);
+    util::Optional<Mixed> sum(ColKey column={}) REQUIRES(!m_mutex);
 
-    util::Optional<Mixed> max(StringData column_name) { return max(key(column_name)); }
-    util::Optional<Mixed> min(StringData column_name) { return min(key(column_name)); }
-    util::Optional<double> average(StringData column_name) { return average(key(column_name)); }
-    util::Optional<Mixed> sum(StringData column_name) { return sum(key(column_name)); }
+    util::Optional<Mixed> max(StringData column_name) REQUIRES(!m_mutex) { return max(key(column_name)); }
+    util::Optional<Mixed> min(StringData column_name) REQUIRES(!m_mutex) { return min(key(column_name)); }
+    util::Optional<double> average(StringData column_name) REQUIRES(!m_mutex) { return average(key(column_name)); }
+    util::Optional<Mixed> sum(StringData column_name) REQUIRES(!m_mutex) { return sum(key(column_name)); }
 
     enum class Mode {
         Empty, // Backed by nothing (for missing tables)
@@ -167,7 +168,7 @@ public:
     };
     // Get the currrent mode of the Results
     // Ideally this would not be public but it's needed for some KVO stuff
-    Mode get_mode() const { return m_mode; }
+    Mode get_mode() const noexcept REQUIRES(!m_mutex);
 
     // Is this Results associated with a Realm that has not been invalidated?
     bool is_valid() const;
@@ -235,22 +236,22 @@ public:
         static void set_table_view(Results& results, TableView&& tv);
     };
 
-    template<typename Context> auto first(Context&);
-    template<typename Context> auto last(Context&);
+    template<typename Context> auto first(Context&) REQUIRES(!m_mutex);
+    template<typename Context> auto last(Context&) REQUIRES(!m_mutex);
 
     template<typename Context, typename T>
-    size_t index_of(Context&, T value);
+    size_t index_of(Context&, T value) REQUIRES(!m_mutex);
 
     // Batch updates all items in this collection with the provided value
     // Must be called inside a transaction
     // Throws an exception if the value does not match the type for given prop_name
     template<typename ValueType, typename ContextType>
-    void set_property_value(ContextType& ctx, StringData prop_name, ValueType value);
+    void set_property_value(ContextType& ctx, StringData prop_name, ValueType value) REQUIRES(!m_mutex);
 
     // Execute the query immediately if needed. When the relevant query is slow, size()
     // may cost similar time compared with creating the tableview. Use this function to
     // avoid running the query twice for size() and other accessors.
-    void evaluate_query_if_needed(bool wants_notifications = true);
+    void evaluate_query_if_needed(bool wants_notifications = true) REQUIRES(!m_mutex);
 
     enum class UpdatePolicy {
         Auto,      // Update automatically to reflect changes in the underlying data.
@@ -262,24 +263,28 @@ public:
 
 private:
     std::shared_ptr<Realm> m_realm;
-    mutable const ObjectSchema *m_object_schema = nullptr;
-    Query m_query;
-    TableView m_table_view;
+    mutable const ObjectSchema *m_object_schema GUARDED_BY(m_mutex) = nullptr;
+    Query m_query GUARDED_BY(m_mutex);
+    TableView m_table_view GUARDED_BY(m_mutex);
     ConstTableRef m_table;
     DescriptorOrdering m_descriptor_ordering;
     std::shared_ptr<LnkLst> m_link_list;
     std::shared_ptr<LstBase> m_list;
-    util::Optional<std::vector<size_t>> m_list_indices;
+    util::Optional<std::vector<size_t>> m_list_indices GUARDED_BY(m_mutex);
 
     _impl::CollectionNotifier::Handle<_impl::ResultsNotifier> m_notifier;
 
-    Mode m_mode = Mode::Empty;
+    Mode m_mode GUARDED_BY(m_mutex) = Mode::Empty;
     UpdatePolicy m_update_policy = UpdatePolicy::Auto;
 
-    bool update_linklist();
+    bool update_linklist() REQUIRES(m_mutex);
 
     void validate_read() const;
     void validate_write() const;
+
+    size_t do_size() REQUIRES(m_mutex);
+    Query do_get_query() const REQUIRES(m_mutex);
+    PropertyType do_get_type() const REQUIRES(m_mutex);
 
     using ForCallback = util::TaggedBool<class ForCallback>;
     void prepare_async(ForCallback);
@@ -287,20 +292,21 @@ private:
     ColKey key(StringData) const;
 
     template<typename T>
-    util::Optional<T> try_get(size_t);
+    util::Optional<T> try_get(size_t) REQUIRES(m_mutex);
 
     template<typename AggregateFunction>
     util::Optional<Mixed> aggregate(ColKey column, const char* name,
-                                    AggregateFunction&& func);
-    DataType prepare_for_aggregate(ColKey column, const char* name);
+                                    AggregateFunction&& func) REQUIRES(!m_mutex);
+    DataType prepare_for_aggregate(ColKey column, const char* name) REQUIRES(m_mutex);
 
     template<typename Fn>
-    auto dispatch(Fn&&) const;
+    auto dispatch(Fn&&) const REQUIRES(!m_mutex);
 
     template<typename T>
     auto& list_as() const;
 
-    void evaluate_sort_and_distinct_on_list();
+    void evaluate_sort_and_distinct_on_list() REQUIRES(m_mutex);
+    void do_evaluate_query_if_needed(bool wants_notifications = true) REQUIRES(m_mutex);
 
     class IteratorWrapper {
     public:
@@ -314,6 +320,14 @@ private:
     private:
         std::unique_ptr<Table::ConstIterator> m_it;
     } m_table_iterator;
+
+    util::CheckedOptionalMutex m_mutex;
+
+    // A work around for what appears to be a false positive in clang's thread
+    // analysis when constructing a different object of the same type within a
+    // member function. Putting the ACQUIRE on the constructor seems like it
+    // should work, but doesn't.
+    void assert_unlocked() ACQUIRE(!m_mutex) {}
 };
 
 template<typename Fn>
@@ -356,7 +370,7 @@ size_t Results::index_of(Context& ctx, T value)
 }
 
 template <typename ValueType, typename ContextType>
-void Results::set_property_value(ContextType& ctx, StringData prop_name, ValueType value)
+void Results::set_property_value(ContextType& ctx, StringData prop_name, ValueType value) NO_THREAD_SAFETY_ANALYSIS
 {
     // Check invariants for calling this method
     validate_write();

--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -28,29 +28,30 @@
 using namespace realm;
 
 namespace realm {
-bool operator==(Schema const& a, Schema const& b)
+bool operator==(Schema const& a, Schema const& b) noexcept
 {
     return static_cast<Schema::base const&>(a) == static_cast<Schema::base const&>(b);
 }
 }
 
-Schema::Schema() = default;
+Schema::Schema() noexcept = default;
 Schema::~Schema() = default;
 Schema::Schema(Schema const&) = default;
-Schema::Schema(Schema &&) = default;
+Schema::Schema(Schema &&) noexcept = default;
 Schema& Schema::operator=(Schema const&) = default;
-Schema& Schema::operator=(Schema&&) = default;
+Schema& Schema::operator=(Schema&&) noexcept = default;
 
 Schema::Schema(std::initializer_list<ObjectSchema> types) : Schema(base(types)) { }
 
-Schema::Schema(base types) : base(std::move(types))
+Schema::Schema(base types) noexcept
+: base(std::move(types))
 {
     std::sort(begin(), end(), [](ObjectSchema const& lft, ObjectSchema const& rgt) {
         return lft.name < rgt.name;
     });
 }
 
-Schema::iterator Schema::find(StringData name)
+Schema::iterator Schema::find(StringData name) noexcept
 {
     auto it = std::lower_bound(begin(), end(), name, [](ObjectSchema const& lft, StringData rgt) {
         return lft.name < rgt;
@@ -61,7 +62,7 @@ Schema::iterator Schema::find(StringData name)
     return it;
 }
 
-Schema::const_iterator Schema::find(StringData name) const
+Schema::const_iterator Schema::find(StringData name) const noexcept
 {
     return const_cast<Schema *>(this)->find(name);
 }
@@ -150,7 +151,7 @@ static void compare(ObjectSchema const& existing_schema,
 }
 
 template<typename T, typename U, typename Func>
-void Schema::zip_matching(T&& a, U&& b, Func&& func)
+void Schema::zip_matching(T&& a, U&& b, Func&& func) noexcept
 {
     size_t i = 0, j = 0;
     while (i < a.size() && j < b.size()) {
@@ -205,7 +206,7 @@ std::vector<SchemaChange> Schema::compare(Schema const& target_schema, bool incl
     return changes;
 }
 
-void Schema::copy_keys_from(realm::Schema const& other)
+void Schema::copy_keys_from(realm::Schema const& other) noexcept
 {
     zip_matching(*this, other, [&](ObjectSchema* existing, const ObjectSchema* other) {
         if (!existing || !other)
@@ -222,7 +223,7 @@ void Schema::copy_keys_from(realm::Schema const& other)
 }
 
 namespace realm {
-bool operator==(SchemaChange const& lft, SchemaChange const& rgt)
+bool operator==(SchemaChange const& lft, SchemaChange const& rgt) noexcept
 {
     if (lft.m_kind != rgt.m_kind)
         return false;

--- a/src/schema.hpp
+++ b/src/schema.hpp
@@ -34,20 +34,20 @@ class Schema : private std::vector<ObjectSchema> {
 private:
     using base = std::vector<ObjectSchema>;
 public:
-    Schema();
+    Schema() noexcept;
     ~Schema();
     // Create a schema from a vector of ObjectSchema
-    Schema(base types);
+    Schema(base types) noexcept;
     Schema(std::initializer_list<ObjectSchema> types);
 
     Schema(Schema const&);
-    Schema(Schema &&);
+    Schema(Schema&&) noexcept;
     Schema& operator=(Schema const&);
-    Schema& operator=(Schema&&);
+    Schema& operator=(Schema&&) noexcept;
 
     // find an ObjectSchema by name
-    iterator find(StringData name);
-    const_iterator find(StringData name) const;
+    iterator find(StringData name) noexcept;
+    const_iterator find(StringData name) const noexcept;
 
     // find an ObjectSchema with the same name as the passed in one
     iterator find(ObjectSchema const& object) noexcept;
@@ -60,10 +60,10 @@ public:
     // Get the changes which must be applied to this schema to produce the passed-in schema
     std::vector<SchemaChange> compare(Schema const&, bool include_removals=false) const;
 
-    void copy_keys_from(Schema const&);
+    void copy_keys_from(Schema const&) noexcept;
 
-    friend bool operator==(Schema const&, Schema const&);
-    friend bool operator!=(Schema const& a, Schema const& b) { return !(a == b); }
+    friend bool operator==(Schema const&, Schema const&) noexcept;
+    friend bool operator!=(Schema const& a, Schema const& b) noexcept { return !(a == b); }
 
     using base::iterator;
     using base::const_iterator;
@@ -74,7 +74,7 @@ public:
 
 private:
     template<typename T, typename U, typename Func>
-    static void zip_matching(T&& a, U&& b, Func&& func);
+    static void zip_matching(T&& a, U&& b, Func&& func) noexcept;
 };
 
 namespace schema_change {
@@ -162,7 +162,7 @@ public:
         REALM_COMPILER_HINT_UNREACHABLE();
     }
 
-    friend bool operator==(SchemaChange const& lft, SchemaChange const& rgt);
+    friend bool operator==(SchemaChange const& lft, SchemaChange const& rgt) noexcept;
 private:
     enum class Kind {
 #define REALM_SCHEMA_CHANGE_TYPE(name) name,

--- a/src/util/checked_mutex.hpp
+++ b/src/util/checked_mutex.hpp
@@ -1,0 +1,176 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or utilied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_OS_CHECKED_MUTEX_HPP
+#define REALM_OS_CHECKED_MUTEX_HPP
+
+#include <mutex>
+
+// Clang's thread safety analysis can be used to statically check that variables
+// which should be guarded by a mutex actually are only accessed with that
+// mutex acquired. This requires annotating variables and functions with which
+// "capabilities" (i.e. a generalization of the concept of a mutex) are required.
+//
+// libc++ has an option to apply this for *all* uses of <mutex> by defining
+// _LIBCPP_ENABLE_THREAD_SAFETY_ANNOTATIONS, but this doesn't make it easy to
+// incrementally adopt the annotations (and it's not obvious that it's even
+// worth trying to universally adopt them), so instead we have some wrappers
+// for std::mutex and locks which add annotations.
+
+// See https://clang.llvm.org/docs/ThreadSafetyAnalysis.html for more information on this
+
+#if defined(__clang__)
+    #define REALM_THREAD_ANNOTATION_ATTRIBUTE__(x) __attribute__((x))
+#else
+    #define REALM_THREAD_ANNOTATION_ATTRIBUTE__(x)
+#endif
+
+#define CAPABILITY(x) \
+    REALM_THREAD_ANNOTATION_ATTRIBUTE__(capability(x))
+
+#define SCOPED_CAPABILITY \
+    REALM_THREAD_ANNOTATION_ATTRIBUTE__(scoped_lockable)
+
+#define GUARDED_BY(x) \
+    REALM_THREAD_ANNOTATION_ATTRIBUTE__(guarded_by(x))
+
+#define REQUIRES(...) \
+    REALM_THREAD_ANNOTATION_ATTRIBUTE__(requires_capability(__VA_ARGS__))
+
+#define ACQUIRE(...) \
+    REALM_THREAD_ANNOTATION_ATTRIBUTE__(acquire_capability(__VA_ARGS__))
+
+#define RELEASE(...) \
+    REALM_THREAD_ANNOTATION_ATTRIBUTE__(release_capability(__VA_ARGS__))
+
+#define EXCLUDES(...) \
+    REALM_THREAD_ANNOTATION_ATTRIBUTE__(locks_excluded(__VA_ARGS__))
+
+#define NO_THREAD_SAFETY_ANALYSIS \
+    REALM_THREAD_ANNOTATION_ATTRIBUTE__(no_thread_safety_analysis)
+
+namespace realm {
+namespace util {
+
+// std::unique_lock with thread safety annotations
+class SCOPED_CAPABILITY CheckedUniqueLock {
+    using Impl = std::unique_lock<std::mutex>;
+public:
+    template<typename Mutex>
+    CheckedUniqueLock(Mutex const& m) ACQUIRE(m) : m_impl(m.lock()) { }
+    ~CheckedUniqueLock() RELEASE() { }
+
+    CheckedUniqueLock(CheckedUniqueLock&&) = default;
+    CheckedUniqueLock& operator=(CheckedUniqueLock&&) = default;
+
+    void lock() ACQUIRE() { m_impl.lock(); }
+    void unlock() RELEASE() { m_impl.unlock(); }
+    void lock_unchecked() { m_impl.lock(); }
+    void unlock_unchecked() { m_impl.unlock(); }
+    bool owns_lock() const noexcept { return m_impl.owns_lock(); }
+
+    Impl& native_handle() { return m_impl; }
+
+private:
+    Impl m_impl;
+};
+
+// std::lock_guard with thread safety annotations
+class SCOPED_CAPABILITY CheckedLockGuard {
+    using Impl = std::unique_lock<std::mutex>;
+public:
+    template<typename Mutex>
+    CheckedLockGuard(Mutex const& m) ACQUIRE(m) : m_impl(m.lock()) { }
+    ~CheckedLockGuard() RELEASE() { }
+
+    CheckedLockGuard(CheckedLockGuard&&) = delete;
+    CheckedLockGuard& operator=(CheckedLockGuard&&) = delete;
+
+private:
+    Impl m_impl;
+};
+
+// std::mutex with thread safety annotations
+class CAPABILITY("mutex") CheckedMutex {
+public:
+    CheckedMutex() = default;
+
+    // Required for REQUIRE(!m); do not actually call
+    CheckedMutex const& operator!() const { return *this; }
+private:
+    mutable std::mutex m_mutex;
+    friend class CheckedUniqueLock;
+    friend class CheckedLockGuard;
+
+    std::unique_lock<std::mutex> lock() const
+    {
+        return std::unique_lock<std::mutex>(m_mutex);
+    }
+};
+
+// An "optional" mutex. If constructed with enable=true, it works like a normal
+// std::mutex. If constructed with enable=false, locking and unlocking it is
+// a no-op.
+class CAPABILITY("mutex") CheckedOptionalMutex {
+public:
+    CheckedOptionalMutex(bool enable=false);
+    CheckedOptionalMutex(CheckedOptionalMutex const&);
+    CheckedOptionalMutex& operator=(CheckedOptionalMutex const&);
+    CheckedOptionalMutex(CheckedOptionalMutex&&) = default;
+    CheckedOptionalMutex& operator=(CheckedOptionalMutex&&) = default;
+
+    // Required for REQUIRE(!m); do not actually call
+    CheckedOptionalMutex const& operator!() const { return *this; }
+private:
+    mutable std::unique_ptr<std::mutex> m_mutex;
+    friend class CheckedUniqueLock;
+    friend class CheckedLockGuard;
+
+    std::unique_lock<std::mutex> lock() const;
+};
+
+inline CheckedOptionalMutex::CheckedOptionalMutex(bool enable)
+: m_mutex(enable ? std::make_unique<std::mutex>() : nullptr)
+{
+}
+
+inline CheckedOptionalMutex::CheckedOptionalMutex(CheckedOptionalMutex const& o)
+: CheckedOptionalMutex(!!o.m_mutex)
+{
+}
+
+inline CheckedOptionalMutex& CheckedOptionalMutex::operator=(CheckedOptionalMutex const& o)
+{
+    if (&o != this) {
+        if (o.m_mutex)
+            m_mutex = std::make_unique<std::mutex>();
+        else
+            m_mutex.reset();
+    }
+    return *this;
+}
+
+inline std::unique_lock<std::mutex> CheckedOptionalMutex::lock() const
+{
+    return m_mutex ? std::unique_lock<std::mutex>(*m_mutex) : std::unique_lock<std::mutex>();
+}
+
+} // namespace util
+} // namespace realm
+
+#endif // REALM_OS_CHECKED_MUTEX_HPP

--- a/src/util/copyable_atomic.hpp
+++ b/src/util/copyable_atomic.hpp
@@ -1,0 +1,50 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or utilied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#ifndef REALM_OS_COPYABLE_ATOMIC_HPP
+#define REALM_OS_COPYABLE_ATOMIC_HPP
+
+namespace realm {
+namespace util {
+
+// std::atomic is not copyable because the resulting semantics are not useful
+// for many of the things atomics can be used for (in particular, anything
+// involving a memory order than `relaxed` is probably broken). In addition,
+// the copying itself cannot be thread-safe. These limitations make this type
+// suitable for storing Results/List's object schema pointer, but not most things.
+template<typename T>
+struct CopyableAtomic : std::atomic<T> {
+    using std::atomic<T>::atomic;
+
+    CopyableAtomic(CopyableAtomic const& a) noexcept : std::atomic<T>(a.load()) { }
+    CopyableAtomic(CopyableAtomic&& a) noexcept : std::atomic<T>(a.load()) { }
+    CopyableAtomic& operator=(CopyableAtomic const& a) noexcept
+    {
+        this->store(a.load());
+        return *this;
+    }
+    CopyableAtomic& operator=(CopyableAtomic&& a) noexcept
+    {
+        this->store(a.load());
+        return *this;
+    }
+};
+
+}
+}
+#endif // REALM_OS_COPYABLE_ATOMIC_HPP

--- a/src/util/tagged_bool.hpp
+++ b/src/util/tagged_bool.hpp
@@ -36,20 +36,20 @@ namespace util {
 template <typename Tag>
 struct TaggedBool {
     // Allow explicit construction from anything convertible to bool
-    constexpr explicit TaggedBool(bool v) : m_value(v) { }
+    constexpr explicit TaggedBool(bool v) noexcept : m_value(v) { }
 
     // Allow implicit construction from *just* bool and not things convertible
     // to bool (such as other types of tagged bools)
     template <typename Bool, typename = typename std::enable_if<std::is_same<Bool, bool>::value>::type>
-    constexpr TaggedBool(Bool v) : m_value(v) {}
+    constexpr TaggedBool(Bool v) noexcept : m_value(v) {}
 
-    constexpr TaggedBool(TaggedBool const& v) : m_value(v.m_value) {}
+    constexpr TaggedBool(TaggedBool const& v) noexcept : m_value(v.m_value) {}
 
-    constexpr operator bool() const { return m_value; }
-    constexpr TaggedBool operator!() const { return TaggedBool{!m_value}; }
+    constexpr operator bool() const noexcept { return m_value; }
+    constexpr TaggedBool operator!() const noexcept { return TaggedBool{!m_value}; }
 
-    friend constexpr bool operator==(TaggedBool l, TaggedBool r) { return l.m_value == r.m_value; }
-    friend constexpr bool operator!=(TaggedBool l, TaggedBool r) { return l.m_value != r.m_value; }
+    friend constexpr bool operator==(TaggedBool l, TaggedBool r) noexcept { return l.m_value == r.m_value; }
+    friend constexpr bool operator!=(TaggedBool l, TaggedBool r) noexcept { return l.m_value != r.m_value; }
 
 private:
     bool m_value;

--- a/tests/util/test_file.cpp
+++ b/tests/util/test_file.cpp
@@ -156,6 +156,7 @@ SyncServer::SyncServer(StartImmediately start_immediately, std::string local_dir
     config.history_ttl = 1s;
     config.history_compaction_interval = 1s;
     config.state_realm_dir = util::make_temp_dir();
+    config.listen_address = "127.0.0.1";
 
     return config;
 })())
@@ -166,20 +167,8 @@ SyncServer::SyncServer(StartImmediately start_immediately, std::string local_dir
     SyncManager::shared().set_log_level(util::Logger::Level::off);
 #endif
 
-    uint64_t port;
-    while (true) {
-        // Try to pick a random available port, or loop forever if other
-        // problems occur because there's no specific error for "port in use"
-        try {
-            port = fastrand(65536 - 1000) + 1000;
-            m_server.start("127.0.0.1", util::to_string(port));
-            break;
-        }
-        catch (std::runtime_error const&) {
-            continue;
-        }
-    }
-    m_url = util::format("realm://127.0.0.1:%1", port);
+    m_server.start();
+    m_url = util::format("realm://127.0.0.1:%1", m_server.listen_endpoint().port());
     if (start_immediately)
         start();
 }


### PR DESCRIPTION
Results being lazily evaluated makes reading from it from multiple threads without any locking unsafe even when it's backed by a frozen Realm. To fix this we need to introduce some locking around the members which can be mutated on read. Benchmarking indicated a measurable slowdown from always doing the locking (~10% time increase for iterating over query results from obj-c), so it uses an "optional" mutex which is a no-op for non-frozen realms and only actually locks when the realm is frozen.

The complicated control flow inside Results made figuring out where exactly locks were needed (and needed to not be present to avoid deadlocks), so I introduced the use of clang's [Thread Safety Analysis annotations](https://clang.llvm.org/docs/ThreadSafetyAnalysis.html) which perform static checks at compile time to verify that mutexes are held or not held at the appropriate times. Applying these to RealmCoordinator and CollectionNotifier also revealed a few missing locks in RealmCoordinator.

List and Results also have a lazily populated pointer to the associated object schema, which merely needs to be atomic.

As part of auditing each of the types applicable to frozen Realms for things which might be thread-unsafe I also went ahead and marked a bunch of things as const and/or noexcept to cut down on the number of things which could be unsafe.