### PR TITLE
Bug fix for count, add more robust tests

### DIFF
--- a/src/sync/remote_mongo_collection.cpp
+++ b/src/sync/remote_mongo_collection.cpp
@@ -204,7 +204,7 @@ void RemoteMongoCollection::count(const bson::BsonDocument& filter_bson,
                                   std::function<void(uint64_t, util::Optional<AppError>)> completion_block)
 {
     auto base_args = m_base_operation_args;
-    base_args["document"] = filter_bson;
+    base_args["query"] = filter_bson;
     
     if (limit != 0) {
         base_args["limit"] = limit;

--- a/src/sync/remote_mongo_collection.hpp
+++ b/src/sync/remote_mongo_collection.hpp
@@ -82,7 +82,7 @@ public:
             }
             
             if (sort_bson) {
-                bson["sort_json"] = *sort_bson;
+                bson["sort"] = *sort_bson;
             }
         }
     };


### PR DESCRIPTION
This PR addressed a bug where `count` would return the amount of all documents in a collection if the query document did not exist. More tests have been added to check this. Another bug caught in this PR is to do with `sort` during a find operation.