### PR TITLE
Add auth options to log_in_with_credential

### DIFF
--- a/src/sync/app.cpp
+++ b/src/sync/app.cpp
@@ -97,9 +97,17 @@ App::App(const Config& config)
 {
     REALM_ASSERT(m_config.transport_generator);
 
-    REALM_ASSERT(!m_config.platform.empty());
-    REALM_ASSERT(!m_config.platform_version.empty());
-    REALM_ASSERT(!m_config.sdk_version.empty());
+    if (m_config.platform.empty()) {
+        throw std::runtime_error("You must specify the Platform in App::Config");
+    }
+    
+    if (m_config.platform_version.empty()) {
+        throw std::runtime_error("You must specify the Platform Version in App::Config");
+    }
+    
+    if (m_config.sdk_version.empty()) {
+        throw std::runtime_error("You must specify the SDK Version in App::Config");
+    }
 
     // change the scheme in the base url to ws from http to satisfy the sync client
     size_t uri_scheme_start = m_sync_route.find("http");

--- a/src/sync/app.cpp
+++ b/src/sync/app.cpp
@@ -97,6 +97,10 @@ App::App(const Config& config)
 {
     REALM_ASSERT(m_config.transport_generator);
 
+    REALM_ASSERT(!m_config.platform.empty());
+    REALM_ASSERT(!m_config.platform_version.empty());
+    REALM_ASSERT(!m_config.sdk_version.empty());
+
     // change the scheme in the base url to ws from http to satisfy the sync client
     size_t uri_scheme_start = m_sync_route.find("http");
     if (uri_scheme_start == 0)
@@ -572,14 +576,8 @@ void App::attach_auth_options(bson::BsonDocument& body, std::shared_ptr<SyncUser
         options["appVersion"] = *m_config.local_app_version;
     }
     
-    if (m_config.platform) {
-        options["platform"] = *m_config.platform;
-    }
-    
-    if (m_config.platform_version) {
-        options["platformVersion"] = *m_config.platform_version;
-    }
-    
+    options["platform"] = m_config.platform;
+    options["platformVersion"] = m_config.platform_version;
     options["sdkVersion"] = m_config.sdk_version;
 
     body["options"] = bson::BsonDocument({{"device", options}});

--- a/src/sync/app.cpp
+++ b/src/sync/app.cpp
@@ -571,19 +571,15 @@ void App::get_profile(std::shared_ptr<SyncUser> sync_user,
     do_authenticated_request(req, sync_user, profile_handler);
 }
 
-void App::attach_auth_options(bson::BsonDocument& body, std::shared_ptr<SyncUser> sync_user)
+void App::attach_auth_options(bson::BsonDocument& body)
 {
     bson::BsonDocument options;
     
-    if (sync_user && sync_user) {
-        options["deviceId"] = sync_user->device_id();
-    }
-    
-    options["appId"] = m_config.app_id;
     if (m_config.local_app_version) {
         options["appVersion"] = *m_config.local_app_version;
     }
     
+    options["appId"] = m_config.app_id;
     options["platform"] = m_config.platform;
     options["platformVersion"] = m_config.platform_version;
     options["sdkVersion"] = m_config.sdk_version;
@@ -633,7 +629,7 @@ void App::log_in_with_credentials(const AppCredentials& credentials,
     
     bson::Bson credentials_as_bson = bson::parse(credentials.serialize_as_json());
     bson::BsonDocument body = static_cast<bson::BsonDocument>(credentials_as_bson);
-    attach_auth_options(body, linking_user);
+    attach_auth_options(body);
     
     std::stringstream s;
     s << bson::Bson(body);

--- a/src/sync/app.cpp
+++ b/src/sync/app.cpp
@@ -561,13 +561,13 @@ void App::get_profile(std::shared_ptr<SyncUser> sync_user,
 
 void App::attach_auth_options(bson::BsonDocument& body)
 {
+    bson::BsonDocument options;
     if (m_config.device_id) {
-        body["options"] = bson::BsonDocument({
-            {"device", bson::BsonDocument({
-                {"deviceId", *m_config.device_id}
-            })}
+        options["device"] = bson::BsonDocument({
+            {"deviceId", *m_config.device_id}
         });
     }
+    body["options"] = options;
 }
 
 void App::log_in_with_credentials(const AppCredentials& credentials,

--- a/src/sync/app.hpp
+++ b/src/sync/app.hpp
@@ -55,6 +55,7 @@ public:
         util::Optional<std::string> local_app_name;
         util::Optional<std::string> local_app_version;
         util::Optional<uint64_t> default_request_timeout_ms;
+        util::Optional<std::string> device_id;
     };
 
     // `enable_shared_from_this` is unsafe with public constructors; use `get_shared_app` instead
@@ -246,7 +247,8 @@ public:
     /// @param completion_block The completion handler to call when the linking is complete.
     ///                         If the operation is  successful, the result will contain the original
     ///                         `SyncUser` object representing the user.
-    void link_user(std::shared_ptr<SyncUser> user, const AppCredentials& credentials,
+    void link_user(std::shared_ptr<SyncUser> user,
+                   const AppCredentials& credentials,
                    std::function<void(std::shared_ptr<SyncUser>, util::Optional<AppError>)> completion_block);
 
     /// Switches the active user with the specified one. The user must

--- a/src/sync/app.hpp
+++ b/src/sync/app.hpp
@@ -426,6 +426,7 @@ private:
                                  const std::shared_ptr<SyncUser> linking_user,
                                  std::function<void(std::shared_ptr<SyncUser>, util::Optional<AppError>)> completion_block);
     
+    /// Provides Realm Cloud with metadata related to the users session
     void attach_auth_options(bson::BsonDocument& body);
 
 };

--- a/src/sync/app.hpp
+++ b/src/sync/app.hpp
@@ -426,7 +426,7 @@ private:
                                  const std::shared_ptr<SyncUser> linking_user,
                                  std::function<void(std::shared_ptr<SyncUser>, util::Optional<AppError>)> completion_block);
     
-    /// Provides Realm Cloud with metadata related to the users session
+    /// Provides MongoDB Realm Cloud with metadata related to the users session
     void attach_auth_options(bson::BsonDocument& body);
 
 };

--- a/src/sync/app.hpp
+++ b/src/sync/app.hpp
@@ -423,6 +423,8 @@ private:
     void log_in_with_credentials(const AppCredentials& credentials,
                                  const std::shared_ptr<SyncUser> linking_user,
                                  std::function<void(std::shared_ptr<SyncUser>, util::Optional<AppError>)> completion_block);
+    
+    void attach_auth_options(bson::BsonDocument& body);
 
 };
 

--- a/src/sync/app.hpp
+++ b/src/sync/app.hpp
@@ -55,7 +55,9 @@ public:
         util::Optional<std::string> local_app_name;
         util::Optional<std::string> local_app_version;
         util::Optional<uint64_t> default_request_timeout_ms;
-        util::Optional<std::string> device_id;
+        util::Optional<std::string> platform;
+        util::Optional<std::string> platform_version;
+        std::string sdk_version;
     };
 
     // `enable_shared_from_this` is unsafe with public constructors; use `get_shared_app` instead
@@ -424,7 +426,7 @@ private:
                                  const std::shared_ptr<SyncUser> linking_user,
                                  std::function<void(std::shared_ptr<SyncUser>, util::Optional<AppError>)> completion_block);
     
-    void attach_auth_options(bson::BsonDocument& body);
+    void attach_auth_options(bson::BsonDocument& body, std::shared_ptr<SyncUser> sync_user);
 
 };
 

--- a/src/sync/app.hpp
+++ b/src/sync/app.hpp
@@ -55,8 +55,8 @@ public:
         util::Optional<std::string> local_app_name;
         util::Optional<std::string> local_app_version;
         util::Optional<uint64_t> default_request_timeout_ms;
-        util::Optional<std::string> platform;
-        util::Optional<std::string> platform_version;
+        std::string platform;
+        std::string platform_version;
         std::string sdk_version;
     };
 

--- a/src/sync/app.hpp
+++ b/src/sync/app.hpp
@@ -426,7 +426,7 @@ private:
                                  const std::shared_ptr<SyncUser> linking_user,
                                  std::function<void(std::shared_ptr<SyncUser>, util::Optional<AppError>)> completion_block);
     
-    void attach_auth_options(bson::BsonDocument& body, std::shared_ptr<SyncUser> sync_user);
+    void attach_auth_options(bson::BsonDocument& body);
 
 };
 

--- a/src/sync/impl/sync_metadata.cpp
+++ b/src/sync/impl/sync_metadata.cpp
@@ -127,7 +127,7 @@ SyncMetadataManager::SyncMetadataManager(std::string path,
                                          bool should_encrypt,
                                          util::Optional<std::vector<char>> encryption_key)
 {
-    constexpr uint64_t SCHEMA_VERSION = 3;
+    constexpr uint64_t SCHEMA_VERSION = 4;
 
     Realm::Config config;
     config.automatic_change_notifications = false;
@@ -475,12 +475,12 @@ util::Optional<std::string> SyncUserMetadata::access_token() const
     return result.is_null() ? util::none : util::make_optional(std::string(result));
 }
 
-util::Optional<std::string> SyncUserMetadata::device_id() const
+std::string SyncUserMetadata::device_id() const
 {
     REALM_ASSERT(m_realm);
     m_realm->verify_thread();
     StringData result = m_obj.get<String>(m_schema.idx_device_id);
-    return result.is_null() ? util::none : util::make_optional(std::string(result));
+    return result.is_null() ? "" : std::string(result);
 }
 
 inline SyncUserIdentity user_identity_from_obj(const ConstObj& obj)
@@ -574,7 +574,7 @@ void SyncUserMetadata::set_access_token(util::Optional<std::string> user_token)
     m_realm->commit_transaction();
 }
 
-void SyncUserMetadata::set_device_id(util::Optional<std::string> device_id)
+void SyncUserMetadata::set_device_id(const std::string& device_id)
 {
     if (m_invalid)
         return;
@@ -582,7 +582,7 @@ void SyncUserMetadata::set_device_id(util::Optional<std::string> device_id)
     REALM_ASSERT_DEBUG(m_realm);
     m_realm->verify_thread();
     m_realm->begin_transaction();
-    m_obj.set(m_schema.idx_device_id, *device_id);
+    m_obj.set(m_schema.idx_device_id, device_id);
     m_realm->commit_transaction();
 }
 

--- a/src/sync/impl/sync_metadata.cpp
+++ b/src/sync/impl/sync_metadata.cpp
@@ -45,6 +45,7 @@ static const char * const c_sync_refresh_token = "refresh_token";
 static const char * const c_sync_access_token = "access_token";
 static const char * const c_sync_identities = "identities";
 static const char * const c_sync_state = "state";
+static const char * const c_sync_device_id = "device_id";
 
 static const char * const c_sync_profile = "profile";
 static const char * const c_sync_profile_name = "name";
@@ -97,7 +98,8 @@ realm::Schema make_schema()
             {c_sync_access_token, PropertyType::String|PropertyType::Nullable},
             {c_sync_identities, PropertyType::Object|PropertyType::Array, c_sync_identityMetadata},
             {c_sync_profile, PropertyType::Object|PropertyType::Nullable, c_sync_profile},
