### PR TITLE
Update catch2 to v2.11.1

### DIFF
--- a/tests/benchmarks/main.cpp
+++ b/tests/benchmarks/main.cpp
@@ -18,9 +18,6 @@
 
 #define CATCH_CONFIG_ENABLE_BENCHMARKING
 
-// FIXME: the nextafter define below can be removed once we upgrade to an
-// Android ndk version which has support for std::nextafter (absent in ndk r10e)
-#define CATCH_CONFIG_GLOBAL_NEXTAFTER
 #define CATCH_CONFIG_RUNNER
 #include "catch2/catch.hpp"
 

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -16,9 +16,6 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-// FIXME: the nextafter define below can be removed once we upgrade to an
-// Android ndk version which has support for std::nextafter (absent in ndk r10e)
-#define CATCH_CONFIG_GLOBAL_NEXTAFTER
 #define CATCH_CONFIG_RUNNER
 #include "catch2/catch.hpp"
 


### PR DESCRIPTION
Catch2 is updated from v2.10.0 to v2.11.1. General fixes and improvements; the release notes are here: https://github.com/catchorg/Catch2/releases