### PR TITLE
change the way we implement an iterator for windows

### DIFF
--- a/src/index_set.hpp
+++ b/src/index_set.hpp
@@ -189,8 +189,14 @@ public:
     void clear() noexcept;
 
     // An iterator over the individual indices in the set rather than the ranges
-    class IndexIterator : public std::iterator<std::forward_iterator_tag, size_t> {
+    class IndexIterator {
     public:
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = size_t;
+        using difference_type = ptrdiff_t;
+        using pointer = const value_type*;
+        using reference = const value_type&;
+
         IndexIterator(IndexSet::const_iterator it) : m_iterator(it) { }
         size_t operator*() const noexcept { return m_iterator->first + m_offset; }
         bool operator==(IndexIterator const& it) const noexcept { return m_iterator == it.m_iterator; }


### PR DESCRIPTION
This fixes the build error on windows universal ([example](https://ci.realm.io/blue/organizations/jenkins/realm%2Frealm-object-store/detail/PR-1011/19/pipeline)) on the new/upgraded CI nodes. There should be no functional difference.
```
C:\jenkins\workspace\realm_realm-object-store_PR-1011\src\index_set.hpp(192,39): error C4996: 'std::iterator<std::forward_iterator_tag,size_t,ptrdiff_t,size_t *,size_t &>': warning STL4015: The std::iterator class template (used as a base class to provide typedefs) is deprecated in C++17. (The <iterator> header is NOT deprecated.) The C++ Standard has never required user-defined iterators to derive from std::iterator. To fix this warning, stop deriving from std::iterator and start providing publicly accessible typedefs named iterator_category, value_type, difference_type, pointer, and reference. Note that value_type is required to be non-const, even for constant iterators. You can define _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING or _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS to acknowledge that you have received this warning. (compiling source file C:\jenkins\workspace\realm_realm-object-store_PR-1011\src\collection_notifications.cpp) [C:\jenkins\workspace\realm_realm-object-store_PR-1011\src\realm-object-store.vcxproj]

C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\VC\Tools\MSVC\14.26.28801\include\xutility(5680,54): message : see declaration of 'std::iterator' (compiling source file C:\jenkins\workspace\realm_realm-object-store_PR-1011\src\collection_notifications.cpp) [C:\jenkins\workspace\realm_realm-object-store_PR-1011\src\realm-object-store.vcxproj]
```