-            {c_sync_state, PropertyType::Int}
+            {c_sync_state, PropertyType::Int},
+            {c_sync_device_id, PropertyType::String}
         }},
         {c_sync_fileActionMetadata, {
             {c_sync_original_name, PropertyType::String, Property::IsPrimary{true}},
@@ -183,7 +185,8 @@ SyncMetadataManager::SyncMetadataManager(std::string path,
         object_schema->persisted_properties[5].column_key,
         object_schema->persisted_properties[6].column_key,
         object_schema->persisted_properties[7].column_key,
-        object_schema->persisted_properties[8].column_key
+        object_schema->persisted_properties[8].column_key,
+        object_schema->persisted_properties[9].column_key
     };
 
     object_schema = realm->schema().find(c_sync_fileActionMetadata);
@@ -472,6 +475,14 @@ util::Optional<std::string> SyncUserMetadata::access_token() const
     return result.is_null() ? util::none : util::make_optional(std::string(result));
 }
 
+util::Optional<std::string> SyncUserMetadata::device_id() const
+{
+    REALM_ASSERT(m_realm);
+    m_realm->verify_thread();
+    StringData result = m_obj.get<String>(m_schema.idx_device_id);
+    return result.is_null() ? util::none : util::make_optional(std::string(result));
+}
+
 inline SyncUserIdentity user_identity_from_obj(const ConstObj& obj)
 {
     return SyncUserIdentity(obj.get<String>(c_sync_user_id), obj.get<String>(c_sync_provider_type));
@@ -560,6 +571,18 @@ void SyncUserMetadata::set_access_token(util::Optional<std::string> user_token)
     m_realm->verify_thread();
     m_realm->begin_transaction();
     m_obj.set(m_schema.idx_access_token, *user_token);
+    m_realm->commit_transaction();
+}
+
+void SyncUserMetadata::set_device_id(util::Optional<std::string> device_id)
+{
+    if (m_invalid)
+        return;
+
+    REALM_ASSERT_DEBUG(m_realm);
+    m_realm->verify_thread();
+    m_realm->begin_transaction();
+    m_obj.set(m_schema.idx_device_id, *device_id);
     m_realm->commit_transaction();
 }
 

--- a/src/sync/impl/sync_metadata.hpp
+++ b/src/sync/impl/sync_metadata.hpp
@@ -74,8 +74,8 @@ public:
     util::Optional<std::string> access_token() const;
     void set_access_token(util::Optional<std::string>);
     
-    util::Optional<std::string> device_id() const;
-    void set_device_id(util::Optional<std::string>);
+    std::string device_id() const;
+    void set_device_id(const std::string&);
 
     void set_user_profile(const SyncUserProfile&);
 

--- a/src/sync/impl/sync_metadata.hpp
+++ b/src/sync/impl/sync_metadata.hpp
@@ -55,6 +55,8 @@ public:
         ColKey idx_profile;
         // The current state of this user.
         ColKey idx_state;
+        // The device id of this user.
+        ColKey idx_device_id;
     };
 
     // Cannot be set after creation.
@@ -71,6 +73,9 @@ public:
 
     util::Optional<std::string> access_token() const;
     void set_access_token(util::Optional<std::string>);
+    
+    util::Optional<std::string> device_id() const;
+    void set_device_id(util::Optional<std::string>);
 
     void set_user_profile(const SyncUserProfile&);
 

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -56,7 +56,7 @@ void SyncManager::configure(SyncClientConfig config, util::Optional<app::App::Co
         std::string provider_type;
         std::vector<SyncUserIdentity> identities;
         SyncUser::State state;
-        util::Optional<std::string> device_id;
+        std::string device_id;
     };
 
     std::vector<UserCreationData> users_to_add;
@@ -311,7 +311,7 @@ std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& user_id,
                                                 std::string refresh_token,
                                                 std::string access_token,
                                                 const std::string provider_type,
-                                                util::Optional<std::string> device_id)
+                                                std::string device_id)
 {
     std::lock_guard<std::mutex> lock(m_user_mutex);
     auto it = std::find_if(m_users.begin(),
@@ -326,7 +326,7 @@ std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& user_id,
                                                    provider_type,
                                                    std::move(access_token),
                                                    SyncUser::State::LoggedIn,
-                                                   device_id);
+                                                   std::move(device_id));
         m_users.emplace(m_users.begin(), new_user);
         return new_user;
     } else {

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -56,6 +56,7 @@ void SyncManager::configure(SyncClientConfig config, util::Optional<app::App::Co
         std::string provider_type;
         std::vector<SyncUserIdentity> identities;
         SyncUser::State state;
+        util::Optional<std::string> device_id;
     };
 
     std::vector<UserCreationData> users_to_add;
@@ -154,7 +155,8 @@ void SyncManager::configure(SyncClientConfig config, util::Optional<app::App::Co
                                                    identity,
                                                    provider_type,
                                                    user_data.access_token,
-                                                   user_data.state);
+                                                   user_data.state,
+                                                   user_data.device_id);
             m_users.emplace_back(std::move(user));
         }
     }
@@ -308,7 +310,8 @@ bool SyncManager::perform_metadata_update(std::function<void(const SyncMetadataM
 std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& user_id,
                                                 std::string refresh_token,
                                                 std::string access_token,
-                                                const std::string provider_type)
+                                                const std::string provider_type,
+                                                util::Optional<std::string> device_id)
 {
     std::lock_guard<std::mutex> lock(m_user_mutex);
     auto it = std::find_if(m_users.begin(),
@@ -322,7 +325,8 @@ std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& user_id,
                                                    user_id,
                                                    provider_type,
                                                    std::move(access_token),
-                                                   SyncUser::State::LoggedIn);
+                                                   SyncUser::State::LoggedIn,
+                                                   device_id);
         m_users.emplace(m_users.begin(), new_user);
         return new_user;
     } else {

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -115,6 +115,7 @@ void SyncManager::configure(SyncClientConfig config, util::Optional<app::App::Co
             auto user_data = users.get(i);
             auto refresh_token = user_data.refresh_token();
             auto access_token = user_data.access_token();
+            auto device_id = user_data.device_id();
             if (refresh_token && access_token) {
                 users_to_add.push_back(UserCreationData{
                     user_data.identity(),
@@ -122,7 +123,8 @@ void SyncManager::configure(SyncClientConfig config, util::Optional<app::App::Co
                     std::move(*access_token),
                     user_data.provider_type(),
                     user_data.identities(),
-                    user_data.state()
+                    user_data.state(),
+                    device_id
                 });
             }
         }
@@ -326,7 +328,7 @@ std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& user_id,
                                                    provider_type,
                                                    std::move(access_token),
                                                    SyncUser::State::LoggedIn,
-                                                   std::move(device_id));
+                                                   device_id);
         m_users.emplace(m_users.begin(), new_user);
         return new_user;
     } else {

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -165,7 +165,7 @@ public:
                                        const std::string provider_type,
                                        std::string refresh_token,
                                        std::string access_token,
-                                       util::Optional<std::string> device_id);
+                                       std::string device_id);
 
     // Get an existing user for a given identifier, if one exists and is logged in.
     std::shared_ptr<SyncUser> get_existing_logged_in_user(const std::string& user_id) const;

--- a/src/sync/sync_manager.hpp
+++ b/src/sync/sync_manager.hpp
@@ -164,7 +164,8 @@ public:
     std::shared_ptr<SyncUser> get_user(const std::string& id,
                                        const std::string provider_type,
                                        std::string refresh_token,
-                                       std::string access_token);
+                                       std::string access_token,
+                                       util::Optional<std::string> device_id);
 
     // Get an existing user for a given identifier, if one exists and is logged in.
     std::shared_ptr<SyncUser> get_existing_logged_in_user(const std::string& user_id) const;

--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -336,7 +336,7 @@ std::string SyncUser::device_id() const
 bool SyncUser::has_device_id() const
 {
     std::lock_guard<std::mutex> lock(m_mutex);
-    return !(m_device_id.empty() || m_device_id == "000000000000000000000000");
+    return !m_device_id.empty() && m_device_id != "000000000000000000000000";
 }
 
 SyncUser::State SyncUser::state() const

--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -112,7 +112,7 @@ SyncUser::SyncUser(std::string refresh_token,
 , m_refresh_token(RealmJWT(std::move(refresh_token)))
 , m_identity(std::move(identity))
 , m_access_token(RealmJWT(std::move(access_token)))
-, m_device_id(device_id)
+, m_device_id(std::move(device_id))
 {
     {
         std::lock_guard<std::mutex> lock(s_binding_context_factory_mutex);
@@ -125,7 +125,7 @@ SyncUser::SyncUser(std::string refresh_token,
         auto metadata = manager.get_or_make_user_metadata(m_identity, m_provider_type);
         metadata->set_refresh_token(m_refresh_token.token);
         metadata->set_access_token(m_access_token.token);
-        metadata->set_device_id(device_id);
+        metadata->set_device_id(m_device_id);
         m_local_identity = metadata->local_uuid();
     });
     if (!updated)

--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -106,13 +106,13 @@ SyncUser::SyncUser(std::string refresh_token,
                    const std::string provider_type,
                    std::string access_token,
                    SyncUser::State state,
-                   util::Optional<std::string> device_id)
-: device_id(device_id)
-, m_state(state)
+                   const std::string device_id)
+: m_state(state)
 , m_provider_type(provider_type)
 , m_refresh_token(RealmJWT(std::move(refresh_token)))
 , m_identity(std::move(identity))
 , m_access_token(RealmJWT(std::move(access_token)))
+, m_device_id(device_id)
 {
     {
         std::lock_guard<std::mutex> lock(s_binding_context_factory_mutex);
@@ -325,6 +325,18 @@ std::string SyncUser::access_token() const
 {
     std::lock_guard<std::mutex> lock(m_mutex);
     return m_access_token.token;
+}
+
+std::string SyncUser::device_id() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_device_id;
+}
+
+bool SyncUser::has_device_id() const
+{
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return !(m_device_id.empty() || m_device_id == "000000000000000000000000");
 }
 
 SyncUser::State SyncUser::state() const

--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -125,6 +125,7 @@ SyncUser::SyncUser(std::string refresh_token,
         auto metadata = manager.get_or_make_user_metadata(m_identity, m_provider_type);
         metadata->set_refresh_token(m_refresh_token.token);
         metadata->set_access_token(m_access_token.token);
+        metadata->set_device_id(device_id);
         m_local_identity = metadata->local_uuid();
     });
     if (!updated)

--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -105,8 +105,10 @@ SyncUser::SyncUser(std::string refresh_token,
                    const std::string identity,
                    const std::string provider_type,
                    std::string access_token,
-                   SyncUser::State state)
-: m_state(state)
+                   SyncUser::State state,
+                   util::Optional<std::string> device_id)
+: device_id(device_id)
+, m_state(state)
 , m_provider_type(provider_type)
 , m_refresh_token(RealmJWT(std::move(refresh_token)))
 , m_identity(std::move(identity))

--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -112,7 +112,7 @@ SyncUser::SyncUser(std::string refresh_token,
 , m_refresh_token(RealmJWT(std::move(refresh_token)))
 , m_identity(std::move(identity))
 , m_access_token(RealmJWT(std::move(access_token)))
-, m_device_id(std::move(device_id))
+, m_device_id(device_id)
 {
     {
         std::lock_guard<std::mutex> lock(s_binding_context_factory_mutex);

--- a/src/sync/sync_user.hpp
+++ b/src/sync/sync_user.hpp
@@ -136,7 +136,7 @@ public:
              const std::string provider_type,
              std::string access_token,
              SyncUser::State state,
-             util::Optional<std::string> device_id);
+             const std::string device_id);
 
     // Return a list of all sessions belonging to this user.
     std::vector<std::shared_ptr<SyncSession>> all_sessions();
@@ -186,8 +186,10 @@ public:
 
     std::string refresh_token() const;
     
-    util::Optional<std::string> device_id;
-
+    std::string device_id() const;
+    
+    bool has_device_id() const;
+    
     SyncUserProfile user_profile() const;
 
     std::vector<SyncUserIdentity> identities() const;
@@ -251,6 +253,8 @@ private:
     std::vector<SyncUserIdentity> m_user_identities;
 
     SyncUserProfile m_user_profile;
+    
+    std::string m_device_id;
 };
 
 }

--- a/src/sync/sync_user.hpp
+++ b/src/sync/sync_user.hpp
@@ -254,7 +254,7 @@ private:
 
     SyncUserProfile m_user_profile;
     
-    std::string m_device_id;
+    const std::string m_device_id;
 };
 
 }

--- a/src/sync/sync_user.hpp
+++ b/src/sync/sync_user.hpp
@@ -135,7 +135,8 @@ public:
              const std::string id,
              const std::string provider_type,
              std::string access_token,
-             SyncUser::State state);
+             SyncUser::State state,
+             util::Optional<std::string> device_id);
 
     // Return a list of all sessions belonging to this user.
     std::vector<std::shared_ptr<SyncSession>> all_sessions();
