### PR TITLE
Implement missing parts of embedded objects

### DIFF
--- a/src/impl/object_accessor_impl.hpp
+++ b/src/impl/object_accessor_impl.hpp
@@ -36,9 +36,11 @@ public:
     // This constructor is the only one used by the object accessor code, and is
     // used when recurring into a link or array property during object creation
     // (i.e. prop.type will always be Object or Array).
-    CppContext(CppContext& c, Property const& prop)
+    CppContext(CppContext& c, Obj parent, Property const& prop)
     : realm(c.realm)
     , object_schema(prop.type == PropertyType::Object ? &*realm->schema().find(prop.object_type) : c.object_schema)
+    , m_parent(std::move(parent))
+    , m_property(&prop)
     { }
 
     CppContext() = default;
@@ -61,11 +63,6 @@ public:
         auto const& v = any_cast<AnyDict&>(dict);
         auto it = v.find(prop.name);
         return it == v.end() ? util::none : util::make_optional(it->second);
-    }
-
-    bool is_embedded() const
-    {
-        return object_schema ? bool(object_schema->is_embedded) : false;
     }
 
     // Get the default value for the given property in the given object schema,
@@ -137,7 +134,7 @@ public:
     template<typename T>
     T unbox(util::Any& v, CreatePolicy = CreatePolicy::Skip, ObjKey /*current_row*/ = ObjKey()) const { return any_cast<T>(v); }
 
-    Obj unbox_embedded(util::Any& v, CreatePolicy policy, Obj& parent, ColKey col, size_t ndx) const;
+    Obj create_embedded_object();
 
     bool is_null(util::Any const& v) const noexcept { return !v.has_value(); }
     util::Any null_value() const noexcept { return {}; }
@@ -159,6 +156,8 @@ public:
 private:
     std::shared_ptr<Realm> realm;
     const ObjectSchema* object_schema = nullptr;
+    Obj m_parent;
+    const Property* m_property = nullptr;
 
 };
 
@@ -200,11 +199,6 @@ inline Obj CppContext::unbox(util::Any& v, CreatePolicy policy, ObjKey current_o
     return Object::create(const_cast<CppContext&>(*this), realm, *object_schema, v, policy, current_obj).obj();
 }
 
-inline Obj CppContext::unbox_embedded(util::Any& v, CreatePolicy policy, Obj& parent, ColKey col, size_t ndx) const
-{
-    return Object::create_embedded(const_cast<CppContext&>(*this), realm, *object_schema, v, policy, parent, col, ndx).obj();
-}
-
 template<>
 inline util::Optional<bool> CppContext::unbox(util::Any& v, CreatePolicy, ObjKey) const
 {
@@ -239,6 +233,11 @@ template<>
 inline Mixed CppContext::unbox(util::Any&, CreatePolicy, ObjKey) const
 {
     throw std::logic_error("'Any' type is unsupported");
+}
+
+inline Obj CppContext::create_embedded_object()
+{
+    return m_parent.create_and_set_linked_object(m_property->column_key);
 }
 }
 

