### PR TITLE
Disable Client Resync

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -209,7 +209,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config, util::O
 }
 
 std::shared_ptr<Realm> RealmCoordinator::get_realm()
-{I
+{
     std::shared_ptr<Realm> realm;
     util::CheckedUniqueLock lock(m_realm_mutex);
     do_get_realm(m_config, realm, none, lock);

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -281,8 +281,9 @@ std::shared_ptr<AsyncOpenTask> RealmCoordinator::get_synchronized_realm(Realm::C
 
     util::CheckedLockGuard lock(m_realm_mutex);
     set_config(config);
-    bool exists = File::exists(m_config.path);
-    create_sync_session(!exists);
+    // FIXME: Re-enable once the server reintroduces support for State Realms
+    // bool exists = File::exists(m_config.path);
+    create_sync_session(false /* exists */);
     return std::make_shared<AsyncOpenTask>(shared_from_this(), m_sync_session);
 }
 
@@ -291,8 +292,9 @@ void RealmCoordinator::create_session(const Realm::Config& config)
     REALM_ASSERT(config.sync_config);
     util::CheckedLockGuard lock(m_realm_mutex);
     set_config(config);
-    bool exists = File::exists(m_config.path);
-    create_sync_session(!exists);
+    // FIXME: Re-enable once the server reintroduces support for State Realms
+    // bool exists = File::exists(m_config.path);
+    create_sync_session(false /* exists */);
 }
 
 #endif

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -209,7 +209,7 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config, util::O
 }
 
 std::shared_ptr<Realm> RealmCoordinator::get_realm()
-{
+{I
     std::shared_ptr<Realm> realm;
     util::CheckedUniqueLock lock(m_realm_mutex);
     do_get_realm(m_config, realm, none, lock);
@@ -281,7 +281,7 @@ std::shared_ptr<AsyncOpenTask> RealmCoordinator::get_synchronized_realm(Realm::C
 
     util::CheckedLockGuard lock(m_realm_mutex);
     set_config(config);
-    // FIXME: Re-enable once the server reintroduces support for State Realms
+    // FIXME: Re-enable once the server reintroduces support for State Realms.
     // bool exists = File::exists(m_config.path);
     create_sync_session(false /* exists */);
     return std::make_shared<AsyncOpenTask>(shared_from_this(), m_sync_session);
@@ -292,7 +292,7 @@ void RealmCoordinator::create_session(const Realm::Config& config)
     REALM_ASSERT(config.sync_config);
     util::CheckedLockGuard lock(m_realm_mutex);
     set_config(config);
-    // FIXME: Re-enable once the server reintroduces support for State Realms
+    // FIXME: Re-enable once the server reintroduces support for State Realms.
     // bool exists = File::exists(m_config.path);
     create_sync_session(false /* exists */);
 }


### PR DESCRIPTION
Disables Client Resync which would make the server send an empty State Realm. Which in return would remove all locally defined schemas.