### PR TITLE
Add auth provider client stubs

### DIFF
--- a/src/sync/app.hpp
+++ b/src/sync/app.hpp
@@ -26,8 +26,6 @@
 namespace realm {
 namespace app {
 
-#pragma mark App
-
 /**
  The `App` has the fundamental set of methods for communicating with a MongoDB Realm application backend.
 
@@ -62,11 +60,11 @@ public:
     */
     struct UserAPIKey {
         // The ID of the key.
-        realm::ObjectId id;
+        ObjectId id;
 
         // The actual key. Will only be included in
         // the response when an API key is first created.
-        std::string key;
+        Optional<std::string> key;
 
         // The name of the key.
         std::string name;
@@ -90,7 +88,7 @@ public:
          *     - completion_block: A callback to be invoked once the call is complete.
         */
         void create_api_key(const std::string& name,
-                            std::function<void(std::shared_ptr<UserAPIKey>, Optional<AppError>)> completion_block);
+                            std::function<void(UserAPIKey, Optional<AppError>)> completion_block);
 
         /**
          * Fetches a user API key associated with the current user.
@@ -99,8 +97,8 @@ public:
          *     - id: The id of the API key to fetch.
          *     - completion_block: A callback to be invoked once the call is complete.
          */
-        void fetch_api_key(const realm::ObjectId& id,
-                           std::function<void(std::shared_ptr<UserAPIKey>, Optional<AppError>)> completion_block);
+        void fetch_api_key(const ObjectId& id,
+                           std::function<void(UserAPIKey, Optional<AppError>)> completion_block);
 
         /**
          * Fetches the user API keys associated with the current user.
@@ -108,7 +106,7 @@ public:
          * - parameters:
          *     - completion_block: A callback to be invoked once the call is complete.
          */
-        void fetch_api_keys(std::function<void(std::vector<UserAPIKey>, Optional<AppError>)> completion_block);
+        void fetch_api_keys(std::function<void(UserAPIKey, Optional<AppError>)> completion_block);
 
         /**
          * Deletes a user API key associated with the current user.
@@ -117,7 +115,7 @@ public:
          *     - id: The id of the API key to delete.
          *     - completion_block: A callback to be invoked once the call is complete.
          */
-        void delete_api_key(const realm::ObjectId& id,
+        void delete_api_key(const ObjectId& id,
                             std::function<void(Optional<AppError>)> completion_block);
 
         /**
@@ -127,7 +125,7 @@ public:
          *     - id: The id of the API key to enable.
          *     - completion_block: A callback to be invoked once the call is complete.
          */
-        void enable_api_key(const realm::ObjectId& id,
+        void enable_api_key(const ObjectId& id,
                             std::function<void(Optional<AppError>)> completion_block);
 
         /**
@@ -137,10 +135,10 @@ public:
          *     - id: The id of the API key to disable.
          *     - completion_block: A callback to be invoked once the call is complete.
          */
-        void disable_api_key(const realm::ObjectId& id,
+        void disable_api_key(const ObjectId& id,
                              std::function<void(Optional<AppError>)> completion_block);
     private:
-        UserAPIKeyProviderClient(std::weak_ptr<App>);
+        UserAPIKeyProviderClient(App*);
     };
 
     /**
@@ -229,7 +227,7 @@ public:
                                           const std::string& args,
                                           std::function<void(Optional<AppError>)> completion_block);
     private:
-        UsernamePasswordProviderClient(std::weak_ptr<App>);
+        UsernamePasswordProviderClient(App*);
     };
 
     App(const Config& config);

--- a/src/sync/app.hpp
+++ b/src/sync/app.hpp
@@ -26,11 +26,10 @@
 namespace realm {
 namespace app {
 
-#pragma mark RealmApp
+#pragma mark App
 
 /**
- The `RealmApp` has the fundamental set of methods for communicating with a MongoDB
- Realm application backend.
+ The `App` has the fundamental set of methods for communicating with a MongoDB Realm application backend.
 
  This class provides access to login and authentication.
 
@@ -58,6 +57,181 @@ public:
         realm::util::Optional<uint64_t> default_request_timeout_ms;
     };
 
+    /**
+     * A struct representing a user API key as returned by the App server.
+    */
+    struct UserAPIKey {
+        // The ID of the key.
+        realm::ObjectId id;
+
+        // The actual key. Will only be included in
+        // the response when an API key is first created.
+        std::string key;
+
+        // The name of the key.
+        std::string name;
+
+        // Whether or not the key is disabled.
+        bool disabled;
+    };
+
+    /**
+     * A client for the user API key authentication provider which
+     * can be used to create and modify user API keys. This
+     * client should only be used by an authenticated user.
+    */
+    class UserAPIKeyProviderClient {
+    public:
+        /**
+         * Creates a user API key that can be used to authenticate as the current user.
+         *
+         * - parameters:
+         *     - name: The name of the API key to be created.
+         *     - completion_block: A callback to be invoked once the call is complete.
+        */
+        void create_api_key(const std::string& name,
+                            std::function<void(std::shared_ptr<UserAPIKey>, Optional<AppError>)> completion_block);
+
+        /**
+         * Fetches a user API key associated with the current user.
+         *
+         * - parameters:
+         *     - id: The id of the API key to fetch.
+         *     - completion_block: A callback to be invoked once the call is complete.
+         */
+        void fetch_api_key(const realm::ObjectId& id,
+                           std::function<void(std::shared_ptr<UserAPIKey>, Optional<AppError>)> completion_block);
+
+        /**
+         * Fetches the user API keys associated with the current user.
+         *
+         * - parameters:
+         *     - completion_block: A callback to be invoked once the call is complete.
+         */
+        void fetch_api_keys(std::function<void(std::vector<UserAPIKey>, Optional<AppError>)> completion_block);
+
+        /**
+         * Deletes a user API key associated with the current user.
+         *
+         * - parameters:
+         *     - id: The id of the API key to delete.
+         *     - completion_block: A callback to be invoked once the call is complete.
+         */
+        void delete_api_key(const realm::ObjectId& id,
+                            std::function<void(Optional<AppError>)> completion_block);
+
+        /**
+         * Enables a user API key associated with the current user.
+         *
+         * - parameters:
+         *     - id: The id of the API key to enable.
+         *     - completion_block: A callback to be invoked once the call is complete.
+         */
+        void enable_api_key(const realm::ObjectId& id,
+                            std::function<void(Optional<AppError>)> completion_block);
+
+        /**
+         * Disables a user API key associated with the current user.
+         *
+         * - parameters:
+         *     - id: The id of the API key to disable.
+         *     - completion_block: A callback to be invoked once the call is complete.
+         */
+        void disable_api_key(const realm::ObjectId& id,
+                             std::function<void(Optional<AppError>)> completion_block);
+    private:
+        UserAPIKeyProviderClient(std::weak_ptr<App>);
+    };
+
+    /**
+     * A client for the username/password authentication provider which
+     * can be used to obtain a credential for logging in,
+     * and to perform requests specifically related to the username/password provider.
+    */
+    class UsernamePasswordProviderClient {
+    public:
+        /**
+         * Registers a new email identity with the username/password provider,
+         * and sends a confirmation email to the provided address.
+         *
+         * - parameters:
+         *     - email: The email address of the user to register.
+         *     - password: The password that the user created for the new username/password identity.
+         *     - completion_block: A callback to be invoked once the call is complete.
+         */
+        void register_email(const std::string& email,
+                            const std::string& password,
+                            std::function<void(Optional<AppError>)> completion_block);
+
+        /**
+         * Confirms an email identity with the username/password provider.
+         *
+         * - parameters:
+         *     - token: The confirmation token that was emailed to the user.
+         *     - token_id: The confirmation token id that was emailed to the user.
+         *     - completion_block: A callback to be invoked once the call is complete.
+         */
+        void confirm_user(const std::string& token,
+                          const std::string& token_id,
+                          std::function<void(Optional<AppError>)> completion_block);
+
+        /**
+         * Re-sends a confirmation email to a user that has registered but
+         * not yet confirmed their email address.
+         *
+         * - parameters:
+         *     - email: The email address of the user to re-send a confirmation for.
+         *     - completion_block: A callback to be invoked once the call is complete.
+         */
+        void resend_confirmation_email(const std::string& email,
+                                       std::function<void(Optional<AppError>)> completion_block);
+
+        /**
+         * Sends a password reset email to the given email address.
+         *
+         * - parameters:
+         *     - email: The email address of the user to send a password reset email for.
+         *     - completion_block: A callback to be invoked once the call is complete.
+         */
+        void send_reset_password_email(const std::string& email,
+                                       std::function<void(Optional<AppError>)> completion_block);
+
+        /**
+         * Resets the password of an email identity using the
+         * password reset token emailed to a user.
+         *
+         * - parameters:
+         *     - password: The desired new password.
+         *     - token: The password reset token that was emailed to the user.
+         *     - token_id: The password reset token id that was emailed to the user.
+         *     - completion_block: A callback to be invoked once the call is complete.
+         */
+        void reset_password(const std::string& password,
+                            const std::string& token,
+                            const std::string& token_id,
+                            std::function<void(Optional<AppError>)> completion_block);
+
+        /**
+         * Resets the password of an email identity using the
+         * password reset function set up in the application.
+         *
+         * TODO: Add an overloaded version of this method that takes
+         * TODO: raw, non-serialized args.
+         *
+         * - parameters:
+         *     - email: The email address of the user.
+         *     - password: The desired new password.
+         *     - args: A pre-serialized list of arguments. Must be a JSON array.
+         *     - completion_block: A callback to be invoked once the call is complete.
+        */
+        void call_reset_password_function(const std::string& email,
+                                          const std::string& password,
+                                          const std::string& args,
+                                          std::function<void(Optional<AppError>)> completion_block);
+    private:
+        UsernamePasswordProviderClient(std::weak_ptr<App>);
+    };
+
     App(const Config& config);
 
     /**
@@ -74,6 +248,13 @@ public:
     void login_with_credentials(const AppCredentials& credentials,
                                 std::function<void(std::shared_ptr<SyncUser>, Optional<AppError>)> completion_block);
 
+    // Get a provider client for the given class type.
+    template <class T>
+    T provider_client();
+    template<>
+    UserAPIKeyProviderClient provider_client();
+    template<>
+    UsernamePasswordProviderClient provider_client();
 private:
     Config m_config;
     std::string m_base_route;

--- a/src/sync/app.hpp
+++ b/src/sync/app.hpp
@@ -88,7 +88,7 @@ public:
          *     - completion_block: A callback to be invoked once the call is complete.
         */
         void create_api_key(const std::string& name,
-                            std::function<void(UserAPIKey, Optional<AppError>)> completion_block);
+                            std::function<void(Optional<UserAPIKey>, Optional<AppError>)> completion_block);
 
         /**
          * Fetches a user API key associated with the current user.
@@ -97,8 +97,8 @@ public:
          *     - id: The id of the API key to fetch.
          *     - completion_block: A callback to be invoked once the call is complete.
          */
-        void fetch_api_key(const ObjectId& id,
-                           std::function<void(UserAPIKey, Optional<AppError>)> completion_block);
+        void fetch_api_key(const UserAPIKey& api_key,
+                           std::function<void(Optional<UserAPIKey>, Optional<AppError>)> completion_block);
 
         /**
          * Fetches the user API keys associated with the current user.
@@ -106,7 +106,7 @@ public:
          * - parameters:
          *     - completion_block: A callback to be invoked once the call is complete.
          */
-        void fetch_api_keys(std::function<void(UserAPIKey, Optional<AppError>)> completion_block);
+        void fetch_api_keys(std::function<void(std::vector<UserAPIKey>, Optional<AppError>)> completion_block);
 
         /**
          * Deletes a user API key associated with the current user.
@@ -115,7 +115,7 @@ public:
          *     - id: The id of the API key to delete.
          *     - completion_block: A callback to be invoked once the call is complete.
          */
-        void delete_api_key(const ObjectId& id,
+        void delete_api_key(const UserAPIKey& api_key,
                             std::function<void(Optional<AppError>)> completion_block);
 
         /**
@@ -125,7 +125,7 @@ public:
          *     - id: The id of the API key to enable.
          *     - completion_block: A callback to be invoked once the call is complete.
          */
-        void enable_api_key(const ObjectId& id,
+        void enable_api_key(const UserAPIKey& api_key,
                             std::function<void(Optional<AppError>)> completion_block);
 
         /**
@@ -135,7 +135,7 @@ public:
          *     - id: The id of the API key to disable.
          *     - completion_block: A callback to be invoked once the call is complete.
          */
-        void disable_api_key(const ObjectId& id,
+        void disable_api_key(const UserAPIKey& api_key,
                              std::function<void(Optional<AppError>)> completion_block);
     private:
         UserAPIKeyProviderClient(App*);


### PR DESCRIPTION
Adds a series of structs and definitions that will allow a user to use functionality based on specific providers that allow it. The two providers that Stitch currently has additional functionality for are:
- `UserAPIKey`
- `UsernamePassword`

See: [CoreUserAPIKeyAuthProviderClient.swift](https://github.com/mongodb/stitch-ios-sdk/blob/master/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Providers/UserAPIKey/CoreUserAPIKeyAuthProviderClient.swift)
See: [CoreUserPasswordAuthProviderClient.swift](https://github.com/mongodb/stitch-ios-sdk/blob/master/Core/StitchCoreSDK/Sources/StitchCoreSDK/Auth/Providers/UserPassword/CoreUserPasswordAuthProviderClient.swift)

Bindings would call this as: 
```cpp
app.provider_client<UsernamePasswordProviderClient>().register_email(
    "bar@foo.com",
    "password", 
    [=](Optional<AppError> error) {
        if (error) {
            ...
        }
    }
);
```
The main purpose of this substructure is to declutter the App namespace from functionality that only certain users will need.

`TODO`: The actual method impls. The reason I have only stubbed these out is so the rest of the work can be parallelised.