### PR TITLE
Fix cobertura coverage reports

### DIFF
--- a/CMake/CodeCoverage.cmake
+++ b/CMake/CodeCoverage.cmake
@@ -49,7 +49,7 @@ if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
 
     add_custom_target(${targetname}-cobertura
       COMMAND ${testrunner}
-      COMMAND ${GCOVR_PATH} -x --verbose -o coverage.xml -f 'src/.*' -f "${CMAKE_SOURCE_DIR}/src.*" --exclude-directories "${CMAKE_BINARY_DIR}/tests" --exclude-directories="${CMAKE_SOURCE_DIR}/\.tmp" --exclude ".*realm\-core.*" --exclude ".*realm\-sync.*"
+      COMMAND ${GCOVR_PATH} -x -o coverage.xml -f 'src/.*' -f "${CMAKE_SOURCE_DIR}/src.*" --exclude-directories "${CMAKE_BINARY_DIR}/tests" --exclude-directories="${CMAKE_SOURCE_DIR}/\.tmp" --exclude ".*realm\-core.*" --exclude ".*realm\-sync.*"
       COMMAND echo Code coverage report written to coverage.xml
 
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}

--- a/CMake/CodeCoverage.cmake
+++ b/CMake/CodeCoverage.cmake
@@ -20,8 +20,7 @@ find_program(LCOV_PATH lcov)
 find_program(GENHTML_PATH genhtml)
 find_program(GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/tests)
 
-set(CMAKE_CXX_FLAGS_COVERAGE "-g -O0 -fprofile-arcs -ftest-coverage -DCATCH_CONFIG_FAST_COMPILE"
-    CACHE STRING "Flags used by the C++ compiler during coverage builds.")
+set(CMAKE_CXX_FLAGS_COVERAGE "-g -O0 -fprofile-arcs -ftest-coverage -DCATCH_CONFIG_FAST_COMPILE")
 mark_as_advanced(CMAKE_CXX_FLAGS_COVERAGE)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
@@ -50,7 +49,7 @@ if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
 
     add_custom_target(${targetname}-cobertura
       COMMAND ${testrunner}
-      COMMAND ${GCOVR_PATH} -x -r ${CMAKE_SOURCE_DIR}/src ./src -o coverage.xml
+      COMMAND ${GCOVR_PATH} -x --verbose -o coverage.xml -f 'src/.*' -f "${CMAKE_SOURCE_DIR}/src.*" --exclude-directories "${CMAKE_BINARY_DIR}/tests" --exclude-directories="${CMAKE_SOURCE_DIR}/\.tmp" --exclude ".*realm\-core.*" --exclude ".*realm\-sync.*" --root "${CMAKE_SOURCE_DIR}"
       COMMAND echo Code coverage report written to coverage.xml
 
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}

--- a/CMake/CodeCoverage.cmake
+++ b/CMake/CodeCoverage.cmake
@@ -49,7 +49,7 @@ if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
 
     add_custom_target(${targetname}-cobertura
       COMMAND ${testrunner}
-      COMMAND ${GCOVR_PATH} -x --verbose -o coverage.xml -f 'src/.*' -f "${CMAKE_SOURCE_DIR}/src.*" --exclude-directories "${CMAKE_BINARY_DIR}/tests" --exclude-directories="${CMAKE_SOURCE_DIR}/\.tmp" --exclude ".*realm\-core.*" --exclude ".*realm\-sync.*" --root "${CMAKE_SOURCE_DIR}"
+      COMMAND ${GCOVR_PATH} -x --verbose -o coverage.xml -f 'src/.*' -f "${CMAKE_SOURCE_DIR}/src.*" --exclude-directories "${CMAKE_BINARY_DIR}/tests" --exclude-directories="${CMAKE_SOURCE_DIR}/\.tmp" --exclude ".*realm\-core.*" --exclude ".*realm\-sync.*"
       COMMAND echo Code coverage report written to coverage.xml
 
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}


### PR DESCRIPTION
Previously, the report was empty. This gets it working again, even linking properly to source files so you don't have to run coverage builds locally to see what is missing test coverage. The Jenkins Cobertura plugin tracks coverage over time as well so we can see trends. Current coverage:

<img width="591" alt="Screen Shot 2020-03-18 at 7 22 51 PM" src="https://user-images.githubusercontent.com/2826060/77025430-5012db00-694e-11ea-9523-287679ee4f4d.png">