--- a/src/impl/object_accessor_impl.hpp
+++ b/src/impl/object_accessor_impl.hpp
@@ -193,7 +193,7 @@ inline Obj CppContext::unbox(util::Any& v, CreatePolicy policy, ObjKey current_o
         return object->obj();
     if (auto obj = any_cast<Obj>(&v))
         return *obj;
-    if (policy == CreatePolicy::Skip)
+    if (!policy.create)
         return Obj();
 
     REALM_ASSERT(object_schema);

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -54,7 +54,7 @@ List& List::operator=(List&&) = default;
 
 List::List(std::shared_ptr<Realm> r, const Obj& parent_obj, ColKey col)
 : m_realm(std::move(r))
-, m_type(ObjectSchema::from_core_type(*parent_obj.get_table(), col) & ~PropertyType::Array)
+, m_type(ObjectSchema::from_core_type(col) & ~PropertyType::Array)
 , m_list_base(parent_obj.get_listbase_ptr(col))
 , m_is_embedded(m_type == PropertyType::Object && as<Obj>().get_target_table()->is_embedded())
 {
@@ -62,7 +62,7 @@ List::List(std::shared_ptr<Realm> r, const Obj& parent_obj, ColKey col)
 
 List::List(std::shared_ptr<Realm> r, const LstBase& list)
 : m_realm(std::move(r))
-, m_type(ObjectSchema::from_core_type(*list.get_table(), list.get_col_key()) & ~PropertyType::Array)
+, m_type(ObjectSchema::from_core_type(list.get_col_key()) & ~PropertyType::Array)
 , m_list_base(list.clone())
 , m_is_embedded(m_type == PropertyType::Object && as<Obj>().get_target_table()->is_embedded())
 {

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -138,15 +138,15 @@ public:
     size_t find(Context&, T&& value) const;
 
     template<typename T, typename Context>
-    void add(Context&, T&& value, CreatePolicy=CreatePolicy::ForceCreate);
+    void add(Context&, T&& value, CreatePolicy=CreatePolicy::SetLink);
     template<typename T, typename Context>
-    void insert(Context&, size_t list_ndx, T&& value, CreatePolicy=CreatePolicy::ForceCreate);
+    void insert(Context&, size_t list_ndx, T&& value, CreatePolicy=CreatePolicy::SetLink);
     template<typename T, typename Context>
-    void set(Context&, size_t row_ndx, T&& value, CreatePolicy=CreatePolicy::ForceCreate);
+    void set(Context&, size_t row_ndx, T&& value, CreatePolicy=CreatePolicy::SetLink);
 
     // Replace the values in this list with the values from an enumerable object
     template<typename T, typename Context>
-    void assign(Context&, T&& value, CreatePolicy=CreatePolicy::ForceCreate);
+    void assign(Context&, T&& value, CreatePolicy=CreatePolicy::SetLink);
 
     // The List object has been invalidated (due to the Realm being invalidated,
     // or the containing object being deleted)
@@ -287,7 +287,7 @@ void List::assign(Context& ctx, T&& values, CreatePolicy policy)
         return;
     }
 
-    if (policy == CreatePolicy::UpdateModified) {
+    if (policy.diff) {
         size_t sz = size();
         size_t index = 0;
         ctx.enumerate_list(values, [&](auto&& element) {

--- a/src/list.hpp
+++ b/src/list.hpp
@@ -162,15 +162,25 @@ public:
         size_t valid_count;
     };
 
+    // The object being added to the list is already a managed embedded object
+    struct InvalidEmbeddedOperationException : public std::logic_error {
+        InvalidEmbeddedOperationException()
+        : std::logic_error("Cannot add an existing managed embedded object to a List.") { }
+    };
+
 private:
     std::shared_ptr<Realm> m_realm;
     PropertyType m_type;
     mutable util::CopyableAtomic<const ObjectSchema*> m_object_schema = nullptr;
     _impl::CollectionNotifier::Handle<_impl::ListNotifier> m_notifier;
     std::shared_ptr<LstBase> m_list_base;
+    bool m_is_embedded = false;
 
     void verify_valid_row(size_t row_ndx, bool insertion = false) const;
     void validate(const Obj&) const;
+
+    template<typename T, typename Context>
+    void validate_embedded(Context& ctx, T&& value, CreatePolicy policy) const;
 
     template<typename Fn>
     auto dispatch(Fn&&) const;
@@ -215,66 +225,77 @@ size_t List::find(Context& ctx, T&& value) const
 }
 
 template<typename T, typename Context>
+void List::validate_embedded(Context& ctx, T&& value, CreatePolicy policy) const
+{
+    if (!policy.copy && ctx.template unbox<Obj>(value, CreatePolicy::Skip).is_valid())
+        throw InvalidEmbeddedOperationException();
+}
+
+template<typename T, typename Context>
 void List::add(Context& ctx, T&& value, CreatePolicy policy)
 {
+    if (m_is_embedded) {
+        validate_embedded(ctx, value, policy);
+        auto key = as<Obj>().create_and_insert_linked_object(size()).get_key();
+        ctx.template unbox<Obj>(value, policy, key);
+        return;
+    }
     dispatch([&](auto t) { this->add(ctx.template unbox<std::decay_t<decltype(*t)>>(value, policy)); });
 }
 
 template<typename T, typename Context>
 void List::insert(Context& ctx, size_t list_ndx, T&& value, CreatePolicy policy)
 {
+    if (m_is_embedded) {
+        validate_embedded(ctx, value, policy);
+        auto key = as<Obj>().create_and_insert_linked_object(list_ndx).get_key();
+        ctx.template unbox<Obj>(value, policy, key);
+        return;
+    }
     dispatch([&](auto t) { this->insert(list_ndx, ctx.template unbox<std::decay_t<decltype(*t)>>(value, policy)); });
 }
 
 template<typename T, typename Context>
-void List::set(Context& ctx, size_t row_ndx, T&& value, CreatePolicy policy)
+void List::set(Context& ctx, size_t list_ndx, T&& value, CreatePolicy policy)
 {
-    dispatch([&](auto t) { this->set(row_ndx, ctx.template unbox<std::decay_t<decltype(*t)>>(value, policy)); });
-}
+    if (m_is_embedded) {
+        validate_embedded(ctx, value, policy);
 
-namespace _impl {
-template <class T>
-inline ObjKey help_get_current_row(const T&)
-{
-    return ObjKey();
-}
-
-template <>
-inline ObjKey help_get_current_row(const ConstObj& v)
-{
-    return v.get_key();
-}
-
-template <>
-inline ObjKey help_get_current_row(const Obj& v)
-{
-    return v.get_key();
-}
-
-template <class T>
-inline bool help_compare_values(const T& v1, const T& v2)
-{
-    return v1 != v2;
-}
-template <>
-inline bool help_compare_values(const Obj& v1, const Obj& v2)
-{
-    return v1.get_table() != v2.get_table() || v1.get_key() != v2.get_key();
-}
+        auto& list = as<Obj>();
+        auto key = policy.diff ? list.get(list_ndx)
+                               : list.create_and_set_linked_object(list_ndx).get_key();
+        ctx.template unbox<Obj>(value, policy, key);
+        return;
+    }
+    dispatch([&](auto t) { this->set(list_ndx, ctx.template unbox<std::decay_t<decltype(*t)>>(value, policy)); });
 }
 
 template<typename T, typename Context>
 void List::set_if_different(Context& ctx, size_t row_ndx, T&& value, CreatePolicy policy)
 {
+    if (m_is_embedded) {
+        validate_embedded(ctx, value, policy);
+        auto key = policy.diff ? this->get<Obj>(row_ndx)
+                               : as<Obj>().create_and_set_linked_object(row_ndx);
+        ctx.template unbox<Obj>(value, policy, key.get_key());
+        return;
+    }
     dispatch([&](auto t) {
         using U = std::decay_t<decltype(*t)>;
-        auto old_value =  this->get<U>(row_ndx);
-        auto new_value = ctx.template unbox<U>(value, policy, _impl::help_get_current_row(old_value));
-        if (_impl::help_compare_values(old_value, new_value))
-            this->set(row_ndx, new_value);
+        if constexpr (std::is_same_v<U, Obj>) {
+            auto old_value = this->get<U>(row_ndx);
+            auto new_value = ctx.template unbox<U>(value, policy, old_value.get_key());
+            if (new_value.get_key() != old_value.get_key())
+                this->set(row_ndx, new_value);
+        }
+        else {
+            auto old_value =  this->get<U>(row_ndx);
+            auto new_value = ctx.template unbox<U>(value, policy);
+            if (old_value != new_value)
+                this->set(row_ndx, new_value);
+        }
     });
 }
-
 
 template<typename T, typename Context>
 void List::assign(Context& ctx, T&& values, CreatePolicy policy)
@@ -287,28 +308,23 @@ void List::assign(Context& ctx, T&& values, CreatePolicy policy)
         return;
     }
 
-    if (policy.diff) {
-        size_t sz = size();
-        size_t index = 0;
-        ctx.enumerate_list(values, [&](auto&& element) {
-            if (index < sz) {
-                this->set_if_different(ctx, index, element, policy);
-            }
-            else {
-                this->add(ctx, element, policy);
-            }
-            index++;
-        });
-        while (index < sz) {
-            remove(--sz);
-        }
-    }
-    else {
+
+    if (!policy.diff)
         remove_all();
-        ctx.enumerate_list(values, [&](auto&& element) {
+
+    size_t sz = size();
+    size_t index = 0;
+    ctx.enumerate_list(values, [&](auto&& element) {
+        if (index >= sz)
             this->add(ctx, element, policy);
-        });
-    }
+        else if (policy.diff)
+            this->set_if_different(ctx, index, element, policy);
+        else
+            this->set(ctx, index, element, policy);
+        index++;
+    });
+    while (index < sz)
+        remove(--sz);
 }
 } // namespace realm
 

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -27,6 +27,12 @@
 
 using namespace realm;
 
+CreatePolicy CreatePolicy::Skip = {.create = false, .copy = false, .update = false, .diff = false};
+CreatePolicy CreatePolicy::ForceCreate = {.create = true, .copy = true, .update = false, .diff = false};
+CreatePolicy CreatePolicy::UpdateAll = {.create = true, .copy = true, .update = true, .diff = false};
+CreatePolicy CreatePolicy::UpdateModified = {.create = true, .copy = true, .update = true, .diff = true};
+CreatePolicy CreatePolicy::SetLink = {.create = true, .copy = false, .update = false, .diff = false};
+
 Object Object::freeze(std::shared_ptr<Realm> frozen_realm) const
 {
     return Object(frozen_realm, frozen_realm->import_copy_of(m_obj));

--- a/src/object.hpp
+++ b/src/object.hpp
@@ -131,12 +131,6 @@ public:
                          CreatePolicy policy = CreatePolicy::ForceCreate,
                          ObjKey current_obj = ObjKey(), Obj* = nullptr);
 
-    // create an Embedded Object from a native representation
-    template<typename ValueType, typename ContextType>
-    static Object create_embedded(ContextType& ctx, std::shared_ptr<Realm> const& realm,
-                         const ObjectSchema &object_schema, ValueType value,
-                         CreatePolicy policy, Obj& parent, ColKey col, size_t ndx);
-
     template<typename ValueType, typename ContextType>
     static Object create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
                          StringData object_type, ValueType value,

--- a/src/object_accessor.hpp
+++ b/src/object_accessor.hpp
@@ -87,16 +87,21 @@ struct ValueUpdater {
 
     void operator()(Obj*)
     {
-        ContextType child_ctx(ctx, property);
-        if (child_ctx.is_embedded()) {
-            child_ctx.unbox_embedded(value, policy, obj, col, 0);
-        }
-        else {
-            auto curr_link = obj.get<ObjKey>(col);
-            auto link = child_ctx.template unbox<Obj>(value, policy, curr_link);
-            if (!policy.diff || curr_link != link.get_key()) {
+        ContextType child_ctx(ctx, obj, property);
+        auto policy2 = policy;
+        policy2.create = false;
+        auto link = child_ctx.template unbox<Obj>(value, policy2);
+        if (!policy.copy && link && link.get_table()->is_embedded())
+            throw std::logic_error("Cannot set a link to an existing managed embedded object");
+
+        ObjKey curr_link;
+        if (policy.diff)
+            curr_link = obj.get<ObjKey>(col);
+        if (!link || link.get_table()->is_embedded())
+            link = child_ctx.template unbox<Obj>(value, policy, curr_link);
+        if (!policy.diff || curr_link != link.get_key()) {
+            if (!link || !link.get_table()->is_embedded())
                 obj.set(col, link.get_key());
-            }
         }
     }
 
@@ -137,20 +142,9 @@ void Object::set_property_value_impl(ContextType& ctx, const Property &property,
         if (property.type == PropertyType::LinkingObjects)
             throw ReadOnlyPropertyException(m_object_schema->name, property.name);
 
-        ContextType child_ctx(ctx, property);
-        if (child_ctx.is_embedded()) {
-            size_t index = 0;
-            ctx.enumerate_list(value, [&](auto&& element) {
-                child_ctx.unbox_embedded(element, policy, m_obj, col, index);
-                index++;
-            });
-            auto ll = m_obj.get_linklist(col);
-            ll.remove(index, ll.size());
-        }
-        else {
-            List list(m_realm, m_obj, col);
-            list.assign(child_ctx, value, policy);
-        }
+        ContextType child_ctx(ctx, m_obj, property);
+        List list(m_realm, m_obj, col);
+        list.assign(child_ctx, value, policy);
         ctx.did_change();
         return;
     }
@@ -262,13 +256,13 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
         }
     }
     else {
-        if (policy.diff && current_obj) {
+        if (current_obj)
             obj = table->get_object(current_obj);
-        }
-        else {
+        else if (object_schema.is_embedded)
+            obj = ctx.create_embedded_object();
+        else
             obj = table->create_object();
-            created = true;
-        }
+        created = !policy.diff || !current_obj;
     }
 
     // populate
@@ -293,58 +287,6 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
         if ((!v || ctx.is_null(*v)) && !is_nullable(prop.type) && !is_array(prop.type)) {
             if (prop.is_primary || !ctx.allow_missing(value))
                 throw MissingPropertyValueException(object_schema.name, prop.name);
-        }
-        if (v)
-            object.set_property_value_impl(ctx, prop, *v, policy, is_default);
-    }
-    return object;
-}
-
-template<typename ValueType, typename ContextType>
-Object Object::create_embedded(ContextType& ctx, std::shared_ptr<Realm> const& realm,
-                      ObjectSchema const& object_schema, ValueType value,
-                      CreatePolicy policy, Obj& parent, ColKey col, size_t ndx)
-{
-    realm->verify_in_write();
-
-    Obj obj;
-    if (col.get_attrs().test(col_attr_List)) {
-        auto ll = parent.get_linklist(col);
-        auto sz = ll.size();
-        if (ndx < sz) {
-            if (policy.diff) {
-                obj = ll.get_object(ndx);
-            }
-            else {
-                obj = ll.create_and_set_linked_object(ndx);
-            }
-        }
-        else {
-            obj = ll.create_and_insert_linked_object(ndx);
-        }
-    }
-    else {
-        ObjKey current_obj = parent.get<ObjKey>(col);
-        if (policy.diff && current_obj) {
-            auto table = realm->read_group().get_table(object_schema.table_key);
-            obj = table->get_object(current_obj);
-        }
-        else {
-            obj = parent.create_and_set_linked_object(col);
-        }
-    }
-
-    // populate
-    Object object(realm, object_schema, obj);
-    for (size_t i = 0; i < object_schema.persisted_properties.size(); ++i) {
-        auto& prop = object_schema.persisted_properties[i];
-
-        auto v = ctx.value_for_property(value, prop, i);
-
-        bool is_default = false;
-        if (!v) {
-            v = ctx.default_value_for_property(object_schema, prop);
-            is_default = true;
         }
         if (v)
             object.set_property_value_impl(ctx, prop, *v, policy, is_default);

--- a/src/object_schema.hpp
+++ b/src/object_schema.hpp
@@ -79,7 +79,7 @@ public:
 
     friend bool operator==(ObjectSchema const& a, ObjectSchema const& b) noexcept;
 
-    static PropertyType from_core_type(Table const& table, ColKey col);
+    static PropertyType from_core_type(ColKey col);
 
 private:
     void set_primary_key_property() noexcept;

--- a/src/object_schema.hpp
+++ b/src/object_schema.hpp
@@ -19,9 +19,10 @@
 #ifndef REALM_OBJECT_SCHEMA_HPP
 #define REALM_OBJECT_SCHEMA_HPP
 
+#include "util/tagged_bool.hpp"
+
 #include <realm/keys.hpp>
 #include <realm/string_data.hpp>
-#include "util/tagged_bool.hpp"
 
 #include <string>
 #include <vector>

--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -243,6 +243,14 @@ struct SchemaDifferenceExplainer {
         // We never do anything for RemoveTable
     }
 
+    void operator()(schema_change::ChangeTableType op)
+    {
+        if (op.object->is_embedded)
+            errors.emplace_back("Class '%1' has been changed from top-level to embedded.", op.object->name);
+        else
+            errors.emplace_back("Class '%1' has been changed from embedded to top-level.", op.object->name);
+    }
+
     void operator()(schema_change::AddInitialProperties)
     {
         // Nothing. Always preceded by AddTable.
@@ -343,6 +351,7 @@ bool ObjectStore::needs_migration(std::vector<SchemaChange> const& changes)
         bool operator()(AddProperty) { return true; }
         bool operator()(AddTable) { return false; }
         bool operator()(RemoveTable) { return false; }
+        bool operator()(ChangeTableType) { return true; }
         bool operator()(ChangePrimaryKey) { return true; }
         bool operator()(ChangePropertyType) { return true; }
         bool operator()(MakePropertyNullable) { return true; }
@@ -393,7 +402,7 @@ bool ObjectStore::verify_valid_additive_changes(std::vector<SchemaChange> const&
         void operator()(AddIndex) { index_changes = true; }
         void operator()(RemoveIndex) { index_changes = true; }
     } verifier;
-    verify_no_errors<InvalidSchemaChangeException>(verifier, changes);
+    verify_no_errors<InvalidAdditiveSchemaChangeException>(verifier, changes);
     return verifier.other_changes || (verifier.index_changes && update_indexes);
 }
 
@@ -426,11 +435,12 @@ void ObjectStore::verify_compatible_for_immutable_and_readonly(std::vector<Schem
 
         void operator()(AddTable) { }
         void operator()(AddInitialProperties) { }
+        void operator()(ChangeTableType) { }
         void operator()(RemoveProperty) { }
         void operator()(AddIndex) { }
         void operator()(RemoveIndex) { }
     } verifier;
-    verify_no_errors<InvalidSchemaChangeException>(verifier, changes);
+    verify_no_errors<InvalidReadOnlySchemaChangeException>(verifier, changes);
 }
 
 static void apply_non_migration_changes(Group& group, std::vector<SchemaChange> const& changes)
@@ -453,6 +463,15 @@ static void apply_non_migration_changes(Group& group, std::vector<SchemaChange> 
     verify_no_errors<SchemaMismatchException>(applier, changes);
 }
 
+static void set_embedded(Table& table, ObjectSchema::IsEmbedded is_embedded)
+{
+    if (!table.set_embedded(is_embedded) && is_embedded) {
+        auto msg = util::format("Cannot convert object type '%1' to embedded because objects have multiple incoming links.",
+                                ObjectStore::object_type_for_table_name(table.get_name()));
+        throw std::logic_error(std::move(msg));
+    }
+}
+
 static void create_initial_tables(Group& group, std::vector<SchemaChange> const& changes)
 {
     using namespace schema_change;
@@ -470,6 +489,7 @@ static void create_initial_tables(Group& group, std::vector<SchemaChange> const&
         // Implementing these makes us better able to handle weird
         // not-quite-correct files produced by other things and has no obvious
         // downside.
+        void operator()(ChangeTableType op) { set_embedded(table(op.object), op.object->is_embedded); }
         void operator()(AddProperty op) { add_column(group, table(op.object), *op.property); }
         void operator()(RemoveProperty op) { table(op.object).remove_column(op.property->column_key); }
         void operator()(MakePropertyNullable op) { make_property_optional(table(op.object), *op.property); }
@@ -508,6 +528,7 @@ void ObjectStore::apply_additive_changes(Group& group, std::vector<SchemaChange>
         void operator()(RemoveProperty) { }
 
         // No need for errors for these, as we've already verified that they aren't present
+        void operator()(ChangeTableType) { }
         void operator()(ChangePrimaryKey) { }
         void operator()(ChangePropertyType) { }
         void operator()(MakePropertyNullable) { }
@@ -529,6 +550,7 @@ static void apply_pre_migration_changes(Group& group, std::vector<SchemaChange> 
 
         void operator()(AddTable op) { create_table(group, *op.object); }
         void operator()(RemoveTable) { }
+        void operator()(ChangeTableType op) { set_embedded(table(op.object), op.object->is_embedded); }
         void operator()(AddInitialProperties op) { add_initial_columns(group, *op.object); }
         void operator()(AddProperty op) { add_column(group, table(op.object), *op.property); }
         void operator()(RemoveProperty) { /* delayed until after the migration */ }
@@ -598,6 +620,7 @@ static void apply_post_migration_changes(Group& group,
         void operator()(AddIndex op) { table(op.object).add_search_index(op.property->column_key); }
         void operator()(RemoveIndex op) { table(op.object).remove_search_index(op.property->column_key); }
 
+        void operator()(ChangeTableType) { }
         void operator()(RemoveTable) { }
         void operator()(ChangePropertyType) { }
         void operator()(MakePropertyNullable) { }
@@ -696,7 +719,7 @@ util::Optional<Property> ObjectStore::property_for_column_key(ConstTableRef& tab
 
     Property property;
     property.name = column_name;
-    property.type = ObjectSchema::from_core_type(*table, column_key);
+    property.type = ObjectSchema::from_core_type(column_key);
     property.is_primary = table->get_primary_key_column() == column_key;
     property.is_indexed = table->has_search_index(column_key);
     property.column_key = column_key;
@@ -810,12 +833,18 @@ InvalidSchemaVersionException::InvalidSchemaVersionException(uint64_t old_versio
 {
 }
 
+static void append_errors(std::string& message, std::vector<ObjectSchemaValidationException> const& errors)
+{
+    for (auto const& error : errors) {
+        message += "\n- ";
+        message += error.what();
+    }
+}
+
 SchemaValidationException::SchemaValidationException(std::vector<ObjectSchemaValidationException> const& errors)
 : std::logic_error([&] {
     std::string message = "Schema validation failed due to the following errors:";
-    for (auto const& error : errors) {
-        message += std::string("\n- ") + error.what();
-    }
+    append_errors(message, errors);
     return message;
 }())
 {
@@ -824,20 +853,25 @@ SchemaValidationException::SchemaValidationException(std::vector<ObjectSchemaVal
 SchemaMismatchException::SchemaMismatchException(std::vector<ObjectSchemaValidationException> const& errors)
 : std::logic_error([&] {
     std::string message = "Migration is required due to the following errors:";
-    for (auto const& error : errors) {
-        message += std::string("\n- ") + error.what();
-    }
+    append_errors(message, errors);
     return message;
 }())
 {
 }
 
-InvalidSchemaChangeException::InvalidSchemaChangeException(std::vector<ObjectSchemaValidationException> const& errors)
+InvalidReadOnlySchemaChangeException::InvalidReadOnlySchemaChangeException(std::vector<ObjectSchemaValidationException> const& errors)
+: std::logic_error([&] {
+    std::string message = "The following changes cannot be made in read-only schema mode:";
+    append_errors(message, errors);
+    return message;
+}())
+{
+}
+
+InvalidAdditiveSchemaChangeException::InvalidAdditiveSchemaChangeException(std::vector<ObjectSchemaValidationException> const& errors)
 : std::logic_error([&] {
     std::string message = "The following changes cannot be made in additive-only schema mode:";
-    for (auto const& error : errors) {
-        message += std::string("\n- ") + error.what();
-    }
+    append_errors(message, errors);
     return message;
 }())
 {
@@ -849,9 +883,7 @@ InvalidExternalSchemaChangeException::InvalidExternalSchemaChangeException(std::
         "Unsupported schema changes were made by another client or process. For a "
         "synchronized Realm, this may be due to the server reverting schema changes which "
         "the local user did not have permission to make.";
-    for (auto const& error : errors) {
-        message += std::string("\n- ") + error.what();
-    }
+    append_errors(message, errors);
     return message;
 }())
 {

--- a/src/object_store.cpp
+++ b/src/object_store.cpp
@@ -125,13 +125,13 @@ TableRef create_table(Group& group, ObjectSchema const& object_schema)
 {
     auto name = ObjectStore::table_name_for_object_type(object_schema.name);
 
-    TableRef table;
+    TableRef table = group.get_table(name);
+    if (table)
+        return table;
+
     if (auto* pk_property = object_schema.primary_key_property()) {
-        table = group.get_table(name);
-        if (!table) {
-            table = group.add_table_with_primary_key(name, to_core_type(pk_property->type), pk_property->name,
-                                                     is_nullable(pk_property->type));
-        }
+        table = group.add_table_with_primary_key(name, to_core_type(pk_property->type), pk_property->name,
+                                                 is_nullable(pk_property->type));
     }
     else {
         if (object_schema.is_embedded) {

--- a/src/object_store.hpp
+++ b/src/object_store.hpp
@@ -154,8 +154,11 @@ struct SchemaMismatchException : public std::logic_error {
     SchemaMismatchException(std::vector<ObjectSchemaValidationException> const& errors);
 };
 
-struct InvalidSchemaChangeException : public std::logic_error {
-    InvalidSchemaChangeException(std::vector<ObjectSchemaValidationException> const& errors);
+struct InvalidAdditiveSchemaChangeException : public std::logic_error {
+    InvalidAdditiveSchemaChangeException(std::vector<ObjectSchemaValidationException> const& errors);
+};
+struct InvalidReadOnlySchemaChangeException : public std::logic_error {
+    InvalidReadOnlySchemaChangeException(std::vector<ObjectSchemaValidationException> const& errors);
 };
 
 struct InvalidExternalSchemaChangeException : public std::logic_error {

--- a/src/results.cpp
+++ b/src/results.cpp
@@ -407,9 +407,7 @@ size_t Results::index_of(Obj const& row)
     if (m_table && row.get_table() != m_table) {
         throw IncorrectTableException(
             ObjectStore::object_type_for_table_name(m_table->get_name()),
-            ObjectStore::object_type_for_table_name(row.get_table()->get_name()),
-            "Attempting to get the index of a Row of the wrong type"
-        );
+            ObjectStore::object_type_for_table_name(row.get_table()->get_name()));
     }
 
     switch (m_mode) {
@@ -1083,8 +1081,13 @@ bool Results::is_frozen()
 }
 
 Results::OutOfBoundsIndexException::OutOfBoundsIndexException(size_t r, size_t c)
-: std::out_of_range(util::format("Requested index %1 greater than max %2", r, c - 1))
+: std::out_of_range(c == 0 ? util::format("Requested index %1 in empty Results", r)
+                           : util::format("Requested index %1 greater than max %2", r, c - 1))
 , requested(r), valid_count(c) {}
+
+Results::IncorrectTableException::IncorrectTableException(StringData e, StringData a)
+: std::logic_error(util::format("Object of type '%1' does not match Results type '%2'", a, e))
+, expected(e), actual(a) {}
 
 static std::string unsupported_operation_msg(ColKey column, Table const& table, const char* operation)
 {

--- a/src/results.cpp
+++ b/src/results.cpp
@@ -698,7 +698,7 @@ PropertyType Results::do_get_type() const
         case Mode::Table:
             return PropertyType::Object;
         case Mode::List:
-            return ObjectSchema::from_core_type(*m_list->get_table(), m_list->get_col_key());
+            return ObjectSchema::from_core_type(m_list->get_col_key());
     }
     REALM_COMPILER_HINT_UNREACHABLE();
 }
@@ -1088,7 +1088,7 @@ Results::OutOfBoundsIndexException::OutOfBoundsIndexException(size_t r, size_t c
 
 static std::string unsupported_operation_msg(ColKey column, Table const& table, const char* operation)
 {
-    auto type = ObjectSchema::from_core_type(table, column);
+    auto type = ObjectSchema::from_core_type(column);
     const char* column_type = string_for_property_type(type & ~PropertyType::Array);
     if (!is_array(type))
         return util::format("Cannot %1 property '%2': operation not supported for '%3' properties",
@@ -1102,7 +1102,7 @@ Results::UnsupportedColumnTypeException::UnsupportedColumnTypeException(ColKey c
 : std::logic_error(unsupported_operation_msg(column, table, operation))
 , column_key(column)
 , column_name(table.get_column_name(column))
-, property_type(ObjectSchema::from_core_type(table, ColKey(column)) & ~PropertyType::Array)
+, property_type(ObjectSchema::from_core_type(column) & ~PropertyType::Array)
 {
 }
 

--- a/src/results.hpp
+++ b/src/results.hpp
@@ -189,13 +189,12 @@ public:
 
     // The input Row object is not attached
     struct DetatchedAccessorException : public std::logic_error {
-        DetatchedAccessorException() : std::logic_error("Atempting to access an invalid object") {}
+        DetatchedAccessorException() : std::logic_error("Attempting to access an invalid object") {}
     };
 
     // The input Row object belongs to a different table
     struct IncorrectTableException : public std::logic_error {
-        IncorrectTableException(StringData e, StringData a, const std::string &error) :
-            std::logic_error(error), expected(e), actual(a) {}
+        IncorrectTableException(StringData e, StringData a);
         const StringData expected;
         const StringData actual;
     };

--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -188,9 +188,12 @@ std::vector<SchemaChange> Schema::compare(Schema const& target_schema, bool incl
         if (target && !existing) {
             changes.emplace_back(schema_change::AddTable{target});
         }
-        else if (include_table_removals && existing && !target) {
-            changes.emplace_back(schema_change::RemoveTable{existing});
+        else if (existing && !target) {
+            if (include_table_removals)
+                changes.emplace_back(schema_change::RemoveTable{existing});
         }
+        else if (existing->is_embedded != target->is_embedded)
+            changes.emplace_back(schema_change::ChangeTableType{target});
     });
 
     // Modify columns
@@ -244,6 +247,7 @@ bool operator==(SchemaChange const& lft, SchemaChange const& rgt) noexcept
         REALM_SC_COMPARE(AddInitialProperties, v.object)
         REALM_SC_COMPARE(AddTable, v.object)
         REALM_SC_COMPARE(RemoveTable, v.object)
+        REALM_SC_COMPARE(ChangeTableType, v.object)
         REALM_SC_COMPARE(ChangePrimaryKey, v.object, v.property)
         REALM_SC_COMPARE(ChangePropertyType, v.object, v.old_property, v.new_property)
         REALM_SC_COMPARE(MakePropertyNullable, v.object, v.property)

--- a/src/schema.hpp
+++ b/src/schema.hpp
@@ -86,6 +86,10 @@ struct RemoveTable {
     const ObjectSchema* object;
 };
 
+struct ChangeTableType {
+    const ObjectSchema* object;
+};
+
 struct AddInitialProperties {
     const ObjectSchema* object;
 };
@@ -135,6 +139,7 @@ struct ChangePrimaryKey {
 #define REALM_FOR_EACH_SCHEMA_CHANGE_TYPE(macro) \
     macro(AddTable) \
     macro(RemoveTable) \
+    macro(ChangeTableType) \
     macro(AddInitialProperties) \
     macro(AddProperty) \
     macro(RemoveProperty) \

--- a/src/sync/app.hpp
+++ b/src/sync/app.hpp
@@ -19,9 +19,9 @@
 #ifndef REALM_APP_HPP
 #define REALM_APP_HPP
 
-#include "app_credentials.hpp"
-#include "generic_network_transport.hpp"
-#include "sync_user.hpp"
+#include "sync/app_credentials.hpp"
+#include "sync/generic_network_transport.hpp"
+#include "sync/sync_user.hpp"
 
 namespace realm {
 namespace app {

--- a/src/sync/generic_network_transport.cpp
+++ b/src/sync/generic_network_transport.cpp
@@ -16,7 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#include "generic_network_transport.hpp"
+#include "sync/generic_network_transport.hpp"
+
 #include <string>
 
 namespace realm {

--- a/src/sync/generic_network_transport.hpp
+++ b/src/sync/generic_network_transport.hpp
@@ -23,9 +23,9 @@
 #include <realm/util/to_string.hpp>
 
 #include <functional>
-#include <memory>
+#include <iosfwd>
 #include <map>
-#include <ostream>
+#include <memory>
 #include <string>
 #include <system_error>
 #include <vector>

--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -18,7 +18,7 @@
 
 #include "sync/sync_user.hpp"
 
-#include "app_credentials.hpp"
+#include "sync/app_credentials.hpp"
 #include "sync/generic_network_transport.hpp"
 #include "sync/impl/sync_metadata.hpp"
 #include "sync/sync_manager.hpp"

--- a/src/thread_safe_reference.cpp
+++ b/src/thread_safe_reference.cpp
@@ -156,7 +156,7 @@ public:
                 // return an invalid Results rather than an Empty Results, to
                 // match what happens for other types of handover where the
                 // object doesn't exist.
-                switch_on_type(ObjectSchema::from_core_type(*table, m_col_key), [&](auto* t) -> void {
+                switch_on_type(ObjectSchema::from_core_type(m_col_key), [&](auto* t) -> void {
                     list = std::make_unique<typename ListType<decltype(*t)>::type>();
                 });
             }

--- a/tests/list.cpp
+++ b/tests/list.cpp
@@ -909,3 +909,446 @@ TEST_CASE("list") {
         REQUIRE(obj.obj().get_key() == target_keys[1]);
     }
 }
+
+TEST_CASE("embedded List") {
+    InMemoryTestFile config;
+    config.automatic_change_notifications = false;
+    auto r = Realm::get_shared_realm(config);
+    r->update_schema({
+        {"origin", {
+            {"pk", PropertyType::Int, Property::IsPrimary{true}},
+            {"array", PropertyType::Array|PropertyType::Object, "target"}
+        }},
+        {"target", ObjectSchema::IsEmbedded{true}, {
+            {"value", PropertyType::Int}
+        }},
+        {"other_origin", {
+            {"array", PropertyType::Array|PropertyType::Object, "other_target"}
+        }},
+        {"other_target", ObjectSchema::IsEmbedded{true}, {
+            {"value", PropertyType::Int}
+        }},
+    });
+
+    auto& coordinator = *_impl::RealmCoordinator::get_coordinator(config.path);
+
+    auto origin = r->read_group().get_table("class_origin");
+    auto target = r->read_group().get_table("class_target");
+    auto other_origin = r->read_group().get_table("class_other_origin");
+    ColKey col_link = origin->get_column_key("array");
+    ColKey col_value = target->get_column_key("value");
+    ColKey other_col_link = other_origin->get_column_key("array");
+
+    r->begin_transaction();
+
+    Obj obj = origin->create_object_with_primary_key(0);
+    auto lv = obj.get_linklist_ptr(col_link);
+    for (int i = 0; i < 10; ++i)
+        lv->create_and_insert_linked_object(i).set_all(i);
+    auto lv2 = origin->create_object_with_primary_key(1).get_linklist_ptr(col_link);
+    for (int i = 0; i < 10; ++i)
+        lv2->create_and_insert_linked_object(i).set_all(i);
+
+
+    Obj other_obj = other_origin->create_object();
+    auto other_lv = other_obj.get_linklist_ptr(other_col_link);
+    for (int i = 0; i < 10; ++i)
+        other_lv->create_and_insert_linked_object(i).set_all(i);
+
+    r->commit_transaction();
+    lv->size();
+    lv2->size();
+    other_lv->size();
+
+    auto r2 = coordinator.get_realm();
+    auto r2_lv = r2->read_group().get_table("class_origin")->get_object(0).get_linklist_ptr(col_link);
+
+    SECTION("add_notification_block()") {
+        CollectionChangeSet change;
+        List lst(r, obj, col_link);
+
+        auto write = [&](auto&& f) {
+            r->begin_transaction();
+            f();
+            r->commit_transaction();
+
+            advance_and_notify(*r);
+        };
+
+        auto require_change = [&] {
+            auto token = lst.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
+                change = c;
+            });
+            advance_and_notify(*r);
+            return token;
+        };
+
+        auto require_no_change = [&] {
+            bool first = true;
+            auto token = lst.add_notification_callback([&, first](CollectionChangeSet, std::exception_ptr) mutable {
+                REQUIRE(first);
+                first = false;
+            });
+            advance_and_notify(*r);
+            return token;
+        };
+
+        SECTION("modifying the list sends a change notifications") {
+            auto token = require_change();
+            write([&] { lst.remove(5); });
+            REQUIRE_INDICES(change.deletions, 5);
+        }
+
+        SECTION("modifying a different list doesn't send a change notification") {
+            auto token = require_no_change();
+            write([&] { lv2->remove(5); });
+        }
+
+        SECTION("deleting the list sends a change notification") {
+            auto token = require_change();
+            write([&] { obj.remove(); });
+            REQUIRE_INDICES(change.deletions, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+            // Should not resend delete all notification after another commit
+            change = {};
+            write([&] { lv2->size(); lv2->create_and_insert_linked_object(0); });
+            REQUIRE(change.empty());
+        }
+
+        SECTION("deleting list before first run of notifier reports deletions") {
+            auto token = lst.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr) {
+                change = c;
+            });
+            advance_and_notify(*r);
+            write([&] { origin->begin()->remove(); });
+            REQUIRE_INDICES(change.deletions, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        }
+
+        SECTION("modifying one of the target rows sends a change notification") {
+            auto token = require_change();
+            write([&] { lst.get(5).set(col_value, 6); });
+            REQUIRE_INDICES(change.modifications, 5);
+        }
+
+        SECTION("deleting a target row sends a change notification") {
+            auto token = require_change();
+            write([&] { target->remove_object(lv->get(5)); });
+            REQUIRE_INDICES(change.deletions, 5);
+        }
+
+        SECTION("modifying and then moving a row reports move/insert but not modification") {
+            auto token = require_change();
+            write([&] {
+                target->get_object(lv->get(5)).set(col_value, 10);
+                lst.move(5, 8);
+            });
+            REQUIRE_INDICES(change.insertions, 8);
+            REQUIRE_INDICES(change.deletions, 5);
+            REQUIRE_MOVES(change, {5, 8});
+            REQUIRE(change.modifications.empty());
+        }
+
+        SECTION("clearing the target table sends a change notification") {
+            auto token = require_change();
+            write([&] { target->clear(); });
+            REQUIRE_INDICES(change.deletions, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        }
+
+    }
+
+    SECTION("sorted add_notification_block()") {
+        List lst(r, *lv);
+        Results results = lst.sort({{{col_value}}, {false}});
+
+        int notification_calls = 0;
+        CollectionChangeSet change;
+        auto token = results.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr err) {
+            REQUIRE_FALSE(err);
+            change = c;
+            ++notification_calls;
+        });
+
+        advance_and_notify(*r);
+
+        auto write = [&](auto&& f) {
+            r->begin_transaction();
+            f();
+            r->commit_transaction();
+
+            advance_and_notify(*r);
+        };
+
+        SECTION("change order by modifying target") {
+            write([&] {
+                lst.get(5).set(col_value, 15);
+            });
+            REQUIRE(notification_calls == 2);
+            REQUIRE_INDICES(change.deletions, 4);
+            REQUIRE_INDICES(change.insertions, 0);
+        }
+
+        SECTION("swap") {
+            write([&] {
+                lst.swap(1, 2);
+            });
+            REQUIRE(notification_calls == 1);
+        }
+
+        SECTION("move") {
+            write([&] {
+                lst.move(5, 3);
+            });
+            REQUIRE(notification_calls == 1);
+        }
+    }
+
+    SECTION("filtered add_notification_block()") {
+        List lst(r, *lv);
+        Results results = lst.filter(target->where().less(col_value, 9));
+
+        int notification_calls = 0;
+        CollectionChangeSet change;
+        auto token = results.add_notification_callback([&](CollectionChangeSet c, std::exception_ptr err) {
+            REQUIRE_FALSE(err);
+            change = c;
+            ++notification_calls;
+        });
+
+        advance_and_notify(*r);
+
+        auto write = [&](auto&& f) {
+            r->begin_transaction();
+            f();
+            r->commit_transaction();
+
+            advance_and_notify(*r);
+        };
+
+        SECTION("swap") {
+            write([&] {
+                lst.swap(1, 2);
+            });
+            REQUIRE(notification_calls == 2);
+            REQUIRE_INDICES(change.deletions, 2);
+            REQUIRE_INDICES(change.insertions, 1);
+
+            write([&] {
+                lst.swap(5, 8);
+            });
+            REQUIRE(notification_calls == 3);
+            REQUIRE_INDICES(change.deletions, 5, 8);
+            REQUIRE_INDICES(change.insertions, 5, 8);
+        }
+
+        SECTION("move") {
+            write([&] {
+                lst.move(5, 3);
+            });
+            REQUIRE(notification_calls == 2);
+            REQUIRE_INDICES(change.deletions, 5);
+            REQUIRE_INDICES(change.insertions, 3);
+        }
+
+        SECTION("move non-matching entry") {
+            write([&] {
+                lst.move(9, 3);
+            });
+            REQUIRE(notification_calls == 1);
+        }
+    }
+
+    auto initial_view_size = lv->size();
+    auto initial_target_size = target->size();
+    SECTION("delete_at()") {
+        List list(r, *lv);
+        r->begin_transaction();
+        list.delete_at(1);
+        REQUIRE(lv->size() == initial_view_size - 1);
+        REQUIRE(target->size() == initial_target_size - 1);
+        r->cancel_transaction();
+    }
+
+    SECTION("delete_all()") {
+        List list(r, *lv);
+        r->begin_transaction();
+        list.delete_all();
+        REQUIRE(lv->size() == 0);
+        REQUIRE(target->size() == initial_target_size - 10);
+        r->cancel_transaction();
+    }
+
+    SECTION("as_results().clear()") {
+        List list(r, *lv);
+        r->begin_transaction();
+        list.as_results().clear();
+        REQUIRE(lv->size() == 0);
+        REQUIRE(target->size() == initial_target_size - 10);
+        r->cancel_transaction();
+    }
+
+    SECTION("snapshot().clear()") {
+        List list(r, *lv);
+        r->begin_transaction();
+        auto snapshot = list.snapshot();
+        snapshot.clear();
+        REQUIRE(snapshot.size() == 10);
+        REQUIRE(list.size() == 0);
+        REQUIRE(lv->size() == 0);
+        REQUIRE(target->size() == initial_target_size - 10);
+        r->cancel_transaction();
+    }
+
+    SECTION("add(), insert(), and set() to existing object is not allowed") {
+        List list(r, *lv);
+        r->begin_transaction();
+        REQUIRE_THROWS_AS(list.add(target->get_object(0)),
+                          List::InvalidEmbeddedOperationException);
+        REQUIRE_THROWS_AS(list.insert(0, target->get_object(0)),
+                          List::InvalidEmbeddedOperationException);
+        REQUIRE_THROWS_AS(list.set(0, target->get_object(0)),
+                          List::InvalidEmbeddedOperationException);
+        r->cancel_transaction();
+    }
+
+    SECTION("find(RowExpr)") {
+        List list(r, *lv);
+        Obj obj1 = target->get_object(1);
+        Obj obj5 = target->get_object(5);
+
+        SECTION("returns index in list for values in the list") {
+            REQUIRE(list.find(obj5) == 5);
+        }
+
+        SECTION("returns index in list and not index in table") {
+            r->begin_transaction();
+            list.remove(1);
+            REQUIRE(list.find(obj5) == 4);
+            REQUIRE(list.as_results().index_of(obj5) == 4);
+            r->cancel_transaction();
+        }
+
+        SECTION("returns npos for values not in the list") {
+            r->begin_transaction();
+            list.remove(1);
+            REQUIRE(list.find(obj1) == npos);
+            REQUIRE_THROWS_AS(list.as_results().index_of(obj1), Results::DetatchedAccessorException);
+            r->cancel_transaction();
+        }
+
+        SECTION("throws for row in wrong table") {
+            REQUIRE_THROWS(list.find(obj));
+            REQUIRE_THROWS(list.as_results().index_of(obj));
+        }
+    }
+
+    SECTION("find(Query)") {
+        List list(r, *lv);
+
+        SECTION("returns index in list for values in the list") {
+            REQUIRE(list.find(std::move(target->where().equal(col_value, 5))) == 5);
+        }
+
+        SECTION("returns index in list and not index in table") {
+            r->begin_transaction();
+            list.remove(1);
+            REQUIRE(list.find(std::move(target->where().equal(col_value, 5))) == 4);
+            r->cancel_transaction();
+        }
+
+        SECTION("returns npos for values not in the list") {
+            REQUIRE(list.find(std::move(target->where().equal(col_value, 11))) == npos);
+        }
+    }
+
+    SECTION("add(Context)") {
+        List list(r, *lv);
+        CppContext ctx(r, &list.get_object_schema());
+        r->begin_transaction();
+
+        auto initial_target_size = target->size();
+        SECTION("rejects boxed Obj and Object") {
+            REQUIRE_THROWS_AS(list.add(ctx, util::Any(target->get_object(5))),
+                              List::InvalidEmbeddedOperationException);
+            REQUIRE_THROWS_AS(list.add(ctx, util::Any(Object(r, target->get_object(5)))),
+                              List::InvalidEmbeddedOperationException);
+        }
+
+        SECTION("creates new object for dictionary") {
+            list.add(ctx, util::Any(AnyDict{{"value", INT64_C(20)}}));
+            REQUIRE(list.size() == 11);
+            REQUIRE(target->size() == initial_target_size + 1);
+            REQUIRE(list.get(10).get<Int>(col_value) == 20);
+        }
+
+        r->cancel_transaction();
+    }
+
+    SECTION("set(Context)") {
+        List list(r, *lv);
+        CppContext ctx(r, &list.get_object_schema());
+        r->begin_transaction();
+
+        auto initial_target_size = target->size();
+        SECTION("rejects boxed Obj and Object") {
+            REQUIRE_THROWS_AS(list.set(ctx, 0, util::Any(target->get_object(5))),
+                              List::InvalidEmbeddedOperationException);
+            REQUIRE_THROWS_AS(list.set(ctx, 0, util::Any(Object(r, target->get_object(5)))),
+                              List::InvalidEmbeddedOperationException);
+        }
+
+        SECTION("creates new object for update mode All") {
+            auto old_object = list.get<Obj>(0);
+            list.set(ctx, 0, util::Any(AnyDict{{"value", INT64_C(20)}}));
+            REQUIRE(list.size() == 10);
+            REQUIRE(target->size() == initial_target_size);
+            REQUIRE(list.get(0).get<Int>(col_value) == 20);
+            REQUIRE_FALSE(old_object.is_valid());
+        }
+
+        SECTION("mutates the existing object for update mode Modified") {
+            auto old_object = list.get<Obj>(0);
+            list.set(ctx, 0, util::Any(AnyDict{{"value", INT64_C(20)}}), CreatePolicy::UpdateModified);
+            REQUIRE(list.size() == 10);
+            REQUIRE(target->size() == initial_target_size);
+            REQUIRE(list.get(0).get<Int>(col_value) == 20);
+            REQUIRE(old_object.is_valid());
+            REQUIRE(list.get(0) == old_object);
+        }
+
+        r->cancel_transaction();
+    }
+
+    SECTION("find(Context)") {
+        List list(r, *lv);
+        CppContext ctx(r, &list.get_object_schema());
+
+        SECTION("returns index in list for boxed Obj") {
+            REQUIRE(list.find(ctx, util::Any(list.get(5))) == 5);
+        }
+
+        SECTION("returns index in list for boxed Object") {
+            realm::Object obj(r, *r->schema().find("origin"), list.get(5));
+            REQUIRE(list.find(ctx, util::Any(obj)) == 5);
+        }
+
+        SECTION("does not insert new objects for dictionaries") {
+            auto initial_target_size = target->size();
+            REQUIRE(list.find(ctx, util::Any(AnyDict{{"value", INT64_C(20)}})) == npos);
+            REQUIRE(target->size() == initial_target_size);
+        }
+
+        SECTION("throws for object in wrong table") {
+            REQUIRE_THROWS(list.find(ctx, util::Any(obj)));
+        }
+    }
+
+    SECTION("get(Context)") {
+        List list(r, *lv);
+        CppContext ctx(r, &list.get_object_schema());
+
+        Object obj;
+        REQUIRE_NOTHROW(obj = any_cast<Object&&>(list.get(ctx, 1)));
+        REQUIRE(obj.is_valid());
+        REQUIRE(obj.obj().get<int64_t>(col_value) == 1);
+    }
+}

--- a/tests/list.cpp
+++ b/tests/list.cpp
@@ -653,7 +653,7 @@ TEST_CASE("list") {
         REQUIRE(results.get_mode() == Results::Mode::Query);
         REQUIRE(results.size() == 4);
 
-        for (size_t i = 0; i < 4; ++i) {
+        for (int64_t i = 0; i < 4; ++i) {
             REQUIRE(results.get(i).get_key().value == i + 6);
         }
     }

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -774,7 +774,7 @@ TEST_CASE("migration: Automatic") {
                 auto list = any_cast<List>(obj.get_property_value<util::Any>(ctx, "array"));
                 REQUIRE(list.size() == 1);
 
-                CppContext list_ctx(ctx, *obj.get_object_schema().property_for_name("array"));
+                CppContext list_ctx(ctx, obj.obj(), *obj.get_object_schema().property_for_name("array"));
                 link = any_cast<Object>(list.get(list_ctx, 0));
                 REQUIRE(link.is_valid());
                 REQUIRE(any_cast<int64_t>(link.get_property_value<util::Any>(list_ctx, "value")) == 20);
@@ -830,7 +830,7 @@ TEST_CASE("migration: Automatic") {
                 auto list = any_cast<List>(obj.get_property_value<util::Any>(ctx, "array"));
                 REQUIRE(list.size() == 1);
 
-                CppContext list_ctx(ctx, *obj.get_object_schema().property_for_name("array"));
+                CppContext list_ctx(ctx, obj.obj(), *obj.get_object_schema().property_for_name("array"));
                 link = any_cast<Object>(list.get(list_ctx, 0));
                 REQUIRE(link.is_valid());
                 REQUIRE(any_cast<int64_t>(link.get_property_value<util::Any>(list_ctx, "value")) == 20);

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -678,7 +678,11 @@ TEST_CASE("migration: Automatic") {
                 {"not a pk", PropertyType::Int},
                 {"object", PropertyType::Object|PropertyType::Nullable, "object"},
                 {"array", PropertyType::Array|PropertyType::Object, "object"},
-            }}
+            }},
+            {"no pk object", {
+                {"value", PropertyType::Int, Property::IsPrimary{false}, Property::IsIndexed{true}},
+                {"optional", PropertyType::Int|PropertyType::Nullable},
+            }},
         };
         realm->update_schema(schema);
 
@@ -704,7 +708,7 @@ TEST_CASE("migration: Automatic") {
             }}));
         }
         SECTION("change table type") {
-            VERIFY_SCHEMA_IN_MIGRATION(set_embedded(schema, "link origin", true));
+            VERIFY_SCHEMA_IN_MIGRATION(set_embedded(schema, "no pk object", true));
         }
         SECTION("add property to table") {
             VERIFY_SCHEMA_IN_MIGRATION(add_property(schema, "object", {"new", PropertyType::Int}));

--- a/tests/object.cpp
+++ b/tests/object.cpp
@@ -776,7 +776,7 @@ TEST_CASE("object") {
     }
 
     for (auto policy : {CreatePolicy::UpdateAll, CreatePolicy::UpdateModified}) {
-        SECTION("set existing fields to null with update "s + (policy == CreatePolicy::UpdateModified ? "(diffed)" : "(all)")) {
+        SECTION("set existing fields to null with update "s + (policy.diff ? "(diffed)" : "(all)")) {
             AnyDict initial_values{
                 {"pk", INT64_C(1)},
                 {"bool", true},

--- a/tests/object.cpp
+++ b/tests/object.cpp
@@ -1119,6 +1119,11 @@ TEST_CASE("Embedded Object") {
             {"object", PropertyType::Object|PropertyType::Nullable, "link target"},
             {"array", PropertyType::Object|PropertyType::Array, "array target"},
         }},
+        {"all types no pk", {
+            {"value", PropertyType::Int},
+            {"object", PropertyType::Object|PropertyType::Nullable, "link target"},
+            {"array", PropertyType::Object|PropertyType::Array, "array target"},
+        }},
         {"link target", ObjectSchema::IsEmbedded{true}, {
             {"value", PropertyType::Int},
         }},

--- a/tests/object.cpp
+++ b/tests/object.cpp
@@ -52,8 +52,8 @@ struct TestContext : CppContext {
     std::map<std::string, AnyDict> defaults;
 
     using CppContext::CppContext;
-    TestContext(TestContext& parent, realm::Property const& prop)
-    : CppContext(parent, prop)
+    TestContext(TestContext& parent, realm::Obj& obj, realm::Property const& prop)
+    : CppContext(parent, obj, prop)
     , defaults(parent.defaults)
     { }
 
@@ -1112,51 +1112,178 @@ TEST_CASE("object") {
 #endif
 }
 
-TEST_CASE("Embedded Object")
-{
-    SECTION("Object creation") {
-        Schema schema{
-            {"all types", {
-                {"pk", PropertyType::Int, Property::IsPrimary{true}},
-                {"object", PropertyType::Object|PropertyType::Nullable, "link target"},
-                {"array", PropertyType::Object|PropertyType::Array, "array target"},
-            }},
-            {"link target", ObjectSchema::IsEmbedded{true}, {
-                {"value", PropertyType::Int},
-            }},
-            {"array target", ObjectSchema::IsEmbedded{true}, {
-                {"value", PropertyType::Int},
-            }},
-        };
+TEST_CASE("Embedded Object") {
+    Schema schema{
+        {"all types", {
+            {"pk", PropertyType::Int, Property::IsPrimary{true}},
+            {"object", PropertyType::Object|PropertyType::Nullable, "link target"},
+            {"array", PropertyType::Object|PropertyType::Array, "array target"},
+        }},
+        {"link target", ObjectSchema::IsEmbedded{true}, {
+            {"value", PropertyType::Int},
+        }},
+        {"array target", ObjectSchema::IsEmbedded{true}, {
+            {"value", PropertyType::Int},
+        }},
+    };
+    InMemoryTestFile config;
+    config.automatic_change_notifications = false;
+    config.schema_mode = SchemaMode::Automatic;
+    config.schema = schema;
 
-        InMemoryTestFile config;
-        config.automatic_change_notifications = false;
-        config.schema_mode = SchemaMode::Automatic;
-        config.schema = schema;
-        auto realm = Realm::get_shared_realm(config);
-        CppContext ctx(realm);
+    auto realm = Realm::get_shared_realm(config);
+    CppContext ctx(realm);
 
-        auto create = [&](util::Any&& value, CreatePolicy policy = CreatePolicy::UpdateAll) {
-            realm->begin_transaction();
-            auto obj = Object::create(ctx, realm, *realm->schema().find("all types"), value, policy);
-            realm->commit_transaction();
-            return obj;
-        };
+    auto create = [&](util::Any&& value, CreatePolicy policy = CreatePolicy::UpdateAll) {
+        realm->begin_transaction();
+        auto obj = Object::create(ctx, realm, *realm->schema().find("all types"), value, policy);
+        realm->commit_transaction();
+        return obj;
+    };
 
+    SECTION("Basic object creation") {
         auto obj = create(AnyDict{
             {"pk", INT64_C(1)},
             {"object", AnyDict{{"value", INT64_C(10)}}},
             {"array", AnyVector{AnyDict{{"value", INT64_C(20)}}, AnyDict{{"value", INT64_C(30)}}}},
         });
-        // realm->read_group().to_json(std::cout);
 
-        bool obj_callback_called;
-        bool list_callback_called;
+        REQUIRE(obj.obj().get<int64_t>("pk") == 1);
+        auto linked_obj = any_cast<Object>(obj.get_property_value<util::Any>(ctx, "object")).obj();
+        REQUIRE(linked_obj.is_valid());
+        REQUIRE(linked_obj.get<int64_t>("value") == 10);
+        auto list = any_cast<List>(obj.get_property_value<util::Any>(ctx, "array"));
+        REQUIRE(list.size() == 2);
+        REQUIRE(list.get(0).get<int64_t>("value") == 20);
+        REQUIRE(list.get(1).get<int64_t>("value") == 30);
+    }
+
+    SECTION("set_property_value() on link to embedded object") {
+        auto obj = create(AnyDict{
+            {"pk", INT64_C(1)},
+            {"object", AnyDict{{"value", INT64_C(10)}}},
+            {"array", AnyVector{AnyDict{{"value", INT64_C(20)}}, AnyDict{{"value", INT64_C(30)}}}},
+        });
+
+        SECTION("throws when given a managed object") {
+            realm->begin_transaction();
+            REQUIRE_THROWS_WITH(obj.set_property_value(ctx, "object", obj.get_property_value<util::Any>(ctx, "object")),
+                                "Cannot set a link to an existing managed embedded object");
+            realm->cancel_transaction();
+        }
+
+        SECTION("replaces object when given a dictionary and CreatePolicy::UpdateAll") {
+            realm->begin_transaction();
+            auto old_linked = any_cast<Object>(obj.get_property_value<util::Any>(ctx, "object"));
+            obj.set_property_value(ctx, "object", util::Any(AnyDict{{"value", INT64_C(40)}}));
+            auto new_linked = any_cast<Object>(obj.get_property_value<util::Any>(ctx, "object"));
+            REQUIRE_FALSE(old_linked.is_valid());
+            REQUIRE(new_linked.obj().get<int64_t>("value") == 40);
+            realm->cancel_transaction();
+        }
+
+        SECTION("mutates existing object when given a dictionary and CreatePolicy::UpdateModified") {
+            realm->begin_transaction();
+            auto old_linked = any_cast<Object>(obj.get_property_value<util::Any>(ctx, "object"));
+            obj.set_property_value(ctx, "object",
+                                   util::Any(AnyDict{{"value", INT64_C(40)}}),
+                                   CreatePolicy::UpdateModified);
+            auto new_linked = any_cast<Object>(obj.get_property_value<util::Any>(ctx, "object"));
+            REQUIRE(old_linked.is_valid());
+            REQUIRE(old_linked.obj() == new_linked.obj());
+            REQUIRE(new_linked.obj().get<int64_t>("value") == 40);
+            realm->cancel_transaction();
+        }
+
+        SECTION("can set embedded link to null") {
+            realm->begin_transaction();
+            auto old_linked = any_cast<Object>(obj.get_property_value<util::Any>(ctx, "object"));
+            obj.set_property_value(ctx, "object", util::Any());
+            auto new_linked = obj.get_property_value<util::Any>(ctx, "object");
+            REQUIRE_FALSE(old_linked.is_valid());
+            REQUIRE_FALSE(new_linked.has_value());
+            realm->cancel_transaction();
+        }
+    }
+
+    SECTION("set_property_value() on list of embedded objects") {
+        auto obj = create(AnyDict{
+            {"pk", INT64_C(1)},
+            {"array", AnyVector{AnyDict{{"value", INT64_C(1)}}, AnyDict{{"value", INT64_C(2)}}}},
+        });
+        List list(realm, obj.obj().get_linklist("array"));
+        auto obj2 = create(AnyDict{
+            {"pk", INT64_C(2)},
+            {"array", AnyVector{AnyDict{{"value", INT64_C(1)}}, AnyDict{{"value", INT64_C(2)}}}},
+        });
+        List list2(realm, obj2.obj().get_linklist("array"));
+
+        SECTION("throws when given a managed object") {
+            realm->begin_transaction();
+            REQUIRE_THROWS_WITH(obj.set_property_value(ctx, "array", util::Any{AnyVector{list2.get(0)}}),
+                                "Cannot add an existing managed embedded object to a List.");
+            realm->cancel_transaction();
+        }
+
+        SECTION("replaces objects when given a dictionary and CreatePolicy::UpdateAll") {
+            realm->begin_transaction();
+            auto old_obj_1 = list.get(0);
+            auto old_obj_2 = list.get(1);
+            obj.set_property_value(ctx, "array", util::Any(AnyVector{
+                AnyDict{{"value", INT64_C(1)}},
+                AnyDict{{"value", INT64_C(2)}},
+                AnyDict{{"value", INT64_C(3)}}
+            }), CreatePolicy::UpdateAll);
+            REQUIRE(list.size() == 3);
+            REQUIRE_FALSE(old_obj_1.is_valid());
+            REQUIRE_FALSE(old_obj_2.is_valid());
+            REQUIRE(list.get(0).get<int64_t>("value") == 1);
+            REQUIRE(list.get(1).get<int64_t>("value") == 2);
+            REQUIRE(list.get(2).get<int64_t>("value") == 3);
+            realm->cancel_transaction();
+        }
+
+        SECTION("mutates existing objects when given a dictionary and CreatePolicy::UpdateModified") {
+            realm->begin_transaction();
+            auto old_obj_1 = list.get(0);
+            auto old_obj_2 = list.get(1);
+            obj.set_property_value(ctx, "array", util::Any(AnyVector{
+                AnyDict{{"value", INT64_C(1)}},
+                AnyDict{{"value", INT64_C(2)}},
+                AnyDict{{"value", INT64_C(3)}}
+            }), CreatePolicy::UpdateModified);
+            REQUIRE(list.size() == 3);
+            REQUIRE(old_obj_1.is_valid());
+            REQUIRE(old_obj_2.is_valid());
+            REQUIRE(old_obj_1.get<int64_t>("value") == 1);
+            REQUIRE(old_obj_2.get<int64_t>("value") == 2);
+            REQUIRE(list.get(2).get<int64_t>("value") == 3);
+            realm->cancel_transaction();
+        }
+
+        SECTION("clears list when given null") {
+            realm->begin_transaction();
+            obj.set_property_value(ctx, "array", util::Any());
+            REQUIRE(list.size() == 0);
+            realm->cancel_transaction();
+        }
+    }
+
+    SECTION("create with UpdateModified diffs child objects") {
+        auto obj = create(AnyDict{
+            {"pk", INT64_C(1)},
+            {"object", AnyDict{{"value", INT64_C(10)}}},
+            {"array", AnyVector{AnyDict{{"value", INT64_C(20)}}, AnyDict{{"value", INT64_C(30)}}}},
+        });
+
+        auto array_table = realm->read_group().get_table("class_array target");
+        Results result(realm, array_table);
+
+        bool obj_callback_called = false;
         auto token = obj.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
             obj_callback_called = true;
         });
-        auto array_table = realm->read_group().get_table("class_array target");
-        Results result(realm, array_table);
+        bool list_callback_called = false;
         auto token1 = result.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {
             list_callback_called = true;
         });
@@ -1174,6 +1301,7 @@ TEST_CASE("Embedded Object")
         REQUIRE(!obj_callback_called);
         REQUIRE(!list_callback_called);
 
+        // Update with different values
         create(AnyDict{
             {"pk", INT64_C(1)},
             {"array", AnyVector{AnyDict{{"value", INT64_C(40)}}, AnyDict{{"value", INT64_C(50)}}}},
@@ -1184,7 +1312,5 @@ TEST_CASE("Embedded Object")
         advance_and_notify(*realm);
         REQUIRE(!obj_callback_called);
         REQUIRE(list_callback_called);
-
-        // realm->read_group().to_json(std::cout);
     }
 }

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -50,6 +50,23 @@ public:
 };
 }
 
+namespace Catch {
+template<>
+struct StringMaker<realm::util::Any> {
+    static std::string convert(realm::util::Any const& any)
+    {
+        return realm::util::format("Any<%1>", any.type().name());
+    }
+};
+template<>
+struct StringMaker<realm::util::Optional<realm::util::Any>> {
+    static std::string convert(realm::util::Optional<realm::util::Any> any)
+    {
+        return any ? "none" : realm::util::format("some(Any<%1>)", any->type().name());
+    }
+};
+} // namespace Catch
+
 using namespace realm;
 using namespace std::string_literals;
 
@@ -2773,7 +2790,7 @@ struct ResultsFromLinkView {
     }
 };
 
-TEMPLATE_TEST_CASE("results: get()", "", ResultsFromTable, ResultsFromQuery, ResultsFromTableView, ResultsFromLinkView) {
+TEMPLATE_TEST_CASE("results: get<Obj>()", "", ResultsFromTable, ResultsFromQuery, ResultsFromTableView, ResultsFromLinkView) {
     InMemoryTestFile config;
     config.automatic_change_notifications = false;
 
@@ -2818,6 +2835,87 @@ TEMPLATE_TEST_CASE("results: get()", "", ResultsFromTable, ResultsFromQuery, Res
         std::shuffle(std::begin(indexes), std::end(indexes), std::mt19937(rd()));
         for (auto index : indexes)
             CHECK(results.get<Obj>(index).get<int64_t>(col_value) == index);
+    }
+}
+
+TEMPLATE_TEST_CASE("results: accessor interface", "",
+                   ResultsFromTable, ResultsFromQuery, ResultsFromTableView, ResultsFromLinkView) {
+    InMemoryTestFile config;
+    config.automatic_change_notifications = false;
+
+    auto r = Realm::get_shared_realm(config);
+    r->update_schema({
+        {"object", {
+            {"value", PropertyType::Int},
+        }},
+        {"different type", {
+            {"value", PropertyType::Int},
+        }},
+        {"linking_object", {
+            {"link", PropertyType::Array|PropertyType::Object, "object"}
+        }},
+    });
+
+    auto table = r->read_group().get_table("class_object");
+
+    Results empty_results = TestType::call(r, table);
+    CppContext ctx(r, &empty_results.get_object_schema());
+
+    SECTION("no objects") {
+        SECTION("get()") {
+            CHECK_THROWS_WITH(empty_results.get(ctx, 0), "Requested index 0 in empty Results");
+        }
+        SECTION("first()") {
+            CHECK_FALSE(empty_results.first(ctx));
+        }
+        SECTION("last()") {
+            CHECK_FALSE(empty_results.last(ctx));
+        }
+    }
+
+    r->begin_transaction();
+    auto other_obj = r->read_group().get_table("class_different type")->create_object();
+    for (int i = 0; i < 10; ++i)
+        table->create_object().set_all(i);
+    r->commit_transaction();
+
+    Results results = TestType::call(r, table);
+    auto r2 = Realm::get_shared_realm(config);
+
+    SECTION("get()") {
+        for (int i = 0; i < 10; ++i)
+            CHECK(any_cast<Object>(results.get(ctx, i)).get_column_value<int64_t>("value") == i);
+        CHECK_THROWS_WITH(results.get(ctx, 10), "Requested index 10 greater than max 9");
+    }
+
+    SECTION("first()") {
+        CHECK(any_cast<Object>(*results.first(ctx)).get_column_value<int64_t>("value") == 0);
+    }
+
+    SECTION("last()") {
+        CHECK(any_cast<Object>(*results.last(ctx)).get_column_value<int64_t>("value") == 9);
+    }
+
+    SECTION("index_of()") {
+        SECTION("valid") {
+            for (size_t i = 0; i < 10; ++i)
+                REQUIRE(results.index_of(ctx, util::Any(results.get<Obj>(i))) == i);
+        }
+        SECTION("wrong object type") {
+            CHECK_THROWS_WITH(results.index_of(ctx, util::Any(other_obj)),
+                              "Object of type 'different type' does not match Results type 'object'");
+        }
+        SECTION("wrong realm") {
+            auto obj = r2->read_group().get_table("class_object")->get_object(0);
+            CHECK_THROWS_WITH(results.index_of(ctx, util::Any(obj)),
+                              "Object of type 'object' does not match Results type 'object'");
+
+        }
+        SECTION("detached object") {
+            Obj detached_obj;
+            CHECK_THROWS_WITH(results.index_of(ctx, util::Any(detached_obj)),
+                              "Attempting to access an invalid object");
+        }
     }
 }
 
@@ -2962,10 +3060,8 @@ TEMPLATE_TEST_CASE("results: aggregate", "[query][aggregate]", ResultsFromTable,
 }
 
 TEST_CASE("results: set property value on all objects", "[batch_updates]") {
-
     InMemoryTestFile config;
     config.automatic_change_notifications = false;
-    // config.cache = false;
     config.schema = Schema{
         {"AllTypes", {
             {"pk", PropertyType::Int, Property::IsPrimary{true}},

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -62,9 +62,9 @@ struct TestContext : CppContext {
     std::map<std::string, AnyDict> defaults;
 
     using CppContext::CppContext;
-    TestContext(TestContext& parent, realm::Property const& prop)
-            : CppContext(parent, prop)
-            , defaults(parent.defaults)
+    TestContext(TestContext& parent, realm::Obj& obj, realm::Property const& prop)
+    : CppContext(parent, obj, prop)
+    , defaults(parent.defaults)
     { }
 
     void will_change(Object const&, Property const&) {}

--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -57,6 +57,7 @@ struct SchemaChangePrinter {
     REALM_SC_PRINT(AddProperty, v.object, v.property)
     REALM_SC_PRINT(AddTable, v.object)
     REALM_SC_PRINT(RemoveTable, v.object)
+    REALM_SC_PRINT(ChangeTableType, v.object)
     REALM_SC_PRINT(AddInitialProperties, v.object)
     REALM_SC_PRINT(ChangePrimaryKey, v.object, v.property)
     REALM_SC_PRINT(ChangePropertyType, v.object, v.old_property, v.new_property)


### PR DESCRIPTION
Only Object::create() was implemented, and mutating an object or list after creation didn't work. Migrations involving embedded tables didn't work correctly, and some schema validation was missing.

This changes the SDK API for embedded objects a bit. unbox_embedded() and create_embedded_obectj() are gone, and instead the context must implement create_embedded_object(), which uses the object and property passed to the context at construction time. CreatePolicy is now a struct of bools because there's an additional bit of data that needs to be passed along (whether we're in a create operation or add operation) which determines how we handle nested objects which are already managed by the realm (inside create() we copy existing managed embedded objects, but setting a link directly to a managed embedded object throws). Cocoa previously tracked this state externally, but in a way that didn't work for embedded objects.

This depends on a version of core newer than the latest release, so it won't build successfully on CI.

