### PR TITLE
Allow linking from embedded to top-level object types

### DIFF
--- a/src/object_schema.cpp
+++ b/src/object_schema.cpp
@@ -257,15 +257,8 @@ static void validate_property(Schema const& schema,
                                 object_name, prop.name, string_for_property_type(prop.type), prop.object_type);
         return;
     }
-    if (prop.type != PropertyType::LinkingObjects) {
-        if (parent_object_schema.is_embedded && !it->is_embedded) {
-            exceptions.emplace_back("Property '%1.%2' of type '%3' cannot link to top-level object type '%4'",
-                                    object_name, prop.name, string_for_property_type(prop.type), prop.object_type);
-            return;
-        }
-
+    if (prop.type != PropertyType::LinkingObjects)
         return;
-    }
 
     const Property *origin_property = it->property_for_name(prop.link_origin_property_name);
     if (!origin_property) {

--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -293,7 +293,7 @@ TEST_CASE("Schema") {
             REQUIRE_THROWS_CONTAINING(schema.validate(), "Property 'object.array' of type 'array' has unknown object type 'invalid target'");
         }
 
-        SECTION("rejects link properties from embedded to top-level") {
+        SECTION("allows link properties from embedded to top-level") {
             Schema schema = {
                 {"target", {
                     {"value", PropertyType::Int}
@@ -302,10 +302,10 @@ TEST_CASE("Schema") {
                     {"link", PropertyType::Object|PropertyType::Nullable, "target"}
                 }}
             };
-            REQUIRE_THROWS_CONTAINING(schema.validate(), "Property 'origin.link' of type 'object' cannot link to top-level object type 'target'");
+            REQUIRE_NOTHROW(schema.validate());
         }
 
-        SECTION("rejects array properties from embedded to top-level") {
+        SECTION("allows array properties from embedded to top-level") {
             Schema schema = {
                 {"target", {
                     {"value", PropertyType::Int}
@@ -314,7 +314,7 @@ TEST_CASE("Schema") {
                     {"array", PropertyType::Array|PropertyType::Object, "target"}
                 }}
             };
-            REQUIRE_THROWS_CONTAINING(schema.validate(), "Property 'origin.array' of type 'array' cannot link to top-level object type 'target'");
+            REQUIRE_NOTHROW(schema.validate());
         }
 
         SECTION("allows linking objects from embedded to top-level") {


### PR DESCRIPTION
This was an arbitrary restriction that I thought was imposed by the server but actually is fine.