### PR TITLE
Fix remote mongo findOneAndX to use 'filter'

### DIFF
--- a/src/sync/app.cpp
+++ b/src/sync/app.cpp
@@ -927,7 +927,6 @@ void App::call_function(std::shared_ptr<SyncUser> user,
         if (auto error = check_for_errors(response)) {
             return completion_block(error, util::none);
         }
-        
         completion_block(util::none, util::Optional<bson::Bson>(bson::parse(response.body)));
     };
 

--- a/src/sync/app.cpp
+++ b/src/sync/app.cpp
@@ -927,6 +927,10 @@ void App::call_function(std::shared_ptr<SyncUser> user,
         if (auto error = check_for_errors(response)) {
             return completion_block(error, util::none);
         }
+        
+        if (response.body == "null") {
+            return completion_block(util::none, util::none);
+        }
 
         completion_block(util::none, util::Optional<bson::Bson>(bson::parse(response.body)));
     };

--- a/src/sync/app.cpp
+++ b/src/sync/app.cpp
@@ -928,10 +928,6 @@ void App::call_function(std::shared_ptr<SyncUser> user,
             return completion_block(error, util::none);
         }
         
-        if (response.body == "null") {
-            return completion_block(util::none, util::none);
-        }
-
         completion_block(util::none, util::Optional<bson::Bson>(bson::parse(response.body)));
     };
 

