### PR TITLE
Restore support for notifications on sorted primitive lists

### DIFF
--- a/src/impl/collection_change_builder.hpp
+++ b/src/impl/collection_change_builder.hpp
@@ -46,8 +46,11 @@ public:
     // it into new_rows, and check all matching rows for modifications
     static CollectionChangeBuilder calculate(std::vector<int64_t> const& old_rows,
                                              std::vector<int64_t> const& new_rows,
-                                             std::function<bool (decltype(ObjKey::value))> row_did_change,
-                                             bool in_table_order=false);
+                                             std::function<bool (int64_t)> key_did_change,
+                                             bool in_table_order);
+    static CollectionChangeBuilder calculate(std::vector<size_t> const& old_rows,
+                                             std::vector<size_t> const& new_rows,
+                                             std::function<bool (int64_t)> key_did_change);
 
     // generic operations {
     CollectionChangeSet finalize() &&;

--- a/src/impl/collection_notifier.hpp
+++ b/src/impl/collection_notifier.hpp
@@ -277,7 +277,8 @@ public:
         return *this;
     }
 
-    Handle& operator=(std::shared_ptr<T>&& other)
+    template<typename U>
+    Handle& operator=(std::shared_ptr<U>&& other)
     {
         reset();
         std::shared_ptr<T>::operator=(std::move(other));

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -331,7 +331,9 @@ Results List::filter(Query q) const
 Results List::as_results() const
 {
     verify_attached();
-    return (m_type == PropertyType::Object) ? Results(m_realm, std::static_pointer_cast<LnkLst>(m_list_base)) : Results(m_realm, m_list_base);
+    return m_type == PropertyType::Object
+        ? Results(m_realm, std::static_pointer_cast<LnkLst>(m_list_base))
+        : Results(m_realm, m_list_base);
 }
 
 Results List::snapshot() const

--- a/src/results.hpp
+++ b/src/results.hpp
@@ -37,7 +37,7 @@ class Mixed;
 class ObjectSchema;
 
 namespace _impl {
-    class ResultsNotifier;
+    class ResultsNotifierBase;
 }
 
 class Results {
@@ -71,7 +71,7 @@ public:
     Query get_query() const REQUIRES(!m_mutex);
 
     // Get the Lst this Results is derived from, if any
-    const LstBase* get_list() const { return m_list.get(); }
+    std::shared_ptr<LstBase> const& get_list() const { return m_list; }
 
     // Get the list of sort and distinct operations applied for this Results.
     DescriptorOrdering const& get_descriptor_ordering() const noexcept { return m_descriptor_ordering; }
@@ -230,13 +230,6 @@ public:
     // Returns whether the rows are guaranteed to be in table order.
     bool is_in_table_order() const;
 
-    // Helper type to let ResultsNotifier update the tableview without giving access
-    // to any other privates or letting anyone else do so
-    class Internal {
-        friend class _impl::ResultsNotifier;
-        static void set_table_view(Results& results, TableView&& tv);
-    };
-
     template<typename Context> auto first(Context&) REQUIRES(!m_mutex);
     template<typename Context> auto last(Context&) REQUIRES(!m_mutex);
 
@@ -273,7 +266,7 @@ private:
     std::shared_ptr<LstBase> m_list;
     util::Optional<std::vector<size_t>> m_list_indices GUARDED_BY(m_mutex);
 
-    _impl::CollectionNotifier::Handle<_impl::ResultsNotifier> m_notifier;
+    _impl::CollectionNotifier::Handle<_impl::ResultsNotifierBase> m_notifier;
 
     Mode m_mode GUARDED_BY(m_mutex) = Mode::Empty;
     UpdatePolicy m_update_policy = UpdatePolicy::Auto;

--- a/tests/collection_change_indices.cpp
+++ b/tests/collection_change_indices.cpp
@@ -363,6 +363,7 @@ TEST_CASE("collection_change: calculate() sorted") {
 
     auto all_modified = [](size_t) { return true; };
     auto none_modified = [](size_t) { return false; };
+    size_t npos = -1;
 
     SECTION("returns an empty set when input and output are identical") {
         c = _impl::CollectionChangeBuilder::calculate({1, 2, 3}, {1, 2, 3}, none_modified);
@@ -380,7 +381,7 @@ TEST_CASE("collection_change: calculate() sorted") {
     }
 
     SECTION("marks npos rows in prev as deleted") {
-        c = _impl::CollectionChangeBuilder::calculate({-1, 1, 2, 3, -1}, {1, 2, 3}, all_modified);
+        c = _impl::CollectionChangeBuilder::calculate({npos, 1, 2, 3, npos}, {1, 2, 3}, all_modified);
         REQUIRE_INDICES(c.deletions, 0, 4);
     }
 
@@ -436,7 +437,7 @@ TEST_CASE("collection_change: calculate() sorted") {
     }
 
     SECTION("reports inserts/deletes for simple reorderings") {
-        auto calc = [&](std::vector<int64_t> old_rows, std::vector<int64_t> new_rows) {
+        auto calc = [&](std::vector<size_t> old_rows, std::vector<size_t> new_rows) {
             return _impl::CollectionChangeBuilder::calculate(old_rows, new_rows, none_modified);
         };
 
@@ -635,8 +636,8 @@ TEST_CASE("collection_change: calculate() sorted") {
     }
 
     SECTION("properly recurses into smaller subblocks") {
-        std::vector<int64_t> prev = {10, 1, 2, 11, 3, 4, 5, 12, 6, 7, 13};
-        std::vector<int64_t> next = {13, 1, 2, 12, 3, 4, 5, 11, 6, 7, 10};
+        std::vector<size_t> prev = {10, 1, 2, 11, 3, 4, 5, 12, 6, 7, 13};
+        std::vector<size_t> next = {13, 1, 2, 12, 3, 4, 5, 11, 6, 7, 10};
         c = _impl::CollectionChangeBuilder::calculate(prev, next, all_modified);
         REQUIRE_INDICES(c.deletions, 0, 3, 7, 10);
         REQUIRE_INDICES(c.insertions, 0, 3, 7, 10);
@@ -651,11 +652,11 @@ TEST_CASE("collection_change: calculate() sorted") {
                 CAPTURE(insert_pos);
                 CAPTURE(move_to_pos);
 
-                std::vector<int64_t> after_insert = {1, 2, 3};
+                std::vector<size_t> after_insert = {1, 2, 3};
                 after_insert.insert(after_insert.begin() + insert_pos, 4);
                 c = _impl::CollectionChangeBuilder::calculate({1, 2, 3}, after_insert, four_modified);
 
-                std::vector<int64_t> after_move = {1, 2, 3};
+                std::vector<size_t> after_move = {1, 2, 3};
                 after_move.insert(after_move.begin() + move_to_pos, 4);
                 c.merge(_impl::CollectionChangeBuilder::calculate(after_insert, after_move, four_modified));
 

--- a/tests/thread_safe_reference.cpp
+++ b/tests/thread_safe_reference.cpp
@@ -668,18 +668,15 @@ TEST_CASE("thread safe reference") {
             REQUIRE(results.is_valid());
             REQUIRE(results.size() == 0);
         }
-#if 0
+
         SECTION("int results") {
             r->begin_transaction();
             obj = create_object(r, "int array", {{"value", AnyVector{INT64_C(1)}}});
-            List list(r, *get_table(*r, "int array"), 0, 0);
+            List list(r, obj.obj(), get_table(*r, "int array")->get_column_key("value"));
             r->commit_transaction();
 
-            auto results = delete_and_resolve(list.sort({{"self", true}}));
-            REQUIRE(results.is_valid());
-            REQUIRE(results.size() == 0);
+            REQUIRE(!delete_and_resolve(list).is_valid());
         }
-#endif
     }
 
     SECTION("lifetime") {

--- a/workflow/test_coverage.sh
+++ b/workflow/test_coverage.sh
@@ -20,7 +20,7 @@ if [ "${TMPDIR}" = "" ]; then
 fi
 
 echo "TMPDIR: ${TMPDIR}"
-ls "${TMPDIR}/realm*" | while read filename; do rm -rf "$filename"; done
+find $TMPDIR -name 'realm*' -exec rm -rf "{}" \+ || true
 rm -rf coverage.build
 mkdir -p coverage.build
 cd coverage.build
@@ -32,3 +32,5 @@ fi
 
 cmake ${cmake_flags} -DCMAKE_BUILD_TYPE=Coverage -DDEPENDENCIES_FILE="dependencies${deps_suffix}.list" ..
 make VERBOSE=1 -j${nprocs} generate-coverage-cobertura
+
+find $TMPDIR -name 'realm*' -exec rm -rf "{}" \+ || true


### PR DESCRIPTION
As Lists can no longer be accessed via Query/TableView, Lists which have been wrapped in a 
 Results (normally for sort/distinct) need their own special handling for notifications.

The logic for this is very similar to sorted notifications in core 5, with manual updating of row indices to reflect insertions/deletions prior to diffing.