### PR TITLE
Add support for logging specific user out

### DIFF
--- a/src/sync/app.cpp
+++ b/src/sync/app.cpp
@@ -586,10 +586,9 @@ void App::log_in_with_credentials(const AppCredentials& credentials,
     }, handler);
 }
 
-void App::log_out(std::function<void (Optional<AppError>)> completion_block) const
+void App::log_out(std::shared_ptr<SyncUser> user, std::function<void (Optional<AppError>)> completion_block) const
 {
-    auto user = current_user();
-    if (!user) {
+    if (!user || user->state() != SyncUser::State::Active) {
         return completion_block(util::none);
     }
     std::string bearer = util::format("Bearer %1", current_user()->refresh_token());
@@ -615,6 +614,10 @@ void App::log_out(std::function<void (Optional<AppError>)> completion_block) con
         },
         ""
     }, handler);
+}
+
+void App::log_out(std::function<void (Optional<AppError>)> completion_block) const {
+    log_out(current_user(), completion_block);
 }
 
 } // namespace app

--- a/src/sync/app.hpp
+++ b/src/sync/app.hpp
@@ -261,9 +261,14 @@ public:
                                  std::function<void(std::shared_ptr<SyncUser>, Optional<AppError>)> completion_block) const;
 
     /**
-     Logout the current user.
+     * Log out the current user.
      */
     void log_out(std::function<void(Optional<AppError>)>) const;
+
+    /**
+     * Log out the given user if they are not already logged out.
+     */
+    void log_out(std::shared_ptr<SyncUser> user, std::function<void(Optional<AppError>)> completion_block) const;
 
     // Get a provider client for the given class type.
     template <class T>

--- a/tests/sync/app.cpp
+++ b/tests/sync/app.cpp
@@ -913,6 +913,35 @@ TEST_CASE("app: user_semantics", "[app]") {
         CHECK(app.all_users().size() == 1);
         CHECK(app.all_users()[0]->state() == SyncUser::State::Active);
     }
+
+    SECTION("logout user") {
+        auto user1 = login_user_email_pass();
+        auto user2 = login_user_anonymous();
+
+        // Anonymous users are special
+        app.log_out(user2, [](Optional<AppError> error) {
+            CHECK(!error);
+        });
+        CHECK(user2->state() == SyncUser::State::Error);
+
+        // Other users can be LoggedOut
+        app.log_out(user1, [](Optional<AppError> error) {
+            CHECK(!error);
+        });
+        CHECK(user1->state() == SyncUser::State::LoggedOut);
+
+        // Logging out already logged out users, does nothing
+        app.log_out(user1, [](Optional<AppError> error) {
+            CHECK(!error);
+        });
+        CHECK(user1->state() == SyncUser::State::LoggedOut);
+
+        app.log_out(user2, [](Optional<AppError> error) {
+            CHECK(!error);
+        });
+        CHECK(user1->state() == SyncUser::State::Error);
+
+    }
 }
 
 struct ErrorCheckingTransport : public GenericNetworkTransport {

--- a/tests/sync/app.cpp
+++ b/tests/sync/app.cpp
@@ -939,8 +939,7 @@ TEST_CASE("app: user_semantics", "[app]") {
         app.log_out(user2, [](Optional<AppError> error) {
             CHECK(!error);
         });
-        CHECK(user1->state() == SyncUser::State::Error);
-
+        CHECK(user2->state() == SyncUser::State::Error);
     }
 }
 


### PR DESCRIPTION
This PR adds support for logging individual users out instead of only the current user.


Note: Does not run the tests until Authentication tests are enabled.