### PR TITLE
keypath helper update

### DIFF
--- a/src/keypath_helpers.hpp
+++ b/src/keypath_helpers.hpp
@@ -24,7 +24,7 @@
 
 namespace realm {
 /// Populate the mapping from public name to internal name for queries.
-static void populate_keypath_mapping(parser::KeyPathMapping& mapping, Realm& realm)
+inline void populate_keypath_mapping(parser::KeyPathMapping& mapping, Realm& realm)
 {
     mapping.set_backlink_class_prefix("class_");
 
@@ -77,7 +77,7 @@ inline IncludeDescriptor generate_include_from_keypaths(std::vector<StringData> 
         while (index < path.size()) {
             parser::KeyPathElement element = mapping.process_next_path(cur_table, path, index); // throws if invalid
             // backlinks use type_LinkList since list operations apply to them (and is_backlink is set)
-            if (element.col_type != type_Link && element.col_type != type_LinkList) {
+            if (!element.table->is_link_type(element.col_key.get_type()) && element.col_key.get_type() != col_type_BackLink) {
                 throw InvalidPathError(util::format("Property '%1' is not a link in object of type '%2' in 'INCLUDE' clause",
                                                     element.table->get_column_name(element.col_key),
                                                     get_printable_table_name(*element.table)));
@@ -94,7 +94,7 @@ inline IncludeDescriptor generate_include_from_keypaths(std::vector<StringData> 
                 cur_table = element.table; // advance through backlink
             }
             ConstTableRef tr;
-            if (element.is_backlink) {
+            if (element.operation == parser::KeyPathElement::KeyPathOperation::BacklinkTraversal) {
                 tr = element.table;
             }
             links.emplace_back(element.col_key, tr);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,10 +82,10 @@ endif()
 if(REALM_ENABLE_SYNC)
     # It's necessary to explicitly link to realm-sync here to control the order in which libraries are
     # linked to avoid link errors when using GNU ld.
-    target_link_libraries(tests realm-sync realm-sync-server realm-parser)
+    target_link_libraries(tests realm-sync realm-sync-server)
 endif()
 
-target_link_libraries(tests realm-object-store ${EXTRA_LIBRARIES} ${PLATFORM_LIBRARIES})
+target_link_libraries(tests realm-object-store ${EXTRA_LIBRARIES} ${PLATFORM_LIBRARIES} realm-parser)
 
 add_custom_command(TARGET tests POST_BUILD
                    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${CMAKE_CURRENT_SOURCE_DIR}/sync-1.x.realm $<TARGET_FILE_DIR:tests>)


### PR DESCRIPTION
These helper methods needed to be updated when changing to core v10.0.0-alpha.8 because of changes to `KeyPathElement`. However, this code was unused and untested at the object store level so didn't cause any build failures until the SDK's tried to update.