### PR TITLE
Only require ID for ApiKey provider

### DIFF
--- a/src/sync/app.cpp
+++ b/src/sync/app.cpp
@@ -414,11 +414,11 @@ void App::UserAPIKeyProviderClient::fetch_api_keys(std::shared_ptr<SyncUser> use
 }
 
 
-void App::UserAPIKeyProviderClient::delete_api_key(const UserAPIKey& api_key, std::shared_ptr<SyncUser> user,
+void App::UserAPIKeyProviderClient::delete_api_key(const realm::ObjectId& id, std::shared_ptr<SyncUser> user,
                                                    std::function<void(Optional<AppError>)> completion_block)
 {
     REALM_ASSERT(m_parent);
-    std::string route = util::format("%1/auth/%2/%3", m_parent->m_base_route, user_api_key_provider_key, api_key.id.to_string());
+    std::string route = util::format("%1/auth/%2/%3", m_parent->m_base_route, user_api_key_provider_key, id.to_string());
 
     auto handler = [completion_block](const Response& response) {
         if (auto error = check_for_errors(response)) {
@@ -436,11 +436,11 @@ void App::UserAPIKeyProviderClient::delete_api_key(const UserAPIKey& api_key, st
     }, handler);
 }
 
-void App::UserAPIKeyProviderClient::enable_api_key(const UserAPIKey& api_key, std::shared_ptr<SyncUser> user,
+void App::UserAPIKeyProviderClient::enable_api_key(const realm::ObjectId& id, std::shared_ptr<SyncUser> user,
                                                    std::function<void(Optional<AppError> error)> completion_block)
 {
     REALM_ASSERT(m_parent);
-    std::string route = util::format("%1/auth/%2/%3/enable", m_parent->m_base_route, user_api_key_provider_key, api_key.id.to_string());
+    std::string route = util::format("%1/auth/%2/%3/enable", m_parent->m_base_route, user_api_key_provider_key, id.to_string());
 
     auto handler = [completion_block](const Response& response) {
         if (auto error = check_for_errors(response)) {
@@ -458,11 +458,11 @@ void App::UserAPIKeyProviderClient::enable_api_key(const UserAPIKey& api_key, st
     }, handler);
 }
 
-void App::UserAPIKeyProviderClient::disable_api_key(const UserAPIKey& api_key, std::shared_ptr<SyncUser> user,
+void App::UserAPIKeyProviderClient::disable_api_key(const realm::ObjectId& id, std::shared_ptr<SyncUser> user,
                                                    std::function<void(Optional<AppError> error)> completion_block)
 {
     REALM_ASSERT(m_parent);
-    std::string route = util::format("%1/auth/%2/%3/disable", m_parent->m_base_route, user_api_key_provider_key, api_key.id.to_string());
+    std::string route = util::format("%1/auth/%2/%3/disable", m_parent->m_base_route, user_api_key_provider_key, id.to_string());
 
     auto handler = [completion_block](const Response& response) {
         if (auto error = check_for_errors(response)) {

--- a/src/sync/app.hpp
+++ b/src/sync/app.hpp
@@ -128,7 +128,7 @@ public:
          *     - id: The id of the API key to delete.
          *     - completion_block: A callback to be invoked once the call is complete.
          */
-        void delete_api_key(const UserAPIKey& api_key, std::shared_ptr<SyncUser> user,
+        void delete_api_key(const realm::ObjectId& id, std::shared_ptr<SyncUser> user,
                             std::function<void(Optional<AppError>)> completion_block);
 
         /**
@@ -138,7 +138,7 @@ public:
          *     - id: The id of the API key to enable.
          *     - completion_block: A callback to be invoked once the call is complete.
          */
-        void enable_api_key(const UserAPIKey& api_key, std::shared_ptr<SyncUser> user,
+        void enable_api_key(const realm::ObjectId& id, std::shared_ptr<SyncUser> user,
                             std::function<void(Optional<AppError>)> completion_block);
 
         /**
@@ -148,7 +148,7 @@ public:
          *     - id: The id of the API key to disable.
          *     - completion_block: A callback to be invoked once the call is complete.
          */
-        void disable_api_key(const UserAPIKey& api_key, std::shared_ptr<SyncUser> user,
+        void disable_api_key(const realm::ObjectId& id, std::shared_ptr<SyncUser> user,
                              std::function<void(Optional<AppError>)> completion_block);
     private:
         friend class App;

--- a/tests/sync/app.cpp
+++ b/tests/sync/app.cpp
@@ -508,7 +508,7 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
         });
 
         app.provider_client<App::UserAPIKeyProviderClient>()
-            .delete_api_key(api_key, logged_in_user, [&](Optional<AppError> error) {
+            .delete_api_key(api_key.id, logged_in_user, [&](Optional<AppError> error) {
                 CHECK(!error);
         });
 
@@ -587,7 +587,7 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
                            });
 
         app.provider_client<App::UserAPIKeyProviderClient>()
-            .delete_api_key(api_key, no_user,
+            .delete_api_key(api_key.id, no_user,
                             [&](Optional<AppError> error) {
                                 REQUIRE(error);
                                 CHECK(error->is_service_error());

--- a/tests/sync/app.cpp
+++ b/tests/sync/app.cpp
@@ -495,7 +495,7 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
         });
 
         app.provider_client<App::UserAPIKeyProviderClient>()
-            .disable_api_key(api_key, logged_in_user, [&](Optional<AppError> error) {
+            .disable_api_key(api_key.id, logged_in_user, [&](Optional<AppError> error) {
                 CHECK(!error);
         });
 

--- a/tests/sync/app.cpp
+++ b/tests/sync/app.cpp
@@ -480,7 +480,7 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
         });
 
         app.provider_client<App::UserAPIKeyProviderClient>()
-            .enable_api_key(api_key, logged_in_user, [&](Optional<AppError> error) {
+            .enable_api_key(api_key.id, logged_in_user, [&](Optional<AppError> error) {
                 CHECK(!error);
         });
 
@@ -553,7 +553,7 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
                             });
 
         app.provider_client<App::UserAPIKeyProviderClient>()
-            .enable_api_key(api_key, no_user,
+            .enable_api_key(api_key.id, no_user,
                             [&](Optional<AppError> error) {
                                 REQUIRE(error);
                                 CHECK(error->is_service_error());
@@ -570,7 +570,7 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
                            });
 
         app.provider_client<App::UserAPIKeyProviderClient>()
-            .disable_api_key(api_key, no_user,
+            .disable_api_key(api_key.id, no_user,
                              [&](Optional<AppError> error) {
                                  REQUIRE(error);
                                  CHECK(error->is_service_error());
@@ -653,11 +653,11 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
                                     CHECK(!error);
                                 });
 
-        provider.enable_api_key(api_key, first_user, [&](Optional<AppError> error) {
+        provider.enable_api_key(api_key.id, first_user, [&](Optional<AppError> error) {
             CHECK(!error);
         });
 
-        provider.enable_api_key(api_key, second_user, [&](Optional<AppError> error) {
+        provider.enable_api_key(api_key.id, second_user, [&](Optional<AppError> error) {
             REQUIRE(error);
             CHECK(error->message == "API key not found");
             CHECK(error->is_service_error());
@@ -681,11 +681,11 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
                                    CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::api_key_not_found);
                                });
 
-        provider.disable_api_key(api_key, first_user, [&](Optional<AppError> error) {
+        provider.disable_api_key(api_key.id, first_user, [&](Optional<AppError> error) {
             CHECK(!error);
         });
 
-        provider.disable_api_key(api_key, second_user, [&](Optional<AppError> error) {
+        provider.disable_api_key(api_key.id, second_user, [&](Optional<AppError> error) {
             REQUIRE(error);
             CHECK(error->message == "API key not found");
             CHECK(error->is_service_error());
@@ -707,14 +707,14 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
             CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::api_key_not_found);
         });
 
-        provider.delete_api_key(api_key, second_user, [&](Optional<AppError> error) {
+        provider.delete_api_key(api_key.id, second_user, [&](Optional<AppError> error) {
             REQUIRE(error);
             CHECK(error->message == "API key not found");
             CHECK(error->is_service_error());
             CHECK(app::ServiceErrorCode(error->error_code.value()) == app::ServiceErrorCode::api_key_not_found);
         });
 
-        provider.delete_api_key(api_key, first_user, [&](Optional<AppError> error) {
+        provider.delete_api_key(api_key.id, first_user, [&](Optional<AppError> error) {
             CHECK(!error);
         });
 


### PR DESCRIPTION
Using the entire ApiKey struct as argument added needless complexity to the Java SDK + we only use the ID anyway.