### PR TITLE
Pass shared pointer (for sync user) by value in log_in

### DIFF
--- a/src/sync/app.cpp
+++ b/src/sync/app.cpp
@@ -524,7 +524,7 @@ void App::log_in_with_credentials(const AppCredentials& credentials,
                 { "Authorization", bearer }
             },
             std::string()
-        }, [completion_block, &sync_user](const Response& profile_response) {
+        }, [completion_block, sync_user](const Response& profile_response) {
             if (auto error = check_for_errors(profile_response)) {
                 return completion_block(nullptr, error);
             }


### PR DESCRIPTION
This should fix the segfault in JS.