### PR TITLE
Add C++17 deduction guides to EventLoopDispatcher

### DIFF
--- a/src/util/event_loop_dispatcher.hpp
+++ b/src/util/event_loop_dispatcher.hpp
@@ -89,20 +89,36 @@ public:
 namespace _impl::ForEventLoopDispatcher {
 template <typename Sig>
 struct ExtractSignatureImpl {};
-template <typename T, typename... Args, bool isNoexcept>
-struct ExtractSignatureImpl<void(T::*)(Args...) noexcept(isNoexcept)> {
+template <typename T, typename... Args>
+struct ExtractSignatureImpl<void(T::*)(Args...)> {
     using signature = void(Args...);
 };
-template <typename T, typename... Args, bool isNoexcept>
-struct ExtractSignatureImpl<void(T::*)(Args...) const noexcept(isNoexcept)> {
+template <typename T, typename... Args>
+struct ExtractSignatureImpl<void(T::*)(Args...) const> {
     using signature = void(Args...);
 };
-template <typename T, typename... Args, bool isNoexcept>
-struct ExtractSignatureImpl<void(T::*)(Args...) & noexcept(isNoexcept)> {
+template <typename T, typename... Args>
+struct ExtractSignatureImpl<void(T::*)(Args...) &> {
     using signature = void(Args...);
 };
-template <typename T, typename... Args, bool isNoexcept>
-struct ExtractSignatureImpl<void(T::*)(Args...) const & noexcept(isNoexcept)> {
+template <typename T, typename... Args>
+struct ExtractSignatureImpl<void(T::*)(Args...) const &> {
+    using signature = void(Args...);
+};
+template <typename T, typename... Args>
+struct ExtractSignatureImpl<void(T::*)(Args...) noexcept> {
+    using signature = void(Args...);
+};
+template <typename T, typename... Args>
+struct ExtractSignatureImpl<void(T::*)(Args...) const noexcept> {
+    using signature = void(Args...);
+};
+template <typename T, typename... Args>
+struct ExtractSignatureImpl<void(T::*)(Args...) & noexcept> {
+    using signature = void(Args...);
+};
+template <typename T, typename... Args>
+struct ExtractSignatureImpl<void(T::*)(Args...) const & noexcept> {
     using signature = void(Args...);
 };
 // Note: no && specializations since std::function doesn't support them, so you can't construct an EventLoopDispatcher

--- a/src/util/event_loop_dispatcher.hpp
+++ b/src/util/event_loop_dispatcher.hpp
@@ -85,6 +85,25 @@ public:
         m_scheduler->notify();
     }
 };
+
+namespace detail {
+template <typename T>
+struct extract_signature_impl {};
+template <typename Sig>
+struct extract_signature_impl<std::function<Sig>> {
+    using signature = Sig;
+};
+
+template <typename T>
+using extract_signature = typename extract_signature_impl<T>::signature;
+}
+
+// Use std::function deduction guides for EventLoopDispatcher. This works with function pointers, lambdas (without
+// auto parameters), and any other function object that has a non-overloaded, non-templated call operator.
+template<typename T,
+         typename Sig = detail::extract_signature<decltype(std::function(std::declval<T>()))>>
+EventLoopDispatcher(const T&) -> EventLoopDispatcher<Sig>;
+
 } // namespace util
 } // namespace realm
 

--- a/tests/util/event_loop.cpp
+++ b/tests/util/event_loop.cpp
@@ -40,12 +40,13 @@
 
 using namespace realm::util;
 
+namespace {
 template <typename Desired, typename Actual>
 void static_assert_EventLoopDispatcher_guide(const EventLoopDispatcher<Actual>&) {
     static_assert(std::is_same_v<Actual, Desired>);
 }
 
-[[maybe_ununsed]] void check_EventLoopDispatcher_guides() {
+[[maybe_unused]] void check_EventLoopDispatcher_guides() {
     // This doesn't actually run, the only "test" is that it compiles.
     static_assert_EventLoopDispatcher_guide<void()>(EventLoopDispatcher([]{}));
     static_assert_EventLoopDispatcher_guide<void()>(EventLoopDispatcher(+[]{}));
@@ -61,6 +62,11 @@ void static_assert_EventLoopDispatcher_guide(const EventLoopDispatcher<Actual>&)
     static_assert_EventLoopDispatcher_guide<void(int, const double&)>(EventLoopDispatcher([](int, const double&){}));
     static_assert_EventLoopDispatcher_guide<void(int, const double&)>(EventLoopDispatcher(+[](int, const double&){}));
 
+    struct Funcy {
+        void operator()(int) const & noexcept {}
+    };
+    static_assert_EventLoopDispatcher_guide<void(int)>(EventLoopDispatcher(Funcy()));
+}
 }
 
 struct EventLoop::Impl {

--- a/tests/util/event_loop.cpp
+++ b/tests/util/event_loop.cpp
@@ -17,6 +17,7 @@
  **************************************************************************/
 
 #include <util/event_loop.hpp>
+#include <util/event_loop_dispatcher.hpp>
 
 #include <realm/util/features.h>
 
@@ -38,6 +39,29 @@
 #endif
 
 using namespace realm::util;
+
+template <typename Desired, typename Actual>
+void static_assert_EventLoopDispatcher_guide(const EventLoopDispatcher<Actual>&) {
+    static_assert(std::is_same_v<Actual, Desired>);
+}
+
+[[maybe_ununsed]] void check_EventLoopDispatcher_guides() {
+    // This doesn't actually run, the only "test" is that it compiles.
+    static_assert_EventLoopDispatcher_guide<void()>(EventLoopDispatcher([]{}));
+    static_assert_EventLoopDispatcher_guide<void()>(EventLoopDispatcher(+[]{}));
+    static_assert_EventLoopDispatcher_guide<void()>(EventLoopDispatcher([]() mutable {}));
+    static_assert_EventLoopDispatcher_guide<void()>(EventLoopDispatcher(+[]() mutable {}));
+    static_assert_EventLoopDispatcher_guide<void()>(EventLoopDispatcher([]() noexcept {}));
+    static_assert_EventLoopDispatcher_guide<void()>(EventLoopDispatcher(+[]() noexcept {}));
+    static_assert_EventLoopDispatcher_guide<void()>(EventLoopDispatcher([]() mutable noexcept {}));
+    static_assert_EventLoopDispatcher_guide<void()>(EventLoopDispatcher(+[]() mutable noexcept {}));
+
+    static_assert_EventLoopDispatcher_guide<void(int)>(EventLoopDispatcher([](int){}));
+    static_assert_EventLoopDispatcher_guide<void(int)>(EventLoopDispatcher(+[](int){}));
+    static_assert_EventLoopDispatcher_guide<void(int, const double&)>(EventLoopDispatcher([](int, const double&){}));
+    static_assert_EventLoopDispatcher_guide<void(int, const double&)>(EventLoopDispatcher(+[](int, const double&){}));
+
+}
 
 struct EventLoop::Impl {
     // Returns the main event loop.


### PR DESCRIPTION
C++17 For the win!

I was about to start using this type a lot in realm-js, so I thought I'd make it a bit easier to use first.