@@ -184,6 +185,8 @@ public:
     std::string access_token() const;
 
     std::string refresh_token() const;
+    
+    util::Optional<std::string> device_id;
 
     SyncUserProfile user_profile() const;
 

--- a/tests/mongodb/auth_providers/anon-user.json
+++ b/tests/mongodb/auth_providers/anon-user.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eabdd97ada449487cf49f60",
+    "id": "5eb95304beeae3717c9e9f96",
     "name": "anon-user",
     "type": "anon-user",
     "disabled": false

--- a/tests/mongodb/auth_providers/anon-user.json
+++ b/tests/mongodb/auth_providers/anon-user.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eb95304beeae3717c9e9f96",
+    "id": "5eb9706410e75a8a49dd2174",
     "name": "anon-user",
     "type": "anon-user",
     "disabled": false

--- a/tests/mongodb/auth_providers/api-key.json
+++ b/tests/mongodb/auth_providers/api-key.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eabdd97ada449487cf49f61",
+    "id": "5eb95304beeae3717c9e9f97",
     "name": "api-key",
     "type": "api-key",
     "disabled": false

--- a/tests/mongodb/auth_providers/api-key.json
+++ b/tests/mongodb/auth_providers/api-key.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eb95304beeae3717c9e9f97",
+    "id": "5eb9706410e75a8a49dd2175",
     "name": "api-key",
     "type": "api-key",
     "disabled": false