--- a/src/sync/remote_mongo_collection.cpp
+++ b/src/sync/remote_mongo_collection.cpp
@@ -336,7 +336,7 @@ void RemoteMongoCollection::find_one_and_update(const bson::BsonDocument& filter
                                                 std::function<void(util::Optional<bson::BsonDocument>, util::Optional<AppError>)> completion_block)
 {
     auto base_args = m_base_operation_args;
-    base_args["query"] = filter_bson;
+    base_args["filter"] = filter_bson;
     base_args["update"] = update_bson;
     options.set_bson(base_args);
     
@@ -371,7 +371,7 @@ void RemoteMongoCollection::find_one_and_replace(const bson::BsonDocument& filte
                                                  std::function<void(util::Optional<bson::BsonDocument>, util::Optional<AppError>)> completion_block)
 {
     auto base_args = m_base_operation_args;
-    base_args["query"] = filter_bson;
+    base_args["filter"] = filter_bson;
     base_args["update"] = replacement_bson;
     options.set_bson(base_args);
 
@@ -405,7 +405,7 @@ void RemoteMongoCollection::find_one_and_delete(const bson::BsonDocument& filter
                                                 std::function<void(util::Optional<AppError>)> completion_block)
 {
     auto base_args = m_base_operation_args;
-    base_args["query"] = filter_bson;
+    base_args["filter"] = filter_bson;
     options.set_bson(base_args);
 
     m_service->call_function("findOneAndDelete",

--- a/src/sync/remote_mongo_collection.cpp
+++ b/src/sync/remote_mongo_collection.cpp
@@ -138,6 +138,11 @@ void RemoteMongoCollection::find_one(const bson::BsonDocument& filter_bson,
             if (error) {
                 return completion_block(util::none, error);
             }
+            
+            if (!value) {
+                // no docs were found
+                return completion_block(util::none, util::none);
+            }
 
             if (bson::holds_alternative<util::None>(*value)) {
                 // no docs were found
@@ -347,6 +352,11 @@ void RemoteMongoCollection::find_one_and_update(const bson::BsonDocument& filter
         if (error) {
             return completion_block(util::none, error);
         }
+        
+        if (!value) {
+            // no docs were found
+            return completion_block(util::none, util::none);
+        }
 
         if (bson::holds_alternative<util::None>(*value)) {
             // no docs were found
@@ -381,6 +391,11 @@ void RemoteMongoCollection::find_one_and_replace(const bson::BsonDocument& filte
                              [completion_block](util::Optional<AppError> error, util::Optional<bson::Bson> value) {
         if (error) {
             return completion_block(util::none, error);
+        }
+        
+        if (!value) {
+            // no docs were found
+            return completion_block(util::none, util::none);
         }
 
         if (bson::holds_alternative<util::None>(*value)) {

--- a/src/sync/remote_mongo_collection.cpp
+++ b/src/sync/remote_mongo_collection.cpp
@@ -69,6 +69,28 @@ static void handle_update_response(util::Optional<AppError> error,
     }
 }
 
+static void handle_document_response(util::Optional<AppError> error,
+                                     util::Optional<bson::Bson> value,
+                                     std::function<void(util::Optional<bson::BsonDocument>, util::Optional<AppError>)> completion_block)
+{
+    if (error) {
+        return completion_block(util::none, error);
+    }
+    
+    if (!value) {
+        // no docs were found
+        return completion_block(util::none, util::none);
+    }
+    
+    if (bson::holds_alternative<util::None>(*value)) {
+        // no docs were found
+        return completion_block(util::none, util::none);
+    }
+    
+    return completion_block(static_cast<bson::BsonDocument>(*value),
+                            util::none);
+}
+
 void RemoteMongoCollection::find(const bson::BsonDocument& filter_bson,
                                  RemoteFindOptions options,
                                  std::function<void(util::Optional<bson::BsonArray>, util::Optional<AppError>)> completion_block)
@@ -135,22 +157,7 @@ void RemoteMongoCollection::find_one(const bson::BsonDocument& filter_bson,
                                  m_service_name,
                                  [completion_block](util::Optional<AppError> error,
                                                     util::Optional<bson::Bson> value) {
-            if (error) {
-                return completion_block(util::none, error);
-            }
-            
-            if (!value) {
-                // no docs were found
-                return completion_block(util::none, util::none);
-            }
-
-            if (bson::holds_alternative<util::None>(*value)) {
-                // no docs were found
-                return completion_block(util::none, util::none);
-            }
-            
-            return completion_block(util::some<bson::BsonDocument>(static_cast<bson::BsonDocument>(*value)),
-                                    util::none);
+            handle_document_response(error, value, completion_block);
         });
 
     } catch (const std::exception& e) {
@@ -349,22 +356,7 @@ void RemoteMongoCollection::find_one_and_update(const bson::BsonDocument& filter
                              bson::BsonArray({base_args}),
                              m_service_name,
                              [completion_block](util::Optional<AppError> error, util::Optional<bson::Bson> value) {
-        if (error) {
-            return completion_block(util::none, error);
-        }
-        
-        if (!value) {
-            // no docs were found
-            return completion_block(util::none, util::none);
-        }
-
-        if (bson::holds_alternative<util::None>(*value)) {
-            // no docs were found
-            return completion_block(util::none, util::none);
-        }
-
-        return completion_block(util::some<bson::BsonDocument>(static_cast<bson::BsonDocument>(*value)),
-                                util::none);
+        handle_document_response(error, value, completion_block);
     });
 }
 
@@ -389,22 +381,7 @@ void RemoteMongoCollection::find_one_and_replace(const bson::BsonDocument& filte
                              bson::BsonArray({base_args}),
                              m_service_name,
                              [completion_block](util::Optional<AppError> error, util::Optional<bson::Bson> value) {
-        if (error) {
-            return completion_block(util::none, error);
-        }
-        
-        if (!value) {
-            // no docs were found
-            return completion_block(util::none, util::none);
-        }
-
-        if (bson::holds_alternative<util::None>(*value)) {
-            // no docs were found
-            return completion_block(util::none, util::none);
-        }
-
-        return completion_block(static_cast<bson::BsonDocument>(*value),
-                                util::none);
+        handle_document_response(error, value, completion_block);
     });
 }
 
@@ -417,7 +394,7 @@ void RemoteMongoCollection::find_one_and_replace(const bson::BsonDocument& filte
 
 void RemoteMongoCollection::find_one_and_delete(const bson::BsonDocument& filter_bson,
                                                 RemoteMongoCollection::RemoteFindOneAndModifyOptions options,
-                                                std::function<void(util::Optional<AppError>)> completion_block)
+                                                std::function<void(util::Optional<bson::BsonDocument>, util::Optional<AppError>)> completion_block)
 {
     auto base_args = m_base_operation_args;
     base_args["filter"] = filter_bson;
@@ -426,13 +403,13 @@ void RemoteMongoCollection::find_one_and_delete(const bson::BsonDocument& filter
     m_service->call_function("findOneAndDelete",
                              bson::BsonArray({base_args}),
                              m_service_name,
-                             [completion_block](util::Optional<AppError> error, util::Optional<bson::Bson>) {
-        completion_block(error);
+                             [completion_block](util::Optional<AppError> error, util::Optional<bson::Bson> value) {
+        handle_document_response(error, value, completion_block);
     });
 }
 
 void RemoteMongoCollection::find_one_and_delete(const bson::BsonDocument& filter_bson,
-                                                std::function<void(util::Optional<AppError>)> completion_block)
+                                                std::function<void(util::Optional<bson::BsonDocument>, util::Optional<AppError>)> completion_block)
 {
     find_one_and_delete(filter_bson, {}, completion_block);
 }

--- a/src/sync/remote_mongo_collection.hpp
+++ b/src/sync/remote_mongo_collection.hpp
@@ -286,7 +286,7 @@ public:
     /// @param completion_block The result of the attempt to delete a document.
     void find_one_and_delete(const bson::BsonDocument& filter_bson,
                              RemoteFindOneAndModifyOptions options,
-                             std::function<void(util::Optional<AppError>)> completion_block);
+                             std::function<void(util::Optional<bson::BsonDocument>, util::Optional<AppError>)> completion_block);
     
     /// Removes a single document from a collection based on a query filter and
     /// returns a document with the same form as the document immediately before
@@ -297,7 +297,7 @@ public:
     /// @param filter_bson  A `Document` that should match the query.
     /// @param completion_block The result of the attempt to delete a document.
     void find_one_and_delete(const bson::BsonDocument& filter_bson,
-                             std::function<void(util::Optional<AppError>)> completion_block);
+                             std::function<void(util::Optional<bson::BsonDocument>, util::Optional<AppError>)> completion_block);
 
 private:
     friend class RemoteMongoDatabase;

--- a/src/sync/remote_mongo_collection.hpp
+++ b/src/sync/remote_mongo_collection.hpp
@@ -78,7 +78,7 @@ public:
             }
             
             if (projection_bson) {
-                bson["project"] = *projection_bson;
+                bson["projection"] = *projection_bson;
             }
             
             if (sort_bson) {

--- a/tests/sync/app.cpp
+++ b/tests/sync/app.cpp
@@ -1173,6 +1173,14 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
             CHECK(!error);
         });
         
+        dog_collection.find_one_and_delete({{}}, [&](Optional<app::AppError> error) {
+            CHECK(!error);
+        });
+        
+        dog_collection.find_one_and_delete({{"invalid", "key"}}, [&](Optional<app::AppError> error) {
+            CHECK(!error);
+        });
+        
         dog_collection.find(dog_document,
                         [&](Optional<bson::BsonArray> documents, Optional<app::AppError> error) {
             CHECK(!error);
@@ -1290,6 +1298,16 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
             CHECK(!error);
             auto breed = static_cast<std::string>((*document)["breed"]);
             CHECK(breed == "king charles");
+        });
+        
+        dog_collection.find_one_and_update({{"name", "invalid name"}}, {{"name", "some name"}}, [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
+            CHECK(!error);
+            CHECK(!document);
+        });
+        
+        dog_collection.find_one_and_update({{"name", "invalid name"}}, {{}}, find_and_modify_options, [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
+            CHECK(error->message == "insert not permitted");
+            CHECK(!document);
             processed = true;
         });
         
@@ -1429,6 +1447,22 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
             auto name = static_cast<std::string>((*document)["firstName"]);
             // Should return new document, Bob -> John
             CHECK(name == "John");
+        });
+        
+        person_collection.find_one_and_replace({{"invalid", "item"}},
+                                        {{}},
+                                        [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
+            // If a document is not found then null will be returned for the document and no error will be returned
+            CHECK(!error);
+            CHECK(!document);
+        });
+        
+        person_collection.find_one_and_replace({{"invalid", "item"}},
+                                        {{}},
+                                        person_find_and_modify_options,
+                                        [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
+            CHECK(!error);
+            CHECK(!document);
             processed = true;
         });
                 

--- a/tests/sync/app.cpp
+++ b/tests/sync/app.cpp
@@ -1169,16 +1169,19 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
             CHECK((*documents).size() == 1);
         });
         
-        dog_collection.find_one_and_delete(dog_document, [&](Optional<app::AppError> error) {
+        dog_collection.find_one_and_delete(dog_document, [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
             CHECK(!error);
+            REQUIRE(document);
         });
         
-        dog_collection.find_one_and_delete({{}}, [&](Optional<app::AppError> error) {
+        dog_collection.find_one_and_delete({{}}, [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
             CHECK(!error);
+            REQUIRE(document);
         });
         
-        dog_collection.find_one_and_delete({{"invalid", "key"}}, [&](Optional<app::AppError> error) {
+        dog_collection.find_one_and_delete({{"invalid", "key"}}, [&](Optional<bson::BsonDocument> document, Optional<app::AppError> error) {
             CHECK(!error);
+            CHECK(!document);
         });
         
         dog_collection.find(dog_document,

--- a/tests/sync/app.cpp
+++ b/tests/sync/app.cpp
@@ -1271,7 +1271,7 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
         bool processed = false;
         
         realm::app::RemoteMongoCollection::RemoteFindOneAndModifyOptions find_and_modify_options {
-            util::Optional<bson::BsonDocument>({{"name", "fido"}}), //project
+            util::Optional<bson::BsonDocument>({{"name", 1}, {"breed", 1}}), //project
             util::Optional<bson::BsonDocument>({{"name", 1}}), //sort,
             true, //upsert
             true // return new doc
@@ -1423,8 +1423,8 @@ TEST_CASE("app: remote mongo client", "[sync][app]") {
         });
         
         realm::app::RemoteMongoCollection::RemoteFindOneAndModifyOptions person_find_and_modify_options {
-            util::Optional<bson::BsonDocument>({{"name", 1}}), //project
-            util::Optional<bson::BsonDocument>({{"name", 1}}), //sort,
+            util::Optional<bson::BsonDocument>({{"firstName", 1}}), //project
+            util::Optional<bson::BsonDocument>({{"firstName", 1}}), //sort,
             false, //upsert
             true // return new doc
         };


### PR DESCRIPTION
This PR addresses a bug fix. The bug is where a findOneAndX remote mongo call was passing up the filtering document with `query` instead of `filter` in the request body. Tests have also been added to make sure the unhappy path is captured