### PR TITLE
Fix "previous <= m_schema_transaction_version_max" assertion failure

### DIFF
--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -542,14 +542,15 @@ void Realm::update_schema(Schema schema, uint64_t version, MigrationFunction mig
         initialization_function(shared_from_this());
     }
 
-    if (!in_transaction) {
-        commit_transaction();
-    }
-
     m_schema = std::move(schema);
+    m_new_schema = ObjectStore::schema_from_group(read_group());
     m_schema_version = ObjectStore::get_schema_version(read_group());
     m_dynamic_schema = false;
     m_coordinator->clear_schema_cache_and_set_schema_version(version);
+
+    if (!in_transaction)
+        commit_transaction();
+
     notify_schema_changed();
 }
 

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -1098,12 +1098,7 @@ TEST_CASE("SharedRealm: coordinator schema cache") {
     }
     r->update_schema(schema);
 
-    SECTION("is empty after calling update_schema()") {
-        REQUIRE_FALSE(coordinator->get_cached_schema(cache_schema, cache_sv, cache_tv));
-    }
-
-    Realm::get_shared_realm(config);
-    SECTION("is populated after getting another Realm without a schema specified") {
+    SECTION("is populated after calling update_schema()") {
         REQUIRE(coordinator->get_cached_schema(cache_schema, cache_sv, cache_tv));
         REQUIRE(cache_sv == 0);
         REQUIRE(cache_schema == schema);


### PR DESCRIPTION
Example code which hit this:

    std::vector<ObjectSchema> classes;
    for (int i = 0; i < 10'000; ++i) {
        classes.push_back({util::format("type %1", i), {
            {"value", PropertyType::Int}
        }});
    }
    InMemoryTestFile config;
    config.cache = false;
    config.automatic_change_notifications = false;
    auto r = Realm::get_shared_realm(config);
    r->update_schema(classes);

    std::thread t([&] { Realm::get_shared_realm(config); });
    while (true) {
        r->begin_transaction(); r->commit_transaction();
    }

Previously Realm::update_schema() would clear RealmCoordinator's schema cache, but not repopulate it. This was because populating it requires rereading it from the Realm, so it was optimal to defer doing that until it was next needed (i.e. the next time a Realm instance was obtained). However, this lead to a race condition: if the Realm which performed the migration committed another write while a different Realm was in the middle of reading the schema (specifically in between acquiring the read lock and caching the read schema), the schema cache would be put into an invalid state. The new Realm would cache the schema for just that older version, leading to the Realm which performed the migration being at a version after the one which the schema is cached for.

The simplest fix for this is to just reread the schema after preforming a migration so that caching works normally. This has a small performance hit, but it's very unlikely to ever matter compared to the cost of actually performing schema changes.

I couldn't find a way to reliably reproduce this that's suitable for including in the test suite, so no regression test for it (the above code just loops forever when it works).

Fixes https://github.com/realm/realm-cocoa/issues/6436. Fixes https://github.com/realm/realm-object-store/issues/447.