### PR TITLE
UserAPIKeyProviderClient methods operate on a user

### DIFF
--- a/src/sync/app.hpp
+++ b/src/sync/app.hpp
@@ -99,7 +99,7 @@ public:
          *     - name: The name of the API key to be created.
          *     - completion_block: A callback to be invoked once the call is complete.
         */
-        void create_api_key(const std::string& name,
+        void create_api_key(const std::string& name, std::shared_ptr<SyncUser> user,
                             std::function<void(Optional<UserAPIKey>, Optional<AppError>)> completion_block);
 
         /**
@@ -109,7 +109,7 @@ public:
          *     - id: The id of the API key to fetch.
          *     - completion_block: A callback to be invoked once the call is complete.
          */
-        void fetch_api_key(const realm::ObjectId& id,
+        void fetch_api_key(const realm::ObjectId& id, std::shared_ptr<SyncUser> user,
                            std::function<void(Optional<UserAPIKey>, Optional<AppError>)> completion_block);
 
         /**
@@ -118,7 +118,8 @@ public:
          * - parameters:
          *     - completion_block: A callback to be invoked once the call is complete.
          */
-        void fetch_api_keys(std::function<void(std::vector<UserAPIKey>, Optional<AppError>)> completion_block);
+        void fetch_api_keys(std::shared_ptr<SyncUser> user,
+                            std::function<void(std::vector<UserAPIKey>, Optional<AppError>)> completion_block);
 
         /**
          * Deletes a user API key associated with the current user.
@@ -127,7 +128,7 @@ public:
          *     - id: The id of the API key to delete.
          *     - completion_block: A callback to be invoked once the call is complete.
          */
-        void delete_api_key(const UserAPIKey& api_key,
+        void delete_api_key(const UserAPIKey& api_key, std::shared_ptr<SyncUser> user,
                             std::function<void(Optional<AppError>)> completion_block);
 
         /**
@@ -137,7 +138,7 @@ public:
          *     - id: The id of the API key to enable.
          *     - completion_block: A callback to be invoked once the call is complete.
          */
-        void enable_api_key(const UserAPIKey& api_key,
+        void enable_api_key(const UserAPIKey& api_key, std::shared_ptr<SyncUser> user,
                             std::function<void(Optional<AppError>)> completion_block);
 
         /**
@@ -147,12 +148,16 @@ public:
          *     - id: The id of the API key to disable.
          *     - completion_block: A callback to be invoked once the call is complete.
          */
-        void disable_api_key(const UserAPIKey& api_key,
+        void disable_api_key(const UserAPIKey& api_key, std::shared_ptr<SyncUser> user,
                              std::function<void(Optional<AppError>)> completion_block);
     private:
         friend class App;
-        UserAPIKeyProviderClient(App* app) : parent(app) {}
-        App* parent;
+        UserAPIKeyProviderClient(App* app)
+        : m_parent(app)
+        {
+            REALM_ASSERT(app);
+        }
+        App* m_parent;
     };
 
     /**
@@ -242,8 +247,12 @@ public:
                                           std::function<void(Optional<AppError>)> completion_block);
     private:
         friend class App;
-        UsernamePasswordProviderClient(App* app) : parent(app) {}
-        App* parent;
+        UsernamePasswordProviderClient(App* app)
+        : m_parent(app)
+        {
+            REALM_ASSERT(app);
+        }
+        App* m_parent;
     };
 
     /**
@@ -285,9 +294,9 @@ private:
 };
 
 template<>
-App::UsernamePasswordProviderClient App::provider_client <App::UsernamePasswordProviderClient> ();
+App::UsernamePasswordProviderClient App::provider_client<App::UsernamePasswordProviderClient>();
 template<>
-App::UserAPIKeyProviderClient App::provider_client <App::UserAPIKeyProviderClient>();
+App::UserAPIKeyProviderClient App::provider_client<App::UserAPIKeyProviderClient>();
 
 } // namespace app
 } // namespace realm

--- a/tests/sync/app.cpp
+++ b/tests/sync/app.cpp
@@ -403,9 +403,6 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
 // MARK: - UserAPIKeyProviderClient Tests
 
 TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
-    auto email = util::format("realm_tests_do_autoverify%1@%2.com", random_string(10), random_string(10));
-    auto password = util::format("%1", random_string(15));
-    auto api_key_name = util::format("%1", random_string(15));
 
     std::unique_ptr<GenericNetworkTransport> (*factory)() = []{
         return std::unique_ptr<GenericNetworkTransport>(new IntTestTransport);
@@ -422,90 +419,101 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
 
     bool processed = false;
 
-    app.provider_client<App::UsernamePasswordProviderClient>()
-        .register_email(email,
-            password,
-            [&](Optional<app::AppError> error) {
-                CHECK(!error); // first registration should succeed
-                if (error) {
-                    std::cout << "register failed for email: " << email << " pw: " << password << " message: " << error->error_code.message() << "+" << error->message << std::endl;
-                }
+    auto register_and_log_in_user = [&]() -> std::shared_ptr<SyncUser> {
+        auto email = util::format("realm_tests_do_autoverify%1@%2.com", random_string(10), random_string(10));
+        auto password = util::format("%1", random_string(15));
+        app.provider_client<App::UsernamePasswordProviderClient>()
+            .register_email(email,
+                password,
+                [&](Optional<app::AppError> error) {
+                    CHECK(!error); // first registration should succeed
+                    if (error) {
+                        std::cout << "register failed for email: " << email << " pw: " << password << " message: " << error->error_code.message() << "+" << error->message << std::endl;
+                    }
+                });
+        std::shared_ptr<SyncUser> logged_in_user;
+        app.log_in_with_credentials(realm::app::AppCredentials::username_password(email, password),
+            [&](std::shared_ptr<realm::SyncUser> user, Optional<app::AppError> error) {
+                REQUIRE(user);
+                CHECK(!error);
+                logged_in_user = user;
+                processed = true;
             });
-
-    app.log_in_with_credentials(realm::app::AppCredentials::username_password(email, password),
-        [&](std::shared_ptr<realm::SyncUser> user, Optional<app::AppError> error) {
-            REQUIRE(user);
-            CHECK(!error);
-            processed = true;
-        });
-    CHECK(processed);
-    processed = false;
+        CHECK(processed);
+        processed = false;
+        return logged_in_user;
+    };
 
     App::UserAPIKey api_key;
 
     SECTION("api-key") {
+        std::shared_ptr<SyncUser> logged_in_user = register_and_log_in_user();
+        auto api_key_name = util::format("%1", random_string(15));
         app.provider_client<App::UserAPIKeyProviderClient>()
-            .create_api_key(api_key_name, [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
+            .create_api_key(api_key_name, logged_in_user,
+                            [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
                 CHECK(!error);
                 REQUIRE(bool(user_api_key));
                 CHECK(user_api_key->name == api_key_name);
-                CHECK(user_api_key->id.to_string() == user_api_key->id.to_string());
                 api_key = user_api_key.value();
         });
 
         app.provider_client<App::UserAPIKeyProviderClient>()
-            .fetch_api_key(api_key.id, [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
+            .fetch_api_key(api_key.id, logged_in_user,
+                           [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
                 CHECK(!error);
                 REQUIRE(bool(user_api_key));
                 CHECK(user_api_key->name == api_key_name);
-                CHECK(user_api_key->id.to_string() == user_api_key->id.to_string());
+                CHECK(user_api_key->id == api_key.id);
         });
 
         app.provider_client<App::UserAPIKeyProviderClient>()
-            .fetch_api_keys([&](std::vector<App::UserAPIKey> api_keys, Optional<AppError> error) {
+            .fetch_api_keys(logged_in_user,
+                            [&](std::vector<App::UserAPIKey> api_keys, Optional<AppError> error) {
                 CHECK(api_keys.size() == 1);
-                for(auto api_key : api_keys) {
-                    CHECK(api_key.id.to_string() == api_key.id.to_string());
+                for(auto key : api_keys) {
+                    CHECK(key.id.to_string() == api_key.id.to_string());
                     CHECK(api_key.name == api_key_name);
+                    CHECK(key.id == api_key.id);
                 }
                 CHECK(!error);
         });
 
         app.provider_client<App::UserAPIKeyProviderClient>()
-            .enable_api_key(api_key, [&](Optional<AppError> error) {
+            .enable_api_key(api_key, logged_in_user, [&](Optional<AppError> error) {
                 CHECK(!error);
         });
 
         app.provider_client<App::UserAPIKeyProviderClient>()
-            .fetch_api_key(api_key.id, [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
+            .fetch_api_key(api_key.id, logged_in_user,
+                           [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
                 CHECK(!error);
                 REQUIRE(bool(user_api_key));
                 CHECK(user_api_key->disabled == false);
                 CHECK(user_api_key->name == api_key_name);
-                CHECK(user_api_key->id.to_string() == user_api_key->id.to_string());
+                CHECK(user_api_key->id == api_key.id);
         });
 
         app.provider_client<App::UserAPIKeyProviderClient>()
-            .disable_api_key(api_key, [&](Optional<AppError> error) {
+            .disable_api_key(api_key, logged_in_user, [&](Optional<AppError> error) {
                 CHECK(!error);
         });
 
         app.provider_client<App::UserAPIKeyProviderClient>()
-            .fetch_api_key(api_key.id, [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
+            .fetch_api_key(api_key.id, logged_in_user, [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
                 CHECK(!error);
                 REQUIRE(bool(user_api_key));
                 CHECK(user_api_key->disabled == true);
                 CHECK(user_api_key->name == api_key_name);
-                CHECK(user_api_key->id.to_string() == user_api_key->id.to_string());
         });
 
         app.provider_client<App::UserAPIKeyProviderClient>()
-            .delete_api_key(api_key, [&](Optional<AppError> error) {
+            .delete_api_key(api_key, logged_in_user, [&](Optional<AppError> error) {
                 CHECK(!error);
         });
 
         app.provider_client<App::UserAPIKeyProviderClient>()
-            .fetch_api_key(api_key.id, [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
+            .fetch_api_key(api_key.id, logged_in_user, [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
                 CHECK(!user_api_key);
                 CHECK(error);
                 processed = true;
@@ -513,6 +521,224 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
 
         CHECK(processed);
     }
+
+    SECTION("api-key without a user") {
+        std::shared_ptr<SyncUser> no_user = nullptr;
+        auto api_key_name = util::format("%1", random_string(15));
+        app.provider_client<App::UserAPIKeyProviderClient>()
+            .create_api_key(api_key_name, no_user,
+                            [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
+                                REQUIRE(error);
+                                CHECK(error->is_service_error());
+                                CHECK(error->message == "must authenticate first");
+                                CHECK(!bool(user_api_key));
+                            });
+
+        app.provider_client<App::UserAPIKeyProviderClient>()
+            .fetch_api_key(api_key.id, no_user,
+                           [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
+                               REQUIRE(error);
+                               CHECK(error->is_service_error());
+                               CHECK(error->message == "must authenticate first");
+                               CHECK(!bool(user_api_key));
+                           });
+
+        app.provider_client<App::UserAPIKeyProviderClient>()
+            .fetch_api_keys(no_user,
+                            [&](std::vector<App::UserAPIKey> api_keys, Optional<AppError> error) {
+                                REQUIRE(error);
+                                CHECK(error->is_service_error());
+                                CHECK(error->message == "must authenticate first");
+                                CHECK(api_keys.size() == 0);
+                            });
+
+        app.provider_client<App::UserAPIKeyProviderClient>()
+            .enable_api_key(api_key, no_user,
+                            [&](Optional<AppError> error) {
+                                REQUIRE(error);
+                                CHECK(error->is_service_error());
+                                CHECK(error->message == "must authenticate first");
+                            });
+
+        app.provider_client<App::UserAPIKeyProviderClient>()
+            .fetch_api_key(api_key.id, no_user,
+                           [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
+                               REQUIRE(error);
+                               CHECK(error->is_service_error());
+                               CHECK(error->message == "must authenticate first");
+                               CHECK(!bool(user_api_key));
+                           });
+
+        app.provider_client<App::UserAPIKeyProviderClient>()
+            .disable_api_key(api_key, no_user,
+                             [&](Optional<AppError> error) {
+                                 REQUIRE(error);
+                                 CHECK(error->is_service_error());
+                                 CHECK(error->message == "must authenticate first");
+                             });
+
+        app.provider_client<App::UserAPIKeyProviderClient>()
+            .fetch_api_key(api_key.id, no_user,
+                           [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
+                               REQUIRE(error);
+                               CHECK(error->is_service_error());
+                               CHECK(error->message == "must authenticate first");
+                               CHECK(!bool(user_api_key));
+                           });
+
+        app.provider_client<App::UserAPIKeyProviderClient>()
+            .delete_api_key(api_key, no_user,
+                            [&](Optional<AppError> error) {
+                                REQUIRE(error);
+                                CHECK(error->is_service_error());
+                                CHECK(error->message == "must authenticate first");
+                            });
+
+        app.provider_client<App::UserAPIKeyProviderClient>()
+            .fetch_api_key(api_key.id, no_user,
+                           [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
+                               CHECK(!user_api_key);
+                               REQUIRE(error);
+                               CHECK(error->is_service_error());
+                               CHECK(error->message == "must authenticate first");
+                               processed = true;
+                           });
+        CHECK(processed);
+    }
+
+    SECTION("api-key against the wrong user") {
+        std::shared_ptr<SyncUser> first_user = register_and_log_in_user();
+        std::shared_ptr<SyncUser> second_user = register_and_log_in_user();
+        auto api_key_name = util::format("%1", random_string(15));
+        App::UserAPIKey api_key;
+        App::UserAPIKeyProviderClient provider = app.provider_client<App::UserAPIKeyProviderClient>();
+
+        provider.create_api_key(api_key_name, first_user,
+                        [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
+                            CHECK(!error);
+                            REQUIRE(bool(user_api_key));
+                            CHECK(user_api_key->name == api_key_name);
+                            api_key = user_api_key.value();
+                        });
+
+        provider.fetch_api_key(api_key.id, first_user,
+                       [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
+                           CHECK(!error);
+                           REQUIRE(bool(user_api_key));
+                           CHECK(user_api_key->name == api_key_name);
+                           CHECK(user_api_key->id.to_string() == user_api_key->id.to_string());
+                       });
+
+        provider.fetch_api_key(api_key.id, second_user,
+                       [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
+                           REQUIRE(error);
+                           CHECK(error->message == "API key not found");
+                           CHECK(error->is_service_error());
+                           CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::api_key_not_found);
+                           REQUIRE(!bool(user_api_key));
+                       });
+
+        provider.fetch_api_keys(first_user,
+                        [&](std::vector<App::UserAPIKey> api_keys, Optional<AppError> error) {
+                            CHECK(api_keys.size() == 1);
+                            for(auto api_key : api_keys) {
+                                CHECK(api_key.name == api_key_name);
+                            }
+                            CHECK(!error);
+                        });
+
+        provider.fetch_api_keys(second_user,
+                                [&](std::vector<App::UserAPIKey> api_keys, Optional<AppError> error) {
+                                    CHECK(api_keys.size() == 0);
+                                    CHECK(!error);
+                                });
+
+        provider.enable_api_key(api_key, first_user, [&](Optional<AppError> error) {
+            CHECK(!error);
+        });
+
+        provider.enable_api_key(api_key, second_user, [&](Optional<AppError> error) {
+            REQUIRE(error);
+            CHECK(error->message == "API key not found");
+            CHECK(error->is_service_error());
+            CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::api_key_not_found);
+        });
+
+        provider.fetch_api_key(api_key.id, first_user,
+                       [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
+                           CHECK(!error);
+                           REQUIRE(bool(user_api_key));
+                           CHECK(user_api_key->disabled == false);
+                           CHECK(user_api_key->name == api_key_name);
+                       });
+
+        provider.fetch_api_key(api_key.id, second_user,
+                               [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
+                                   REQUIRE(error);
+                                   REQUIRE(!bool(user_api_key));
+                                   CHECK(error->message == "API key not found");
+                                   CHECK(error->is_service_error());
+                                   CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::api_key_not_found);
+                               });
+
+        provider.disable_api_key(api_key, first_user, [&](Optional<AppError> error) {
+            CHECK(!error);
+        });
+
+        provider.disable_api_key(api_key, second_user, [&](Optional<AppError> error) {
+            REQUIRE(error);
+            CHECK(error->message == "API key not found");
+            CHECK(error->is_service_error());
+            CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::api_key_not_found);
+        });
+
+        provider.fetch_api_key(api_key.id, first_user, [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
+            CHECK(!error);
+            REQUIRE(bool(user_api_key));
+            CHECK(user_api_key->disabled == true);
+            CHECK(user_api_key->name == api_key_name);
+        });
+
+        provider.fetch_api_key(api_key.id, second_user, [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
+            REQUIRE(error);
+            REQUIRE(!bool(user_api_key));
+            CHECK(error->message == "API key not found");
+            CHECK(error->is_service_error());
+            CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::api_key_not_found);
+        });
+
+        provider.delete_api_key(api_key, second_user, [&](Optional<AppError> error) {
+            REQUIRE(error);
+            CHECK(error->message == "API key not found");
+            CHECK(error->is_service_error());
+            CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::api_key_not_found);
+        });
+
+        provider.delete_api_key(api_key, first_user, [&](Optional<AppError> error) {
+            CHECK(!error);
+        });
+
+        provider.fetch_api_key(api_key.id, first_user, [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
+            CHECK(!user_api_key);
+            REQUIRE(error);
+            CHECK(error->message == "API key not found");
+            CHECK(error->is_service_error());
+            CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::api_key_not_found);
+            processed = true;
+        });
+
+        provider.fetch_api_key(api_key.id, second_user, [&](Optional<App::UserAPIKey> user_api_key, Optional<app::AppError> error) {
+            CHECK(!user_api_key);
+            REQUIRE(error);
+            CHECK(error->message == "API key not found");
+            CHECK(error->is_service_error());
+            CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::api_key_not_found);
+            processed = true;
+        });
+
+        CHECK(processed);
+    }
+
 }
 
 #endif // REALM_ENABLE_AUTH_TESTS
@@ -863,17 +1089,6 @@ TEST_CASE("app: login_with_credentials unit_tests", "[sync][app]") {
 }
 
 TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app]") {
-    auto setup_user = []() {
-        if (realm::SyncManager::shared().get_current_user()) {
-            return;
-        }
-
-        realm::SyncManager::shared().get_user(UnitTestTransport::user_id,
-                                              good_access_token,
-                                              good_access_token,
-                                              "anon-user");
-    };
-    
     std::unique_ptr<GenericNetworkTransport> (*factory)() = []{
         return std::unique_ptr<GenericNetworkTransport>(new UnitTestTransport);
     };
@@ -883,13 +1098,15 @@ TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app]") {
     std::string base_path = tmp_dir() + "/" + config.app_id;
     reset_test_directory(base_path);
     TestSyncManager init_sync_manager(base_path);
-    
+    std::shared_ptr<SyncUser> logged_in_user = realm::SyncManager::shared().get_user(UnitTestTransport::user_id,
+                                                                                     good_access_token,
+                                                                                     good_access_token,
+                                                                                     "anon-user");
     bool processed = false;
     ObjectId obj_id(UnitTestTransport::api_key_id.c_str());
 
     SECTION("create api key") {
-        setup_user();
-        app.provider_client<App::UserAPIKeyProviderClient>().create_api_key(UnitTestTransport::api_key_name,
+        app.provider_client<App::UserAPIKeyProviderClient>().create_api_key(UnitTestTransport::api_key_name, logged_in_user,
                                                                             [&](Optional<App::UserAPIKey> user_api_key, Optional<AppError> error) {
             CHECK(!error);
             CHECK(user_api_key->disabled == false);
@@ -900,8 +1117,7 @@ TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app]") {
     }
     
     SECTION("fetch api key") {
-        setup_user();
-        app.provider_client<App::UserAPIKeyProviderClient>().fetch_api_key(obj_id,
+        app.provider_client<App::UserAPIKeyProviderClient>().fetch_api_key(obj_id, logged_in_user,
                                                                            [&](Optional<App::UserAPIKey> user_api_key, Optional<AppError> error) {
             CHECK(!error);
             CHECK(user_api_key->disabled == false);
@@ -911,8 +1127,8 @@ TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app]") {
     }
     
     SECTION("fetch api keys") {
-        setup_user();
-        app.provider_client<App::UserAPIKeyProviderClient>().fetch_api_keys([&](std::vector<App::UserAPIKey> user_api_keys, Optional<AppError> error) {
+        app.provider_client<App::UserAPIKeyProviderClient>().fetch_api_keys(logged_in_user,
+                                                                            [&](std::vector<App::UserAPIKey> user_api_keys, Optional<AppError> error) {
             CHECK(!error);
             CHECK(user_api_keys.size() == 2);
             for(auto user_api_key : user_api_keys) {


### PR DESCRIPTION
This gives the `UserAPIKeyProviderClient` methods a user parameter so that the operations are explicit as to which user they operate on instead of assuming the current user.