### PR TITLE
Fix close triggers reopening a Realm

### DIFF
--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -912,7 +912,7 @@ void Realm::close()
         m_coordinator->unregister_realm(this);
     }
     if (!m_config.immutable() && m_group) {
-        dynamic_cast<Transaction&>(*m_group).close();
+        transaction().close();
     }
 
     m_permissions_cache = nullptr;

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -911,8 +911,8 @@ void Realm::close()
     if (m_coordinator) {
         m_coordinator->unregister_realm(this);
     }
-    if (!m_config.immutable()) {
-        transaction().close();
+    if (!m_config.immutable() && m_group) {
+        dynamic_cast<Transaction&>(*m_group).close();
     }
 
     m_permissions_cache = nullptr;


### PR DESCRIPTION
We have a unit test in Java that caught this https://github.com/realm/realm-java/pull/6838

I tried to create a similar test in Object Store, but so far failed, so I still haven't ruled out this is a bug in the Java SDK. But I thought I would make a PR nonetheless because no matter what, the ObjectStore code looks fishy. `transaction()` will attempt to create a ReadTransaction if one isn't already open, and doing that inside `close()` is definitely wasteful.

