### PR TITLE
Fix sync metadata key lookup failures

### DIFF
--- a/src/impl/apple/keychain_helper.cpp
+++ b/src/impl/apple/keychain_helper.cpp
@@ -62,7 +62,6 @@ CFPtr<CFMutableDictionaryRef> build_search_dictionary(CFStringRef account, CFStr
 
     CFDictionaryAddValue(d.get(), kSecClass, kSecClassGenericPassword);
     CFDictionaryAddValue(d.get(), kSecReturnData, kCFBooleanTrue);
-    CFDictionaryAddValue(d.get(), kSecAttrAccessible, kSecAttrAccessibleAfterFirstUnlock);
     CFDictionaryAddValue(d.get(), kSecAttrAccount, account);
     CFDictionaryAddValue(d.get(), kSecAttrService, service);
 #if !TARGET_IPHONE_SIMULATOR
@@ -97,6 +96,7 @@ util::Optional<std::vector<char>> get_key(CFStringRef account, CFStringRef servi
 void set_key(const std::vector<char>& key, CFStringRef account, CFStringRef service)
 {
     auto search_dictionary = build_search_dictionary(account, service, none);
+    CFDictionaryAddValue(search_dictionary.get(), kSecAttrAccessible, kSecAttrAccessibleAfterFirstUnlock);
     auto key_data = adoptCF(CFDataCreate(nullptr, reinterpret_cast<const UInt8 *>(key.data()), key_size));
     if (!key_data)
         throw std::bad_alloc();


### PR DESCRIPTION
With previous versions we stored the key with `kSecAttrAccessibleAlways`, and looking it up with `kSecAttrAccessibleAfterFirstUnlock` sometimes doesn't work. Fortunately there's no reason to actually include it in the search dictionary for lookup, and only for setting.

I was unable to write a test which reproduces the problem; storing with Always and then immediately looking up with AfterFirstUnlock works unfortunately.

Fixes https://github.com/realm/realm-cocoa/issues/6538.