### PR TITLE
Fix push client and change the token update order in sync_manager

### DIFF
--- a/src/sync/push_client.cpp
+++ b/src/sync/push_client.cpp
@@ -55,8 +55,7 @@ void PushClient::register_device(const std::string& registration_token,
     handler);
 }
 
-void PushClient::deregister_device(const std::string& registration_token,
-                                   std::shared_ptr<SyncUser> sync_user,
+void PushClient::deregister_device(std::shared_ptr<SyncUser> sync_user,
                                    std::function<void(util::Optional<AppError>)> completion_block)
 {
     auto handler = [completion_block](const Response& response) {
@@ -68,19 +67,13 @@ void PushClient::deregister_device(const std::string& registration_token,
     };
     auto push_route = util::format("/app/%1/push/providers/%2/registration", m_app_id, m_service_name);
     std::string route = m_auth_request_client->url_for_path(push_route);
-    
-    auto args = bson::BsonDocument();
-    args["registrationToken"] = registration_token;
-    
-    std::stringstream s;
-    s << bson::Bson(args);
         
     m_auth_request_client->do_authenticated_request({
         HttpMethod::del,
         route,
         m_timeout_ms,
         {},
-        s.str(),
+        "",
         false
     },
     sync_user,

--- a/src/sync/push_client.hpp
+++ b/src/sync/push_client.hpp
@@ -44,13 +44,22 @@ public:
     PushClient(PushClient&&) = default;
     PushClient& operator=(const PushClient&) = default;
     PushClient& operator=(PushClient&&) = default;
-    
+
+
+    /// Register a device for push notifications.
+    /// @param registration_token GCM registration token for the device.
+    /// @param sync_user The sync user requesting push registration.
+    /// @param completion_block An error will be returned should something go wrong.
     void register_device(const std::string& registration_token,
                          std::shared_ptr<SyncUser> sync_user,
                          std::function<void(util::Optional<AppError>)> completion_block);
-    
-    void deregister_device(const std::string& registration_token,
-                           std::shared_ptr<SyncUser> sync_user,
+
+
+    /// Deregister a device for push notificatons, no token or device id needs to be passed
+    /// as it is liked to the user in MongoDB Realm Cloud.
+    /// @param sync_user The sync user requesting push degistration.
+    /// @param completion_block An error will be returned should something go wrong.
+    void deregister_device(std::shared_ptr<SyncUser> sync_user,
                            std::function<void(util::Optional<AppError>)> completion_block);
 
 private:

--- a/src/sync/push_client.hpp
+++ b/src/sync/push_client.hpp
@@ -56,7 +56,7 @@ public:
 
 
     /// Deregister a device for push notificatons, no token or device id needs to be passed
-    /// as it is liked to the user in MongoDB Realm Cloud.
+    /// as it is linked to the user in MongoDB Realm Cloud.
     /// @param sync_user The sync user requesting push degistration.
     /// @param completion_block An error will be returned should something go wrong.
     void deregister_device(std::shared_ptr<SyncUser> sync_user,

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -340,6 +340,10 @@ std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& user_id,
             return nullptr;
         }
 
+        // It is important that the access token is set before the refresh token
+        // as once each token is set it attempts to revive any pending sessions
+        // (e.g. as user logs out and logs back in they would be using an empty access token with the sync client
+        // if the order of these were flipped).
         user->update_access_token(std::move(access_token));
         user->update_refresh_token(std::move(refresh_token));
 

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -339,8 +339,9 @@ std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& user_id,
         if (user->state() == SyncUser::State::Removed) {
             return nullptr;
         }
-        user->update_refresh_token(std::move(refresh_token));
+
         user->update_access_token(std::move(access_token));
+        user->update_refresh_token(std::move(refresh_token));
 
         if (user->state() == SyncUser::State::LoggedOut) {
             user->set_state(SyncUser::State::LoggedIn);

--- a/tests/sync/app.cpp
+++ b/tests/sync/app.cpp
@@ -1596,37 +1596,24 @@ TEST_CASE("app: push notifications", "[sync][app]") {
                 
         CHECK(processed);
     }
-    
+
     SECTION("deregister") {
         bool processed;
 
-        app->push_notification_client("gcm").deregister_device("hello",
-                                                                  sync_user,
-                                                                  [&](Optional<app::AppError> error) {
+        app->push_notification_client("gcm").deregister_device(sync_user,
+                                                               [&](Optional<app::AppError> error) {
             CHECK(!error);
             processed = true;
         });
         CHECK(processed);
     }
-    
-    SECTION("deregister with an unregistered user") {
-        bool processed;
 
-        app->push_notification_client("gcm").deregister_device("helloooo",
-                                                                  sync_user,
-                                                                  [&](Optional<app::AppError> error) {
-            CHECK(!error);
-            processed = true;
-        });
-        CHECK(processed);
-    }
-    
     SECTION("register with unavailable service") {
         bool processed;
 
-        app->push_notification_client("gcm_blah").deregister_device("hello",
-                                                                    sync_user,
-                                                                    [&](Optional<app::AppError> error) {
+        app->push_notification_client("gcm_blah").register_device("hello",
+                                                                  sync_user,
+                                                                  [&](Optional<app::AppError> error) {
             REQUIRE(error);
             CHECK(error->message == "service not found: 'gcm_blah'");
             processed = true;


### PR DESCRIPTION
This PR addresses two issues:

- Remove the need for a registration token when deregistering an device using the `push_client`

- Ensure that the `access_token` is set before the `refresh_token` in the `get_user` call in `sync_manager`. As previously when the `refresh_token` was getting set first it allowed the sync client to start without an `access_token` due to each of the `update_X_token` trying to revive a session once they are set. This issue was prominent when calling log_in with a logged out user and attempting to create a sync connection.