### PR TITLE
Add new protocol error to list of errors handled.

### DIFF
--- a/src/sync/sync_config.hpp
+++ b/src/sync/sync_config.hpp
@@ -105,7 +105,8 @@ struct SyncError {
                 || error_code == ProtocolError::bad_client_file_ident
                 || error_code == ProtocolError::bad_server_version
                 || error_code == ProtocolError::diverging_histories
-                || error_code == ProtocolError::client_file_expired);
+                || error_code == ProtocolError::client_file_expired
+                || error_code == ProtocolError::invalid_schema_change);
     }
 };
 

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -431,6 +431,7 @@ void SyncSession::handle_error(SyncError error)
             case ProtocolError::server_file_deleted:
             case ProtocolError::user_blacklisted:
             case ProtocolError::client_file_expired:
+            case ProtocolError::invalid_schema_change:
                 next_state = NextStateAfterError::inactive;
                 update_error_and_mark_file_for_deletion(error, ShouldBackup::yes);
                 break;


### PR DESCRIPTION
Seems this was forgotten as part of: https://github.com/realm/realm-object-store/pull/1025

Not handling this would otherwise break Realm Java