--- a/tests/mongodb/auth_providers/custom-function.json
+++ b/tests/mongodb/auth_providers/custom-function.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eb95304beeae3717c9e9f98",
+    "id": "5eb9706410e75a8a49dd2176",
     "name": "custom-function",
     "type": "custom-function",
     "config": {

--- a/tests/mongodb/auth_providers/custom-function.json
+++ b/tests/mongodb/auth_providers/custom-function.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eabdd97ada449487cf49f62",
+    "id": "5eb95304beeae3717c9e9f98",
     "name": "custom-function",
     "type": "custom-function",
     "config": {

--- a/tests/mongodb/auth_providers/local-userpass.json
+++ b/tests/mongodb/auth_providers/local-userpass.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eb95304beeae3717c9e9f99",
+    "id": "5eb9706410e75a8a49dd2177",
     "name": "local-userpass",
     "type": "local-userpass",
     "config": {

--- a/tests/mongodb/auth_providers/local-userpass.json
+++ b/tests/mongodb/auth_providers/local-userpass.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eabdd97ada449487cf49f63",
+    "id": "5eb95304beeae3717c9e9f99",
     "name": "local-userpass",
     "type": "local-userpass",
     "config": {

--- a/tests/mongodb/functions/authFunc/config.json
+++ b/tests/mongodb/functions/authFunc/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eb95304beeae3717c9e9f92",
+    "id": "5eb9706410e75a8a49dd2170",
     "name": "authFunc",
     "private": false,
     "can_evaluate": {}

--- a/tests/mongodb/functions/authFunc/config.json
+++ b/tests/mongodb/functions/authFunc/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eabdd97ada449487cf49f5c",
+    "id": "5eb95304beeae3717c9e9f92",
     "name": "authFunc",
     "private": false,
     "can_evaluate": {}

--- a/tests/mongodb/functions/confirmFunc/config.json
+++ b/tests/mongodb/functions/confirmFunc/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eb95304beeae3717c9e9f93",
+    "id": "5eb9706410e75a8a49dd2171",
     "name": "confirmFunc",
     "private": false,
     "can_evaluate": {}

--- a/tests/mongodb/functions/confirmFunc/config.json
+++ b/tests/mongodb/functions/confirmFunc/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eabdd97ada449487cf49f5d",
+    "id": "5eb95304beeae3717c9e9f93",
     "name": "confirmFunc",
     "private": false,
     "can_evaluate": {}

--- a/tests/mongodb/functions/resetFunc/config.json
+++ b/tests/mongodb/functions/resetFunc/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eb95304beeae3717c9e9f94",
+    "id": "5eb9706410e75a8a49dd2172",
     "name": "resetFunc",
     "private": false,
     "can_evaluate": {}

--- a/tests/mongodb/functions/resetFunc/config.json
+++ b/tests/mongodb/functions/resetFunc/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eabdd97ada449487cf49f5e",
+    "id": "5eb95304beeae3717c9e9f94",
     "name": "resetFunc",
     "private": false,
     "can_evaluate": {}

--- a/tests/mongodb/functions/sumFunc/config.json
+++ b/tests/mongodb/functions/sumFunc/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eb95304beeae3717c9e9f95",
+    "id": "5eb9706410e75a8a49dd2173",
     "name": "sumFunc",
     "private": false,
     "can_evaluate": {}

--- a/tests/mongodb/functions/sumFunc/config.json
+++ b/tests/mongodb/functions/sumFunc/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eabdd97ada449487cf49f5f",
+    "id": "5eb95304beeae3717c9e9f95",
     "name": "sumFunc",
     "private": false,
     "can_evaluate": {}

--- a/tests/mongodb/services/BackingDB/config.json
+++ b/tests/mongodb/services/BackingDB/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eabdd97ada449487cf49f59",
+    "id": "5eb95304beeae3717c9e9f8f",
     "name": "BackingDB",
     "type": "mongodb",
     "config": {},

--- a/tests/mongodb/services/BackingDB/config.json
+++ b/tests/mongodb/services/BackingDB/config.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eb95304beeae3717c9e9f8f",
+    "id": "5eb9706410e75a8a49dd216d",
     "name": "BackingDB",
     "type": "mongodb",
     "config": {},

--- a/tests/mongodb/services/BackingDB/rules/test_data.Dog.json
+++ b/tests/mongodb/services/BackingDB/rules/test_data.Dog.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eabdd97ada449487cf49f5a",
+    "id": "5eb95304beeae3717c9e9f90",
     "database": "test_data",
     "collection": "Dog",
     "roles": [

--- a/tests/mongodb/services/BackingDB/rules/test_data.Dog.json
+++ b/tests/mongodb/services/BackingDB/rules/test_data.Dog.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eb95304beeae3717c9e9f90",
+    "id": "5eb9706410e75a8a49dd216e",
     "database": "test_data",
     "collection": "Dog",
     "roles": [

--- a/tests/mongodb/services/BackingDB/rules/test_data.Person.json
+++ b/tests/mongodb/services/BackingDB/rules/test_data.Person.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eabdd97ada449487cf49f5b",
+    "id": "5eb95304beeae3717c9e9f91",
     "database": "test_data",
     "collection": "Person",
     "roles": [

--- a/tests/mongodb/services/BackingDB/rules/test_data.Person.json
+++ b/tests/mongodb/services/BackingDB/rules/test_data.Person.json
@@ -1,5 +1,5 @@
 {
-    "id": "5eb95304beeae3717c9e9f91",
+    "id": "5eb9706410e75a8a49dd216f",
     "database": "test_data",
     "collection": "Person",
     "roles": [

--- a/tests/mongodb/stitch.json
+++ b/tests/mongodb/stitch.json
@@ -1,5 +1,5 @@
 {
-    "app_id": "auth-integration-tests-rzvpn",
+    "app_id": "auth-integration-tests-zsfnh",
     "config_version": 20180301,
     "name": "auth-integration-tests",
     "location": "US-VA",

--- a/tests/mongodb/stitch.json
+++ b/tests/mongodb/stitch.json
@@ -1,5 +1,5 @@
 {
-    "app_id": "auth-integration-tests-zsfnh",
+    "app_id": "auth-integration-tests-sjmbd",
     "config_version": 20180301,
     "name": "auth-integration-tests",
     "location": "US-VA",

--- a/tests/sync/app.cpp
+++ b/tests/sync/app.cpp
@@ -211,13 +211,23 @@ TEST_CASE("app: login_with_credentials integration", "[sync][app]") {
 
         std::string base_url = get_base_url();
         std::string config_path = get_config_path();
+        std::string device_id = "123400000000000000000000";
         std::cout << "base_url for [app] integration tests is set to: " << base_url << std::endl;
         std::cout << "config_path for [app] integration tests is set to: " << config_path << std::endl;
         REQUIRE(!base_url.empty());
         REQUIRE(!config_path.empty());
-
+        REQUIRE(!device_id.empty());
+        
         // this app id is configured in tests/mongodb/stitch.json
-        auto app = App(App::Config{get_runtime_app_id(config_path), factory, base_url});
+        auto app = App(App::Config{
+            get_runtime_app_id(config_path),
+            factory,
+            base_url,
+            util::none,
+            util::none,
+            util::none,
+            device_id
+        });
 
         bool processed = false;
 
@@ -233,6 +243,7 @@ TEST_CASE("app: login_with_credentials integration", "[sync][app]") {
                     << error->error_code.value() << ")" <<std::endl;
             }
             CHECK(user);
+            CHECK(user->device_id == device_id);
             CHECK(!error);
         });
 
@@ -1647,7 +1658,8 @@ TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app]") {
     std::shared_ptr<SyncUser> logged_in_user = realm::SyncManager::shared().get_user(UnitTestTransport::user_id,
                                                                                      good_access_token,
                                                                                      good_access_token,
-                                                                                     "anon-user");
+                                                                                     "anon-user",
+                                                                                     util::none);
     bool processed = false;
     ObjectId obj_id(UnitTestTransport::api_key_id.c_str());
 
@@ -2415,7 +2427,8 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
             realm::SyncManager::shared().get_user("a_user_id",
                                                   good_access_token,
                                                   good_access_token,
-                                                  "anon-user");
+                                                  "anon-user",
+                                                  util::none);
         };
         
         static bool session_route_hit = false;
@@ -2469,7 +2482,8 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
             realm::SyncManager::shared().get_user("a_user_id",
                                                   good_access_token,
                                                   good_access_token,
-                                                  "anon-user");
+                                                  "anon-user",
+                                                  util::none);
         };
         
         static bool session_route_hit = false;
@@ -2524,7 +2538,8 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
             realm::SyncManager::shared().get_user("a_user_id",
                                                   good_access_token,
                                                   good_access_token,
-                                                  "anon-user");
+                                                  "anon-user",
+                                                  util::none);
         };
         
         /*

--- a/tests/sync/app.cpp
+++ b/tests/sync/app.cpp
@@ -1364,6 +1364,7 @@ class UnitTestTransport : public GenericNetworkTransport {
 public:
     static std::string access_token;
     static std::string provider_type;
+    static const std::string app_name;
     static const std::string api_key;
     static const std::string api_key_id;
     static const std::string api_key_name;
@@ -1408,7 +1409,15 @@ private:
         CHECK(request.method == HttpMethod::post);
         CHECK(request.headers.at("Content-Type") == "application/json;charset=utf-8");
 
-        CHECK(nlohmann::json::parse(request.body) == nlohmann::json({{"provider", provider_type}}));
+        CHECK(nlohmann::json::parse(request.body) == nlohmann::json({
+            {"provider", provider_type},
+            {"options", {
+                {"device", {
+                    {"appId", app_name},
+                    {"sdkVersion", ""}
+                }}
+            }}
+        }));
         CHECK(request.timeout_ms == 60000);
 
         std::string response = nlohmann::json({
@@ -1557,7 +1566,9 @@ std::string UnitTestTransport::access_token = good_access_token;
 
 static const std::string bad_access_token = "lolwut";
 static const std::string dummy_device_id = "123400000000000000000000";
+static const std::string app_name = "django";
 
+const std::string UnitTestTransport::app_name = "django";
 const std::string UnitTestTransport::api_key = "lVRPQVYBJSIbGos2ZZn0mGaIq1SIOsGaZ5lrcp8bxlR5jg4OGuGwQq1GkektNQ3i";
 const std::string UnitTestTransport::api_key_id = "5e5e6f0abe4ae2a2c2c2d329";
 const std::string UnitTestTransport::api_key_name = "some_api_key_name";
@@ -1575,7 +1586,7 @@ TEST_CASE("app: login_with_credentials unit_tests", "[sync][app]") {
         return std::unique_ptr<GenericNetworkTransport>(new UnitTestTransport);
     };
 
-    App app(App::Config{"django", factory});
+    App app(App::Config{app_name, factory});
 
     SECTION("login_anonymous good") {
         UnitTestTransport::access_token = good_access_token;
@@ -1627,7 +1638,7 @@ TEST_CASE("app: login_with_credentials unit_tests", "[sync][app]") {
             };
             return std::unique_ptr<GenericNetworkTransport>(new transport);
         };
-        app = App(App::Config{"django", factory});
+        app = App(App::Config{app_name, factory});
 
         bool processed = false;
 
@@ -1652,7 +1663,7 @@ TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app]") {
         return std::unique_ptr<GenericNetworkTransport>(new UnitTestTransport);
     };
     
-    auto config = App::Config{"translate-utwuv", factory};
+    auto config = App::Config{app_name, factory};
     auto app = App(config);
     std::string base_path = tmp_dir() + "/" + config.app_id;
     reset_test_directory(base_path);
@@ -1976,7 +1987,7 @@ TEST_CASE("app: switch user", "[sync][app]") {
         return std::unique_ptr<GenericNetworkTransport>(new UnitTestTransport());
     };
 
-    auto config = App::Config{"translate-utwuv", transport_generator};
+    auto config = App::Config{app_name, transport_generator};
     auto app = App(config);
     
     std::string base_path = tmp_dir() + "/" + config.app_id;
@@ -2074,7 +2085,7 @@ TEST_CASE("app: remove anonymous user", "[sync][app]") {
         return std::unique_ptr<GenericNetworkTransport>(new UnitTestTransport());
     };
 
-    auto config = App::Config{"translate-utwuv", transport_generator};
+    auto config = App::Config{app_name, transport_generator};
     auto app = App(config);
     
     std::string base_path = tmp_dir() + "/" + config.app_id;
@@ -2165,7 +2176,7 @@ TEST_CASE("app: remove user with credentials", "[sync][app]") {
         return std::unique_ptr<GenericNetworkTransport>(new transport);
     };
     
-    auto config = App::Config{"translate-utwuv", transport_generator};
+    auto config = App::Config{app_name, transport_generator};
     std::string base_path = tmp_dir() + "/" + config.app_id;
     reset_test_directory(base_path);
     auto tsm = TestSyncManager(base_path);
@@ -2244,7 +2255,7 @@ TEST_CASE("app: link_user", "[sync][app]") {
             return std::unique_ptr<GenericNetworkTransport>(new transport);
         };
         
-        auto config = App::Config{"translate-utwuv", transport_generator};
+        auto config = App::Config{app_name, transport_generator};
         std::string base_path = tmp_dir() + "/" + config.app_id;
         reset_test_directory(base_path);
         auto tsm = TestSyncManager(base_path);
@@ -2308,7 +2319,7 @@ TEST_CASE("app: link_user", "[sync][app]") {
             return std::unique_ptr<GenericNetworkTransport>(new transport);
         };
         
-        auto config = App::Config{"translate-utwuv", transport_generator};
+        auto config = App::Config{app_name, transport_generator};
         std::string base_path = tmp_dir() + "/" + config.app_id;
         reset_test_directory(base_path);
         auto tsm = TestSyncManager(base_path);
@@ -2455,7 +2466,7 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
             return std::unique_ptr<GenericNetworkTransport>(new transport);
         };
         
-        auto config = App::Config{"translate-utwuv", generic_factory};
+        auto config = App::Config{app_name, generic_factory};
         auto app = App(config);
         std::string base_path = tmp_dir() + "/" + config.app_id;
         reset_test_directory(base_path);
@@ -2510,7 +2521,7 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
             return std::unique_ptr<GenericNetworkTransport>(new transport);
         };
         
-        auto config = App::Config{"translate-utwuv", generic_factory};
+        auto config = App::Config{app_name, generic_factory};
         auto app = App(config);
         std::string base_path = tmp_dir() + "/" + config.app_id;
         reset_test_directory(base_path);
@@ -2614,7 +2625,7 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
             return std::unique_ptr<GenericNetworkTransport>(new transport);
         };
         
-        auto config = App::Config{"translate-utwuv", factory};
+        auto config = App::Config{app_name, factory};
         auto app = App(config);
         std::string base_path = tmp_dir() + "/" + config.app_id;
         reset_test_directory(base_path);

--- a/tests/sync/app.cpp
+++ b/tests/sync/app.cpp
@@ -224,8 +224,8 @@ TEST_CASE("app: login_with_credentials integration", "[sync][app]") {
             util::none,
             Optional<std::string>("A Local App Version"),
             util::none,
-            Optional<std::string>("Object Store Platform Tests"),
-            Optional<std::string>("Object Store Platform Version Blah"),
+            "Object Store Platform Tests",
+            "Object Store Platform Version Blah",
             "An sdk version"
         });
 
@@ -242,7 +242,7 @@ TEST_CASE("app: login_with_credentials integration", "[sync][app]") {
                     << error->error_code.message() << " (value: "
                     << error->error_code.value() << ")" <<std::endl;
             }
-            CHECK(user);
+            REQUIRE(user);
             CHECK(!user->device_id().empty());
             CHECK(user->has_device_id());
             CHECK(!error);
@@ -270,7 +270,18 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
     std::string config_path = get_config_path();
     REQUIRE(!base_url.empty());
     REQUIRE(!config_path.empty());
-    auto config = App::Config{get_runtime_app_id(config_path), factory, base_url};
+    auto config = App::Config {
+        get_runtime_app_id(config_path),
+        factory,
+        base_url,
+        util::none,
+        Optional<std::string>("A Local App Version"),
+        util::none,
+        "Object Store Platform Tests",
+        "Object Store Platform Version Blah",
+        "An sdk version"
+    };
+    
     auto app = App(config);
     std::string base_path = tmp_dir() + "/" + config.app_id;
     reset_test_directory(base_path);
@@ -423,7 +434,18 @@ TEST_CASE("app: UserAPIKeyProviderClient integration", "[sync][app]") {
     std::string config_path = get_config_path();
     REQUIRE(!base_url.empty());
     REQUIRE(!config_path.empty());
-    auto config = App::Config{get_runtime_app_id(config_path), factory, base_url};
+    auto config = App::Config {
+        get_runtime_app_id(config_path),
+        factory,
+        base_url,
+        util::none,
+        Optional<std::string>("A Local App Version"),
+        util::none,
+        "Object Store Platform Tests",
+        "Object Store Platform Version Blah",
+        "An sdk version"
+    };
+    
     auto app = App(config);
     std::string base_path = tmp_dir() + "/" + config.app_id;
     reset_test_directory(base_path);
@@ -754,7 +776,18 @@ TEST_CASE("app: auth providers function integration", "[sync][app]") {
     std::string config_path = get_config_path();
     REQUIRE(!base_url.empty());
     REQUIRE(!config_path.empty());
-    auto config = App::Config{get_runtime_app_id(config_path), factory, base_url};
+    auto config = App::Config {
+        get_runtime_app_id(config_path),
+        factory,
+        base_url,
+        util::none,
+        Optional<std::string>("A Local App Version"),
+        util::none,
+        "Object Store Platform Tests",
+        "Object Store Platform Version Blah",
+        "An sdk version"
+    };
+    
     auto app = App(config);
     std::string base_path = tmp_dir() + "/" + config.app_id;
     reset_test_directory(base_path);
@@ -794,7 +827,18 @@ TEST_CASE("app: link_user integration", "[sync][app]") {
         std::string config_path = get_config_path();
         REQUIRE(!base_url.empty());
         REQUIRE(!config_path.empty());
-        auto config = App::Config{get_runtime_app_id(config_path), factory, base_url};
+        auto config = App::Config {
+            get_runtime_app_id(config_path),
+            factory,
+            base_url,
+            util::none,
+            Optional<std::string>("A Local App Version"),
+            util::none,
+            "Object Store Platform Tests",
+            "Object Store Platform Version Blah",
+            "An sdk version"
+        };
+        
         auto app = App(config);
         std::string base_path = tmp_dir() + "/" + config.app_id;
         reset_test_directory(base_path);
@@ -847,7 +891,18 @@ TEST_CASE("app: call function", "[sync][app]") {
     std::string config_path = get_config_path();
     REQUIRE(!base_url.empty());
     REQUIRE(!config_path.empty());
-    auto config = App::Config{get_runtime_app_id(config_path), factory, base_url};
+    auto config = App::Config {
+        get_runtime_app_id(config_path),
+        factory,
+        base_url,
+        util::none,
+        Optional<std::string>("A Local App Version"),
+        util::none,
+        "Object Store Platform Tests",
+        "Object Store Platform Version Blah",
+        "An sdk version"
+    };
+    
     auto app = App(config);
     std::string base_path = tmp_dir() + "/" + config.app_id;
     reset_test_directory(base_path);
@@ -890,7 +945,18 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
     std::string config_path = get_config_path();
     REQUIRE(!base_url.empty());
     REQUIRE(!config_path.empty());
-    auto config = App::Config{get_runtime_app_id(config_path), factory, base_url};
+    auto config = App::Config {
+        get_runtime_app_id(config_path),
+        factory,
+        base_url,
+        util::none,
+        Optional<std::string>("A Local App Version"),
+        util::none,
+        "Object Store Platform Tests",
+        "Object Store Platform Version Blah",
+        "An sdk version"
+    };
+    
     auto app = App::get_shared_app(config);
     std::string base_path = tmp_dir() + "/" + config.app_id;
     reset_test_directory(base_path);
@@ -1287,8 +1353,20 @@ TEST_CASE("app: custom error handling", "[sync][app][custom_errors]") {
         std::unique_ptr<GenericNetworkTransport> (*factory)() = []{
             return std::unique_ptr<GenericNetworkTransport>(new CustomErrorTransport(1001, "Boom!"));
         };
+        
+        auto config = App::Config {
+            "anything",
+            factory,
+            util::none,
+            util::none,
+            Optional<std::string>("A Local App Version"),
+            util::none,
+            "Object Store Platform Tests",
+            "Object Store Platform Version Blah",
+            "An sdk version"
+        };
 
-        auto app = App(App::Config{"anything", factory});
+        auto app = App(config);
         bool processed = false;
         app.log_in_with_credentials(AppCredentials::anonymous(),
             [&](std::shared_ptr<SyncUser> user, Optional<app::AppError> error) {
@@ -1414,7 +1492,10 @@ private:
             {"options", {
                 {"device", {
                     {"appId", app_name},
-                    {"sdkVersion", ""}
+                    {"appVersion", "A Local App Version"},
+                    {"platform", "Object Store Platform Tests"},
+                    {"platformVersion", "Object Store Platform Version Blah"},
+                    {"sdkVersion", "An sdk version"}
                 }}
             }}
         }));
@@ -1586,7 +1667,19 @@ TEST_CASE("app: login_with_credentials unit_tests", "[sync][app]") {
         return std::unique_ptr<GenericNetworkTransport>(new UnitTestTransport);
     };
 
-    App app(App::Config{app_name, factory});
+    auto config = App::Config {
+        app_name,
+        factory,
+        util::none,
+        util::none,
+        Optional<std::string>("A Local App Version"),
+        util::none,
+        "Object Store Platform Tests",
+        "Object Store Platform Version Blah",
+        "An sdk version"
+    };
+
+    auto app = App(config);
 
     SECTION("login_anonymous good") {
         UnitTestTransport::access_token = good_access_token;
@@ -1638,7 +1731,20 @@ TEST_CASE("app: login_with_credentials unit_tests", "[sync][app]") {
             };
             return std::unique_ptr<GenericNetworkTransport>(new transport);
         };
-        app = App(App::Config{app_name, factory});
+        
+        auto config = App::Config {
+            app_name,
+            factory,
+            util::none,
+            util::none,
+            Optional<std::string>("A Local App Version"),
+            util::none,
+            "Object Store Platform Tests",
+            "Object Store Platform Version Blah",
+            "An sdk version"
+        };
+
+        app = App(config);
 
         bool processed = false;
 
@@ -1663,7 +1769,18 @@ TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app]") {
         return std::unique_ptr<GenericNetworkTransport>(new UnitTestTransport);
     };
     
-    auto config = App::Config{app_name, factory};
+    auto config = App::Config {
+        app_name,
+        factory,
+        util::none,
+        util::none,
+        Optional<std::string>("A Local App Version"),
+        util::none,
+        "Object Store Platform Tests",
+        "Object Store Platform Version Blah",
+        "An sdk version"
+    };
+
     auto app = App(config);
     std::string base_path = tmp_dir() + "/" + config.app_id;
     reset_test_directory(base_path);
@@ -1744,8 +1861,21 @@ TEST_CASE("app: user_semantics", "[app]") {
     };
 
     const auto app_id = random_string(36);
-    App app(App::Config{app_id, factory});
+    
+    auto config = App::Config {
+        app_id,
+        factory,
+        util::none,
+        util::none,
+        Optional<std::string>("A Local App Version"),
+        util::none,
+        "Object Store Platform Tests",
+        "Object Store Platform Version Blah",
+        "An sdk version"
+    };
 
+    auto app = App(config);
+    
     const std::function<std::shared_ptr<SyncUser>(app::AppCredentials)> login_user = [&app](app::AppCredentials creds) {
         std::shared_ptr<SyncUser> test_user;
         app.log_in_with_credentials(creds,
@@ -1881,7 +2011,20 @@ TEST_CASE("app: response error handling", "[sync][app]") {
     std::function<std::unique_ptr<GenericNetworkTransport>()> transport_generator = [&response] {
         return std::unique_ptr<GenericNetworkTransport>(new ErrorCheckingTransport(response));
     };
-    App app(App::Config{"my-app-id", transport_generator});
+    
+    auto config = App::Config {
+        "my-app-id",
+        transport_generator,
+        util::none,
+        util::none,
+        Optional<std::string>("A Local App Version"),
+        util::none,
+        "Object Store Platform Tests",
+        "Object Store Platform Version Blah",
+        "An sdk version"
+    };
+    auto app = App(config);
+    
     bool processed = false;
 
     SECTION("http 404") {
@@ -1987,7 +2130,17 @@ TEST_CASE("app: switch user", "[sync][app]") {
         return std::unique_ptr<GenericNetworkTransport>(new UnitTestTransport());
     };
 
-    auto config = App::Config{app_name, transport_generator};
+    auto config = App::Config {
+        app_name,
+        transport_generator,
+        util::none,
+        util::none,
+        Optional<std::string>("A Local App Version"),
+        util::none,
+        "Object Store Platform Tests",
+        "Object Store Platform Version Blah",
+        "An sdk version"
+    };
     auto app = App(config);
     
     std::string base_path = tmp_dir() + "/" + config.app_id;
@@ -2085,7 +2238,17 @@ TEST_CASE("app: remove anonymous user", "[sync][app]") {
         return std::unique_ptr<GenericNetworkTransport>(new UnitTestTransport());
     };
 
-    auto config = App::Config{app_name, transport_generator};
+    auto config = App::Config {
+        app_name,
+        transport_generator,
+        util::none,
+        util::none,
+        Optional<std::string>("A Local App Version"),
+        util::none,
+        "Object Store Platform Tests",
+        "Object Store Platform Version Blah",
+        "An sdk version"
+    };
     auto app = App(config);
     
     std::string base_path = tmp_dir() + "/" + config.app_id;
@@ -2176,7 +2339,18 @@ TEST_CASE("app: remove user with credentials", "[sync][app]") {
         return std::unique_ptr<GenericNetworkTransport>(new transport);
     };
     
-    auto config = App::Config{app_name, transport_generator};
+   auto config = App::Config {
+       app_name,
+       transport_generator,
+       util::none,
+       util::none,
+       Optional<std::string>("A Local App Version"),
+       util::none,
+       "Object Store Platform Tests",
+       "Object Store Platform Version Blah",
+       "An sdk version"
+   };
+    
     std::string base_path = tmp_dir() + "/" + config.app_id;
     reset_test_directory(base_path);
     auto tsm = TestSyncManager(base_path);
@@ -2255,7 +2429,18 @@ TEST_CASE("app: link_user", "[sync][app]") {
             return std::unique_ptr<GenericNetworkTransport>(new transport);
         };
         
-        auto config = App::Config{app_name, transport_generator};
+        auto config = App::Config {
+            app_name,
+            transport_generator,
+            util::none,
+            util::none,
+            Optional<std::string>("A Local App Version"),
+            util::none,
+            "Object Store Platform Tests",
+            "Object Store Platform Version Blah",
+            "An sdk version"
+        };
+        
         std::string base_path = tmp_dir() + "/" + config.app_id;
         reset_test_directory(base_path);
         auto tsm = TestSyncManager(base_path);
@@ -2319,7 +2504,18 @@ TEST_CASE("app: link_user", "[sync][app]") {
             return std::unique_ptr<GenericNetworkTransport>(new transport);
         };
         
-        auto config = App::Config{app_name, transport_generator};
+        auto config = App::Config {
+            app_name,
+            transport_generator,
+            util::none,
+            util::none,
+            Optional<std::string>("A Local App Version"),
+            util::none,
+            "Object Store Platform Tests",
+            "Object Store Platform Version Blah",
+            "An sdk version"
+        };
+        
         std::string base_path = tmp_dir() + "/" + config.app_id;
         reset_test_directory(base_path);
         auto tsm = TestSyncManager(base_path);
@@ -2466,7 +2662,18 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
             return std::unique_ptr<GenericNetworkTransport>(new transport);
         };
         
-        auto config = App::Config{app_name, generic_factory};
+        auto config = App::Config {
+            app_name,
+            generic_factory,
+            util::none,
+            util::none,
+            Optional<std::string>("A Local App Version"),
+            util::none,
+            "Object Store Platform Tests",
+            "Object Store Platform Version Blah",
+            "An sdk version"
+        };
+        
         auto app = App(config);
         std::string base_path = tmp_dir() + "/" + config.app_id;
         reset_test_directory(base_path);
@@ -2521,7 +2728,18 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
             return std::unique_ptr<GenericNetworkTransport>(new transport);
         };
         
-        auto config = App::Config{app_name, generic_factory};
+        auto config = App::Config {
+            app_name,
+            generic_factory,
+            util::none,
+            util::none,
+            Optional<std::string>("A Local App Version"),
+            util::none,
+            "Object Store Platform Tests",
+            "Object Store Platform Version Blah",
+            "An sdk version"
+        };
+        
         auto app = App(config);
         std::string base_path = tmp_dir() + "/" + config.app_id;
         reset_test_directory(base_path);
@@ -2625,7 +2843,18 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
             return std::unique_ptr<GenericNetworkTransport>(new transport);
         };
         
-        auto config = App::Config{app_name, factory};
+        auto config = App::Config {
+            app_name,
+            factory,
+            util::none,
+            util::none,
+            Optional<std::string>("A Local App Version"),
+            util::none,
+            "Object Store Platform Tests",
+            "Object Store Platform Version Blah",
+            "An sdk version"
+        };
+        
         auto app = App(config);
         std::string base_path = tmp_dir() + "/" + config.app_id;
         reset_test_directory(base_path);

--- a/tests/sync/app.cpp
+++ b/tests/sync/app.cpp
@@ -1391,6 +1391,7 @@ static const std::string profile_0_gender = "Ursus thibetanus";
 static const std::string profile_0_birthday = "Ursus americanus";
 static const std::string profile_0_min_age = "Ursus maritimus";
 static const std::string profile_0_max_age = "Ursus arctos";
+static const std::string app_name = "django";
 
 static const nlohmann::json profile_0 = {
     {"name", profile_0_name},
@@ -1442,7 +1443,6 @@ class UnitTestTransport : public GenericNetworkTransport {
 public:
     static std::string access_token;
     static std::string provider_type;
-    static const std::string app_name;
     static const std::string api_key;
     static const std::string api_key_id;
     static const std::string api_key_name;
@@ -1647,9 +1647,7 @@ std::string UnitTestTransport::access_token = good_access_token;
 
 static const std::string bad_access_token = "lolwut";
 static const std::string dummy_device_id = "123400000000000000000000";
-static const std::string app_name = "django";
 
-const std::string UnitTestTransport::app_name = "django";
 const std::string UnitTestTransport::api_key = "lVRPQVYBJSIbGos2ZZn0mGaIq1SIOsGaZ5lrcp8bxlR5jg4OGuGwQq1GkektNQ3i";
 const std::string UnitTestTransport::api_key_id = "5e5e6f0abe4ae2a2c2c2d329";
 const std::string UnitTestTransport::api_key_name = "some_api_key_name";

--- a/tests/sync/app.cpp
+++ b/tests/sync/app.cpp
@@ -211,12 +211,10 @@ TEST_CASE("app: login_with_credentials integration", "[sync][app]") {
 
         std::string base_url = get_base_url();
         std::string config_path = get_config_path();
-        std::string device_id = "123400000000000000000000";
         std::cout << "base_url for [app] integration tests is set to: " << base_url << std::endl;
         std::cout << "config_path for [app] integration tests is set to: " << config_path << std::endl;
         REQUIRE(!base_url.empty());
         REQUIRE(!config_path.empty());
-        REQUIRE(!device_id.empty());
         
         // this app id is configured in tests/mongodb/stitch.json
         auto app = App(App::Config{
@@ -224,9 +222,11 @@ TEST_CASE("app: login_with_credentials integration", "[sync][app]") {
             factory,
             base_url,
             util::none,
+            Optional<std::string>("A Local App Version"),
             util::none,
-            util::none,
-            device_id
+            Optional<std::string>("Object Store Platform Tests"),
+            Optional<std::string>("Object Store Platform Version Blah"),
+            "An sdk version"
         });
 
         bool processed = false;
@@ -243,7 +243,8 @@ TEST_CASE("app: login_with_credentials integration", "[sync][app]") {
                     << error->error_code.value() << ")" <<std::endl;
             }
             CHECK(user);
-            CHECK(user->device_id == device_id);
+            CHECK(!user->device_id().empty());
+            CHECK(user->has_device_id());
             CHECK(!error);
         });
 
@@ -1555,6 +1556,7 @@ static const std::string good_access_token2 =  "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpX
 std::string UnitTestTransport::access_token = good_access_token;
 
 static const std::string bad_access_token = "lolwut";
+static const std::string dummy_device_id = "123400000000000000000000";
 
 const std::string UnitTestTransport::api_key = "lVRPQVYBJSIbGos2ZZn0mGaIq1SIOsGaZ5lrcp8bxlR5jg4OGuGwQq1GkektNQ3i";
 const std::string UnitTestTransport::api_key_id = "5e5e6f0abe4ae2a2c2c2d329";
@@ -1659,7 +1661,7 @@ TEST_CASE("app: UserAPIKeyProviderClient unit_tests", "[sync][app]") {
                                                                                      good_access_token,
                                                                                      good_access_token,
                                                                                      "anon-user",
-                                                                                     util::none);
+                                                                                     dummy_device_id);
     bool processed = false;
     ObjectId obj_id(UnitTestTransport::api_key_id.c_str());
 
@@ -2428,7 +2430,7 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
                                                   good_access_token,
                                                   good_access_token,
                                                   "anon-user",
-                                                  util::none);
+                                                  dummy_device_id);
         };
         
         static bool session_route_hit = false;
@@ -2483,7 +2485,7 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
                                                   good_access_token,
                                                   good_access_token,
                                                   "anon-user",
-                                                  util::none);
+                                                  dummy_device_id);
         };
         
         static bool session_route_hit = false;
@@ -2539,7 +2541,7 @@ TEST_CASE("app: refresh access token unit tests", "[sync][app]") {
                                                   good_access_token,
                                                   good_access_token,
                                                   "anon-user",
-                                                  util::none);
+                                                  dummy_device_id);
         };
         
         /*

--- a/tests/sync/session/connection_change_notifications.cpp
+++ b/tests/sync/session/connection_change_notifications.cpp
@@ -41,6 +41,7 @@ using namespace realm;
 using namespace realm::util;
 
 static const std::string dummy_auth_url = "https://realm.example.org";
+static const std::string dummy_device_id = "123400000000000000000000";
 
 static const std::string base_path = tmp_dir() + "realm_objectstore_sync_connection_state_changes/";
 
@@ -55,7 +56,7 @@ TEST_CASE("sync: Connection state changes", "[sync]") {
                                                ENCODE_FAKE_JWT("not_a_real_token"),
                                                ENCODE_FAKE_JWT("also_not_a_real_token"),
                                                dummy_auth_url,
-                                               util::none);
+                                               dummy_device_id);
 
     SECTION("register connection change listener") {
         auto session = sync_session(user, "/connection-state-changes-1",

--- a/tests/sync/session/connection_change_notifications.cpp
+++ b/tests/sync/session/connection_change_notifications.cpp
@@ -54,7 +54,8 @@ TEST_CASE("sync: Connection state changes", "[sync]") {
     auto user = SyncManager::shared().get_user("user",
                                                ENCODE_FAKE_JWT("not_a_real_token"),
                                                ENCODE_FAKE_JWT("also_not_a_real_token"),
-                                               dummy_auth_url);
+                                               dummy_auth_url,
+                                               util::none);
 
     SECTION("register connection change listener") {
         auto session = sync_session(user, "/connection-state-changes-1",

--- a/tests/sync/session/session.cpp
+++ b/tests/sync/session/session.cpp
@@ -41,6 +41,7 @@ using namespace realm;
 using namespace realm::util;
 
 static const std::string dummy_auth_url = "https://realm.example.org";
+static const std::string dummy_device_id = "123400000000000000000000";
 
 TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
     if (!EventLoop::has_implementation())
@@ -57,7 +58,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
                                                    ENCODE_FAKE_JWT("fake_refresh_token"),
                                                    ENCODE_FAKE_JWT("fake_access_token"),
                                                    dummy_auth_url,
-                                                   util::none);
+                                                   dummy_device_id);
         auto session1 = sync_session(user, "/test1a-1",
                                      [](auto, auto) { },
                                      SyncSessionStopPolicy::AfterChangesUploaded,
@@ -79,7 +80,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
     }
 
     SECTION("a SyncUser properly unbinds its sessions upon logging out") {
-        auto user = SyncManager::shared().get_user("user1b", ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), dummy_auth_url, util::none);
+        auto user = SyncManager::shared().get_user("user1b", ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), dummy_auth_url, dummy_device_id);
         auto session1 = sync_session(user, "/test1b-1",
                                      [](auto, auto) { });
         auto session2 = sync_session(user, "/test1b-2",
@@ -95,7 +96,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
 
     SECTION("a SyncUser defers binding new sessions until it is logged in") {
         const std::string user_id = "user1c";
-        auto user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), dummy_auth_url, util::none);
+        auto user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), dummy_auth_url, dummy_device_id);
         user->log_out();
         REQUIRE(user->state() == SyncUser::State::LoggedOut);
         auto session1 = sync_session(user, "/test1c-1",
@@ -108,14 +109,14 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
         REQUIRE(sessions_are_inactive(*session2));
         REQUIRE(user->all_sessions().size() == 0);
         // Log the user back in via the sync manager.
-        user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), dummy_auth_url, util::none);
+        user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), dummy_auth_url, dummy_device_id);
         EventLoop::main().run_until([&] { return sessions_are_active(*session1, *session2); });
         REQUIRE(user->all_sessions().size() == 2);
     }
 
     SECTION("a SyncUser properly rebinds existing sessions upon logging back in") {
         const std::string user_id = "user1d";
-        auto user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), dummy_auth_url, util::none);
+        auto user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), dummy_auth_url, dummy_device_id);
         auto session1 = sync_session(user, "/test1d-1",
                                      [](auto, auto) { });
         auto session2 = sync_session(user, "/test1d-2",
@@ -132,7 +133,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
         REQUIRE(sessions_are_inactive(*session2));
         REQUIRE(user->all_sessions().size() == 0);
         // Log the user back in via the sync manager.
-        user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), dummy_auth_url, util::none);
+        user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), dummy_auth_url, dummy_device_id);
         EventLoop::main().run_until([&] { return sessions_are_active(*session1, *session2); });
         REQUIRE(user->all_sessions().size() == 2);
     }
@@ -142,7 +143,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
         std::weak_ptr<SyncSession> weak_session;
         std::string on_disk_path;
         util::Optional<SyncConfig> config;
-        auto user = SyncManager::shared().get_user("user1e", ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), dummy_auth_url, util::none);
+        auto user = SyncManager::shared().get_user("user1e", ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), dummy_auth_url, dummy_device_id);
         {
             // Create the session within a nested scope, so we can control its lifetime.
             auto session = sync_session(user, path,
@@ -167,7 +168,7 @@ TEST_CASE("SyncSession: management by SyncUser", "[sync]") {
     }
 
     SECTION("a user can create multiple sessions for the same URL") {
-        auto user = SyncManager::shared().get_user("user", ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), dummy_auth_url, util::none);
+        auto user = SyncManager::shared().get_user("user", ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), dummy_auth_url, dummy_device_id);
         auto create_session = [&]() {
             // Note that this should put the sessions at different paths.
             return sync_session(user, "/test",
@@ -189,7 +190,7 @@ TEST_CASE("sync: log-in", "[sync]") {
     auto user = SyncManager::shared().get_user("user",
                                                ENCODE_FAKE_JWT("fake_refresh_token"),
                                                ENCODE_FAKE_JWT("fake_access_token"),
-                                               dummy_auth_url, util::none);
+                                               dummy_auth_url, dummy_device_id);
 
     SECTION("Can log in") {
         std::atomic<int> error_count(0);
@@ -210,7 +211,7 @@ TEST_CASE("SyncSession: close() API", "[sync]") {
     SyncServer server;
     TestSyncManager init_sync_manager(server);
 
-    auto user = SyncManager::shared().get_user("close-api-tests-user", ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), "https://realm.example.org", util::none);
+    auto user = SyncManager::shared().get_user("close-api-tests-user", ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), "https://realm.example.org", dummy_device_id);
 
     SECTION("Behaves properly when called on session in the 'active' or 'inactive' state") {
         auto session = sync_session(user, "/test-close-for-active",
@@ -231,7 +232,7 @@ TEST_CASE("SyncSession: update_configuration()", "[sync]") {
     SyncServer server{false};
     TestSyncManager init_sync_manager(server);
 
-    auto user = SyncManager::shared().get_user("userid", ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), dummy_auth_url, util::none);
+    auto user = SyncManager::shared().get_user("userid", ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), dummy_auth_url, dummy_device_id);
     auto session =  sync_session(user, "/update_configuration",
                                  [](auto, auto) { },
                                  SyncSessionStopPolicy::AfterChangesUploaded);
@@ -273,7 +274,7 @@ TEST_CASE("sync: error handling", "[sync]") {
     std::function<void(std::shared_ptr<SyncSession>, SyncError)> error_handler = [](auto, auto) { };
     const std::string user_id = "user1d";
     std::string on_disk_path;
-    auto user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), "https://realm.example.org", util::none);
+    auto user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), "https://realm.example.org", dummy_device_id);
     auto session = sync_session(user, "/test1e",
                                 [&](auto session, SyncError error) {
                                     error_handler(std::move(session), std::move(error));
@@ -346,7 +347,7 @@ TEST_CASE("sync: error handling", "[sync]") {
 }
 
 struct RegularUser {
-    static auto user() { return SyncManager::shared().get_user("user-dying-state", ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), dummy_auth_url, util::none); }
+    static auto user() { return SyncManager::shared().get_user("user-dying-state", ENCODE_FAKE_JWT("fake_refresh_token"), ENCODE_FAKE_JWT("fake_access_token"), dummy_auth_url, dummy_device_id); }
 };
 
 TEMPLATE_TEST_CASE("sync: stop policy behavior", "[sync]", RegularUser) {

--- a/tests/sync/session/wait_for_completion.cpp
+++ b/tests/sync/session/wait_for_completion.cpp
@@ -31,7 +31,8 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
         return;
 
     const std::string dummy_auth_url = "https://realm.example.org";
-
+    const std::string dummy_device_id = "123400000000000000000000";
+    
     SyncServer server{false};
     // Disable file-related functionality and metadata functionality for testing purposes.
     TestSyncManager init_sync_manager(server, "", SyncManager::MetadataMode::NoMetadata);
@@ -40,7 +41,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
 
     SECTION("works properly when called after the session is bound") {
         server.start();
-        auto user = SyncManager::shared().get_user("user-async-wait-download-1", ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, util::none);
+        auto user = SyncManager::shared().get_user("user-async-wait-download-1", ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, dummy_device_id);
         auto session = sync_session(user, "/async-wait-download-1",
                                     [](auto, auto) { });
         EventLoop::main().run_until([&] { return sessions_are_active(*session); });
@@ -54,7 +55,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
     SECTION("works properly when called on a logged-out session") {
         server.start();
         const auto user_id = "user-async-wait-download-3";
-        auto user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, util::none);
+        auto user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, dummy_device_id);
         auto session = sync_session(user, "/user-async-wait-download-3",
                                     [](auto, auto) { });
         EventLoop::main().run_until([&] { return sessions_are_active(*session); });
@@ -68,7 +69,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
         spin_runloop();
         REQUIRE(handler_called == false);
         // Log the user back in
-        user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, util::none);
+        user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, dummy_device_id);
         EventLoop::main().run_until([&] { return sessions_are_active(*session); });
         // Now, wait for the completion handler to be called.
         EventLoop::main().run_until([&] { return handler_called == true; });
@@ -76,7 +77,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
 
     SECTION("aborts properly when queued and the session errors out") {
         using ProtocolError = realm::sync::ProtocolError;
-        auto user = SyncManager::shared().get_user("user-async-wait-download-4", ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, util::none);
+        auto user = SyncManager::shared().get_user("user-async-wait-download-4", ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, dummy_device_id);
         std::atomic<int> error_count(0);
         std::shared_ptr<SyncSession> session = sync_session(user, "/async-wait-download-4",
                                                             [&](auto, auto) { ++error_count; });
@@ -99,6 +100,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
         return;
 
     const std::string dummy_auth_url = "https://realm.example.org";
+    const std::string dummy_device_id = "123400000000000000000000";
 
     SyncServer server{false};
     // Disable file-related functionality and metadata functionality for testing purposes.
@@ -108,7 +110,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
 
     SECTION("works properly when called after the session is bound") {
         server.start();
-        auto user = SyncManager::shared().get_user("user-async-wait-upload-1", ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, util::none);
+        auto user = SyncManager::shared().get_user("user-async-wait-upload-1", ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, dummy_device_id);
         auto session = sync_session(user, "/async-wait-upload-1",
                                     [](auto, auto) { });
         EventLoop::main().run_until([&] { return sessions_are_active(*session); });
@@ -122,7 +124,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
     SECTION("works properly when called on a logged-out session") {
         server.start();
         const auto user_id = "user-async-wait-upload-3";
-        auto user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, util::none);
+        auto user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, dummy_device_id);
         auto session = sync_session(user, "/user-async-wait-upload-3",
                                     [](auto, auto) { });
         EventLoop::main().run_until([&] { return sessions_are_active(*session); });
@@ -136,7 +138,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
         spin_runloop();
         REQUIRE(handler_called == false);
         // Log the user back in
-        user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, util::none);
+        user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, dummy_device_id);
         EventLoop::main().run_until([&] { return sessions_are_active(*session); });
         // Now, wait for the completion handler to be called.
         EventLoop::main().run_until([&] { return handler_called == true; });
@@ -144,7 +146,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
 
     SECTION("aborts properly when queued and the session errors out") {
         using ProtocolError = realm::sync::ProtocolError;
-        auto user = SyncManager::shared().get_user("user-async-wait-upload-4", ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, util::none);
+        auto user = SyncManager::shared().get_user("user-async-wait-upload-4", ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, dummy_device_id);
         std::atomic<int> error_count(0);
         std::shared_ptr<SyncSession> session = sync_session(user, "/async-wait-upload-4",
                                                             [&](auto, auto) { ++error_count; });

--- a/tests/sync/session/wait_for_completion.cpp
+++ b/tests/sync/session/wait_for_completion.cpp
@@ -40,7 +40,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
 
     SECTION("works properly when called after the session is bound") {
         server.start();
-        auto user = SyncManager::shared().get_user("user-async-wait-download-1", ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url);
+        auto user = SyncManager::shared().get_user("user-async-wait-download-1", ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, util::none);
         auto session = sync_session(user, "/async-wait-download-1",
                                     [](auto, auto) { });
         EventLoop::main().run_until([&] { return sessions_are_active(*session); });
@@ -54,7 +54,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
     SECTION("works properly when called on a logged-out session") {
         server.start();
         const auto user_id = "user-async-wait-download-3";
-        auto user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url);
+        auto user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, util::none);
         auto session = sync_session(user, "/user-async-wait-download-3",
                                     [](auto, auto) { });
         EventLoop::main().run_until([&] { return sessions_are_active(*session); });
@@ -68,7 +68,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
         spin_runloop();
         REQUIRE(handler_called == false);
         // Log the user back in
-        user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url);
+        user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, util::none);
         EventLoop::main().run_until([&] { return sessions_are_active(*session); });
         // Now, wait for the completion handler to be called.
         EventLoop::main().run_until([&] { return handler_called == true; });
@@ -76,7 +76,7 @@ TEST_CASE("SyncSession: wait_for_download_completion() API", "[sync]") {
 
     SECTION("aborts properly when queued and the session errors out") {
         using ProtocolError = realm::sync::ProtocolError;
-        auto user = SyncManager::shared().get_user("user-async-wait-download-4", ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url);
+        auto user = SyncManager::shared().get_user("user-async-wait-download-4", ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, util::none);
         std::atomic<int> error_count(0);
         std::shared_ptr<SyncSession> session = sync_session(user, "/async-wait-download-4",
                                                             [&](auto, auto) { ++error_count; });
@@ -108,7 +108,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
 
     SECTION("works properly when called after the session is bound") {
         server.start();
-        auto user = SyncManager::shared().get_user("user-async-wait-upload-1", ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url);
+        auto user = SyncManager::shared().get_user("user-async-wait-upload-1", ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, util::none);
         auto session = sync_session(user, "/async-wait-upload-1",
                                     [](auto, auto) { });
         EventLoop::main().run_until([&] { return sessions_are_active(*session); });
@@ -122,7 +122,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
     SECTION("works properly when called on a logged-out session") {
         server.start();
         const auto user_id = "user-async-wait-upload-3";
-        auto user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url);
+        auto user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, util::none);
         auto session = sync_session(user, "/user-async-wait-upload-3",
                                     [](auto, auto) { });
         EventLoop::main().run_until([&] { return sessions_are_active(*session); });
@@ -136,7 +136,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
         spin_runloop();
         REQUIRE(handler_called == false);
         // Log the user back in
-        user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url);
+        user = SyncManager::shared().get_user(user_id, ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, util::none);
         EventLoop::main().run_until([&] { return sessions_are_active(*session); });
         // Now, wait for the completion handler to be called.
         EventLoop::main().run_until([&] { return handler_called == true; });
@@ -144,7 +144,7 @@ TEST_CASE("SyncSession: wait_for_upload_completion() API", "[sync]") {
 
     SECTION("aborts properly when queued and the session errors out") {
         using ProtocolError = realm::sync::ProtocolError;
-        auto user = SyncManager::shared().get_user("user-async-wait-upload-4", ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url);
+        auto user = SyncManager::shared().get_user("user-async-wait-upload-4", ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("not_a_real_token"), dummy_auth_url, util::none);
         std::atomic<int> error_count(0);
         std::shared_ptr<SyncSession> session = sync_session(user, "/async-wait-upload-4",
                                                             [&](auto, auto) { ++error_count; });

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -77,7 +77,7 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync]") {
         TestSyncManager init_sync_manager("", base_path, SyncManager::MetadataMode::NoMetadata);
         // Get a sync user
         const std::string identity = "foobarbaz";
-        auto user = SyncManager::shared().get_user(identity, ENCODE_FAKE_JWT("dummy_token"), ENCODE_FAKE_JWT("not_a_real_token"), auth_server_url);
+        auto user = SyncManager::shared().get_user(identity, ENCODE_FAKE_JWT("dummy_token"), ENCODE_FAKE_JWT("not_a_real_token"), auth_server_url, util::none);
         const auto expected = base_path + "realm-object-server/foobarbaz/realms%3A%2F%2Frealm.example.org%2Fa%2Fb%2F%7E%2F123456%2Fxyz";
         REQUIRE(SyncManager::shared().path_for_realm(*user, raw_url) == expected);
         // This API should also generate the directory if it doesn't already exist.
@@ -87,7 +87,7 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync]") {
     SECTION("should work properly with metadata") {
         TestSyncManager init_sync_manager("", base_path, SyncManager::MetadataMode::NoEncryption);
         const std::string identity = "foobarbaz";
-        auto user = SyncManager::shared().get_user(identity, ENCODE_FAKE_JWT("dummy_token"), ENCODE_FAKE_JWT("not_a_real_token"), auth_server_url);
+        auto user = SyncManager::shared().get_user(identity, ENCODE_FAKE_JWT("dummy_token"), ENCODE_FAKE_JWT("not_a_real_token"), auth_server_url, util::none);
         auto local_identity = user->local_identity();
         const auto expected = base_path + "realm-object-server/" + local_identity + "/realms%3A%2F%2Frealm.example.org%2Fa%2Fb%2F%7E%2F123456%2Fxyz";
         REQUIRE(SyncManager::shared().path_for_realm(*user, raw_url) == expected);
@@ -117,8 +117,8 @@ TEST_CASE("sync_manager: user state management", "[sync]") {
     const std::string identity_3 = "user-baz";
 
     SECTION("should get all users that are created during run time") {
-        SyncManager::shared().get_user(identity_1, r_token_1, a_token_1, url_1);
-        SyncManager::shared().get_user(identity_2, r_token_2, a_token_2, url_2);
+        SyncManager::shared().get_user(identity_1, r_token_1, a_token_1, url_1, util::none);
+        SyncManager::shared().get_user(identity_2, r_token_2, a_token_2, url_2, util::none);
         auto users = SyncManager::shared().all_users();
         REQUIRE(users.size() == 2);
         CHECK(validate_user_in_vector(users, identity_1, url_1, r_token_1, a_token_1));
@@ -126,10 +126,10 @@ TEST_CASE("sync_manager: user state management", "[sync]") {
     }
 
     SECTION("should be able to distinguish users based solely on URL") {
-        SyncManager::shared().get_user(identity_1, r_token_1, a_token_1, url_1);
-        SyncManager::shared().get_user(identity_1, r_token_1, a_token_1, url_2);
-        SyncManager::shared().get_user(identity_1, r_token_1, a_token_1, url_3);
-        SyncManager::shared().get_user(identity_1, r_token_1, a_token_1, url_1); // existing
+        SyncManager::shared().get_user(identity_1, r_token_1, a_token_1, url_1, util::none);
+        SyncManager::shared().get_user(identity_1, r_token_1, a_token_1, url_2, util::none);
+        SyncManager::shared().get_user(identity_1, r_token_1, a_token_1, url_3, util::none);
+        SyncManager::shared().get_user(identity_1, r_token_1, a_token_1, url_1, util::none); // existing
         auto users = SyncManager::shared().all_users();
         REQUIRE(users.size() == 3);
         CHECK(validate_user_in_vector(users, identity_1, url_1, r_token_1, a_token_1));
@@ -138,10 +138,10 @@ TEST_CASE("sync_manager: user state management", "[sync]") {
     }
 
     SECTION("should be able to distinguish users based solely on user ID") {
-        SyncManager::shared().get_user(identity_1, r_token_1, a_token_1, url_1);
-        SyncManager::shared().get_user(identity_2, r_token_1, a_token_1, url_1);
-        SyncManager::shared().get_user(identity_3, r_token_1, a_token_1, url_1);
-        SyncManager::shared().get_user(identity_1, r_token_1, a_token_1, url_1); // existing
+        SyncManager::shared().get_user(identity_1, r_token_1, a_token_1, url_1, util::none);
+        SyncManager::shared().get_user(identity_2, r_token_1, a_token_1, url_1, util::none);
+        SyncManager::shared().get_user(identity_3, r_token_1, a_token_1, url_1, util::none);
+        SyncManager::shared().get_user(identity_1, r_token_1, a_token_1, url_1, util::none); // existing
         auto users = SyncManager::shared().all_users();
         REQUIRE(users.size() == 3);
         CHECK(validate_user_in_vector(users, identity_1, url_1, r_token_1, a_token_1));
@@ -153,9 +153,9 @@ TEST_CASE("sync_manager: user state management", "[sync]") {
         auto r_token_3a = ENCODE_FAKE_JWT("qwerty");
         auto a_token_3a = ENCODE_FAKE_JWT("ytrewq");
 
-        auto u1 = SyncManager::shared().get_user(identity_1, r_token_1, a_token_1, url_1);
-        auto u2 = SyncManager::shared().get_user(identity_2, r_token_2, a_token_2, url_2);
-        auto u3 = SyncManager::shared().get_user(identity_3, r_token_3, a_token_3, url_3);
+        auto u1 = SyncManager::shared().get_user(identity_1, r_token_1, a_token_1, url_1, util::none);
+        auto u2 = SyncManager::shared().get_user(identity_2, r_token_2, a_token_2, url_2, util::none);
+        auto u3 = SyncManager::shared().get_user(identity_3, r_token_3, a_token_3, url_3, util::none);
         auto users = SyncManager::shared().all_users();
         REQUIRE(users.size() == 3);
         CHECK(validate_user_in_vector(users, identity_1, url_1, r_token_1, a_token_1));
@@ -168,7 +168,7 @@ TEST_CASE("sync_manager: user state management", "[sync]") {
         REQUIRE(users.size() == 3);
         CHECK(validate_user_in_vector(users, identity_2, url_2, r_token_2, a_token_2));
         // Log user 3 back in
-        u3 = SyncManager::shared().get_user(identity_3, r_token_3a, a_token_3a, url_3);
+        u3 = SyncManager::shared().get_user(identity_3, r_token_3a, a_token_3a, url_3, util::none);
         users = SyncManager::shared().all_users();
         REQUIRE(users.size() == 3);
         CHECK(validate_user_in_vector(users, identity_2, url_2, r_token_2, a_token_2));
@@ -184,11 +184,11 @@ TEST_CASE("sync_manager: user state management", "[sync]") {
         auto u_null = SyncManager::shared().get_current_user();
         REQUIRE(u_null == nullptr);
 
-        auto u1 = SyncManager::shared().get_user(identity_1, r_token_1, a_token_1, url_1);
+        auto u1 = SyncManager::shared().get_user(identity_1, r_token_1, a_token_1, url_1, util::none);
         auto u_current = SyncManager::shared().get_current_user();
         REQUIRE(u_current == u1);
 
-        auto u2 = SyncManager::shared().get_user(identity_2, r_token_2, a_token_2, url_2);
+        auto u2 = SyncManager::shared().get_user(identity_2, r_token_2, a_token_2, url_2, util::none);
         // The current user has switched to return the most recently used: "u2"
         u_current = SyncManager::shared().get_current_user();
         REQUIRE(u_current == u2);
@@ -518,7 +518,7 @@ TEST_CASE("sync_manager: has_active_sessions", "[active_sessions]") {
 
     std::atomic<bool> error_handler_invoked(false);
     Realm::Config config;
-    auto user = SyncManager::shared().get_user("user-name", ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("samesies"), "https://realm.example.org");
+    auto user = SyncManager::shared().get_user("user-name", ENCODE_FAKE_JWT("not_a_real_token"), ENCODE_FAKE_JWT("samesies"), "https://realm.example.org", util::none);
     auto create_session = [&](SyncSessionStopPolicy stop_policy) {
         std::shared_ptr<SyncSession> session = sync_session(user, "/test-dying-state",
                                     [&](auto, auto) { error_handler_invoked = true; },

--- a/tests/sync/user.cpp
+++ b/tests/sync/user.cpp
@@ -33,6 +33,7 @@ using namespace realm::util;
 using File = realm::util::File;
 
 static const std::string base_path = tmp_dir() + "/realm_objectstore_sync_user/";
+static const std::string dummy_device_id = "123400000000000000000000";
 
 TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
     reset_test_directory(base_path);
@@ -43,7 +44,7 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
     const std::string server_url = "https://realm.example.org";
 
     SECTION("properly creates a new normal user") {
-        auto user = SyncManager::shared().get_user(identity, refresh_token, access_token, server_url, util::none);
+        auto user = SyncManager::shared().get_user(identity, refresh_token, access_token, server_url, dummy_device_id);
         REQUIRE(user);
         // The expected state for a newly created user:
         REQUIRE(user->identity() == identity);
@@ -57,12 +58,12 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
         const std::string second_refresh_token = ENCODE_FAKE_JWT("0987654321-fake-refresh-token");
         const std::string second_access_token = ENCODE_FAKE_JWT("0987654321-fake-access-token");
 
-        auto first = SyncManager::shared().get_user(identity, refresh_token, access_token, server_url, util::none);
+        auto first = SyncManager::shared().get_user(identity, refresh_token, access_token, server_url, dummy_device_id);
         REQUIRE(first);
         REQUIRE(first->identity() == identity);
         REQUIRE(first->refresh_token() == refresh_token);
         // Get the user again, but with a different token.
-        auto second = SyncManager::shared().get_user(identity, second_refresh_token, second_access_token, server_url, util::none);
+        auto second = SyncManager::shared().get_user(identity, second_refresh_token, second_access_token, server_url, dummy_device_id);
         REQUIRE(second == first);
         REQUIRE(second->identity() == identity);
         REQUIRE(second->access_token() == second_access_token);
@@ -73,12 +74,12 @@ TEST_CASE("sync_user: SyncManager `get_user()` API", "[sync]") {
         const std::string second_refresh_token = ENCODE_FAKE_JWT("0987654321-fake-refresh-token");
         const std::string second_access_token = ENCODE_FAKE_JWT("0987654321-fake-access-token");
 
-        auto first = SyncManager::shared().get_user(identity, refresh_token, access_token, server_url, util::none);
+        auto first = SyncManager::shared().get_user(identity, refresh_token, access_token, server_url, dummy_device_id);
         REQUIRE(first->identity() == identity);
         first->log_out();
         REQUIRE(first->state() == SyncUser::State::LoggedOut);
         // Get the user again, with a new token.
-        auto second = SyncManager::shared().get_user(identity, second_refresh_token, second_access_token, server_url, util::none);
+        auto second = SyncManager::shared().get_user(identity, second_refresh_token, second_access_token, server_url, dummy_device_id);
         REQUIRE(second == first);
         REQUIRE(second->identity() == identity);
         REQUIRE(second->refresh_token() == second_refresh_token);
@@ -100,7 +101,7 @@ TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API", "[sync]"
     }
 
     SECTION("properly returns an existing logged-in user") {
-        auto first = SyncManager::shared().get_user(identity, refresh_token, access_token, server_url, util::none);
+        auto first = SyncManager::shared().get_user(identity, refresh_token, access_token, server_url, dummy_device_id);
         REQUIRE(first->identity() == identity);
         REQUIRE(first->state() == SyncUser::State::LoggedIn);
         // Get that user using the 'existing user' API.
@@ -110,7 +111,7 @@ TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API", "[sync]"
     }
 
     SECTION("properly returns a null pointer for a logged-out user") {
-        auto first = SyncManager::shared().get_user(identity, refresh_token, access_token, server_url, util::none);
+        auto first = SyncManager::shared().get_user(identity, refresh_token, access_token, server_url, dummy_device_id);
         first->log_out();
         REQUIRE(first->identity() == identity);
         REQUIRE(first->state() == SyncUser::State::LoggedOut);
@@ -129,7 +130,7 @@ TEST_CASE("sync_user: logout", "[sync]") {
     const std::string server_url = "https://realm.example.org";
 
     SECTION("properly changes the state of the user object") {
-        auto user = SyncManager::shared().get_user(identity, refresh_token, access_token, server_url, util::none);
+        auto user = SyncManager::shared().get_user(identity, refresh_token, access_token, server_url, dummy_device_id);
         REQUIRE(user->state() == SyncUser::State::LoggedIn);
         user->log_out();
         REQUIRE(user->state() == SyncUser::State::LoggedOut);
@@ -148,7 +149,7 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         const std::string refresh_token = ENCODE_FAKE_JWT("r-token-1");
         const std::string access_token = ENCODE_FAKE_JWT("a-token-1");
         const std::string server_url = "https://realm.example.org/1/";
-        auto user = SyncManager::shared().get_user(identity, refresh_token, access_token, server_url, util::none);
+        auto user = SyncManager::shared().get_user(identity, refresh_token, access_token, server_url, dummy_device_id);
         // Now try to pull the user out of the shadow manager directly.
         auto metadata = manager.get_or_make_user_metadata(identity, server_url, false);
         REQUIRE(metadata->is_valid());
@@ -162,13 +163,13 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         const std::string access_token = ENCODE_FAKE_JWT("a_token-1a");
         const std::string server_url = "https://realm.example.org/2/";
         // Create the user and validate it.
-        auto first = SyncManager::shared().get_user(identity, refresh_token, access_token, server_url, util::none);
+        auto first = SyncManager::shared().get_user(identity, refresh_token, access_token, server_url, dummy_device_id);
         auto first_metadata = manager.get_or_make_user_metadata(identity, server_url, false);
         REQUIRE(first_metadata->is_valid());
         REQUIRE(first_metadata->access_token() == access_token);
         const std::string token_2 = ENCODE_FAKE_JWT("token-2b");
         // Update the user.
-        auto second = SyncManager::shared().get_user(identity, refresh_token, token_2, server_url, util::none);
+        auto second = SyncManager::shared().get_user(identity, refresh_token, token_2, server_url, dummy_device_id);
         auto second_metadata = manager.get_or_make_user_metadata(identity, server_url, false);
         REQUIRE(second_metadata->is_valid());
         REQUIRE(second_metadata->access_token() == token_2);
@@ -180,7 +181,7 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         const std::string access_token = ENCODE_FAKE_JWT("a-token-3");
         const std::string provider_type = app::IdentityProviderGoogle;
         // Create the user and validate it.
-        auto user = SyncManager::shared().get_user(identity, refresh_token, access_token, provider_type, util::none);
+        auto user = SyncManager::shared().get_user(identity, refresh_token, access_token, provider_type, dummy_device_id);
         auto marked_users = manager.all_users_marked_for_removal();
         REQUIRE(marked_users.size() == 0);
         // Log out the user.
@@ -195,7 +196,7 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         const std::string access_token = ENCODE_FAKE_JWT("a-token-3");
         const std::string provider_type = app::IdentityProviderAnonymous;
         // Create the user and validate it.
-        auto user = SyncManager::shared().get_user(identity, refresh_token, access_token, provider_type, util::none);
+        auto user = SyncManager::shared().get_user(identity, refresh_token, access_token, provider_type, dummy_device_id);
         auto marked_users = manager.all_users_marked_for_removal();
         REQUIRE(marked_users.size() == 0);
         // Log out the user.
@@ -209,14 +210,14 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         const std::string access_token = ENCODE_FAKE_JWT("a-token-4a");
         const std::string provider_type = app::IdentityProviderApple;
         // Create the user and log it out.
-        auto first = SyncManager::shared().get_user(identity, refresh_token, access_token, provider_type, util::none);
+        auto first = SyncManager::shared().get_user(identity, refresh_token, access_token, provider_type, dummy_device_id);
         first->log_out();
         REQUIRE(SyncManager::shared().all_users().size() == 1);
         REQUIRE(SyncManager::shared().all_users()[0]->state() == SyncUser::State::LoggedOut);
         // Log the user back in.
         const std::string r_token_2 = ENCODE_FAKE_JWT("r-token-4b");
         const std::string a_token_2 = ENCODE_FAKE_JWT("atoken-4b");
-        auto second = SyncManager::shared().get_user(identity, r_token_2, a_token_2, provider_type, util::none);
+        auto second = SyncManager::shared().get_user(identity, r_token_2, a_token_2, provider_type, dummy_device_id);
         REQUIRE(SyncManager::shared().all_users().size() == 1);
         REQUIRE(SyncManager::shared().all_users()[0]->state() == SyncUser::State::LoggedIn);
     }

--- a/tests/sync/user.cpp
+++ b/tests/sync/user.cpp
@@ -155,6 +155,7 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         REQUIRE(metadata->is_valid());
         REQUIRE(metadata->provider_type() == server_url);
         REQUIRE(metadata->access_token() == access_token);
+        REQUIRE(metadata->device_id() == dummy_device_id);
     }
 
     SECTION("properly persists a user's information when the user is updated") {

--- a/tests/sync/user.cpp
+++ b/tests/sync/user.cpp
@@ -104,6 +104,7 @@ TEST_CASE("sync_user: SyncManager `get_existing_logged_in_user()` API", "[sync]"
         auto first = SyncManager::shared().get_user(identity, refresh_token, access_token, server_url, dummy_device_id);
         REQUIRE(first->identity() == identity);
         REQUIRE(first->state() == SyncUser::State::LoggedIn);
+        REQUIRE(first->device_id() == dummy_device_id);
         // Get that user using the 'existing user' API.
         auto second = SyncManager::shared().get_existing_logged_in_user(identity);
         REQUIRE(second == first);

--- a/tests/util/test_file.cpp
+++ b/tests/util/test_file.cpp
@@ -115,7 +115,8 @@ SyncTestFile::SyncTestFile(std::shared_ptr<app::App> app, std::string name, std:
 
     std::string fake_refresh_token = ENCODE_FAKE_JWT("not_a_real_token");
     std::string fake_access_token = ENCODE_FAKE_JWT("also_not_real");
-    sync_config = std::make_shared<SyncConfig>(SyncManager::shared().get_user(user_name, fake_refresh_token, fake_access_token, app->base_url()), name);
+    sync_config = std::make_shared<SyncConfig>(SyncManager::shared().get_user(user_name, fake_refresh_token, fake_access_token, app->base_url(),
+    util::none), name);
     sync_config->stop_policy = SyncSessionStopPolicy::Immediately;
     sync_config->error_handler = [](auto, auto) { abort(); };
     schema_mode = SchemaMode::Additive;

--- a/tests/util/test_file.cpp
+++ b/tests/util/test_file.cpp
@@ -240,6 +240,9 @@ void TestSyncManager::configure(const std::string& base_url, std::string const& 
     app::App::Config app_config;
     app_config.transport_generator = []() -> std::unique_ptr<app::GenericNetworkTransport> { REALM_ASSERT_RELEASE(false); };
     app_config.base_url = base_url;
+    app_config.platform = "OS Test Platform";
+    app_config.platform_version = "OS Test Platform Version";
+    app_config.sdk_version = "SDK Version";
     SyncManager::shared().configure(config, app_config);
     app::App::OnlyForTesting::set_sync_route(*SyncManager::shared().app(), base_url + "/realm-sync");
 }

--- a/tests/util/test_file.cpp
+++ b/tests/util/test_file.cpp
@@ -115,8 +115,9 @@ SyncTestFile::SyncTestFile(std::shared_ptr<app::App> app, std::string name, std:
 
     std::string fake_refresh_token = ENCODE_FAKE_JWT("not_a_real_token");
     std::string fake_access_token = ENCODE_FAKE_JWT("also_not_real");
+    std::string fake_device_id = "123400000000000000000000";
     sync_config = std::make_shared<SyncConfig>(SyncManager::shared().get_user(user_name, fake_refresh_token, fake_access_token, app->base_url(),
-    util::none), name);
+    fake_device_id), name);
     sync_config->stop_policy = SyncSessionStopPolicy::Immediately;
     sync_config->error_handler = [](auto, auto) { abort(); };
     schema_mode = SchemaMode::Additive;


### PR DESCRIPTION
This PR will address sending a set of `options` in the body of the `log_in_with_credential`. The `options` in this PR just contain a `deviceId` parameter, which will be needed for services such as push notifications. 

Consumers of the Object Store will pass the deviceId into `App::Config`. Once a user has successfully logged in the deviceId will be passed to the `SyncUser`.