### PR TITLE
Add fix for refreshing an expired access token on sync start

### DIFF
--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -90,7 +90,7 @@ struct SyncSession::State {
     // The session should be closed and moved to `inactive`, in accordance with its stop policy and other state.
     virtual void close(std::unique_lock<std::mutex>&, SyncSession&) const { }
 
-    // Returns true iff the error has been fully handled and the error handler should immediately return.
+    // Returns true if the error has been fully handled and the error handler should immediately return.
     virtual void handle_error(std::unique_lock<std::mutex>&, SyncSession&, const SyncError&) const { }
 
     // Register a handler to wait for sync session uploads, downloads, or synchronization.

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -500,6 +500,13 @@ void SyncSession::handle_error(SyncError error)
                 error.is_unrecognized_by_client = true;
         }
     }
+
+    // Dont't bother invoking m_config.error_handler if the sync is inactive.
+    // It does not make sense to call the handler when the session is closed.
+    if (m_state == &State::inactive) {
+        return;
+    }
+
     switch (next_state) {
         case NextStateAfterError::none:
             if (m_config.cancel_waits_on_nonfatal_error) {

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -90,7 +90,7 @@ struct SyncSession::State {
     // The session should be closed and moved to `inactive`, in accordance with its stop policy and other state.
     virtual void close(std::unique_lock<std::mutex>&, SyncSession&) const { }
 
-    // Returns true if the error has been fully handled and the error handler should immediately return.
+    // If the error is fatal advance the state to inactive.
     virtual void handle_error(std::unique_lock<std::mutex>&, SyncSession&, const SyncError&) const { }
 
     // Register a handler to wait for sync session uploads, downloads, or synchronization.
@@ -256,7 +256,6 @@ const SyncSession::State& SyncSession::State::inactive = Inactive();
 std::function<void(util::Optional<app::AppError>)> SyncSession::handle_refresh(std::shared_ptr<SyncSession> session) {
     return [session](util::Optional<app::AppError> error) {
         using namespace std::chrono;
-        if (!session) return;
 
         auto session_user = session->user();
         auto is_user_expired = session_user &&

--- a/src/sync/sync_session.cpp
+++ b/src/sync/sync_session.cpp
@@ -276,7 +276,6 @@ std::function<void(util::Optional<app::AppError>)> SyncSession::handle_refresh(s
             // 10 seconds is arbitrary, but it is to not swamp the server
             std::this_thread::sleep_for(milliseconds(10000));
             if (session_user) {
-                std::cout << "Will try to refresh access token \n";
                 session_user->refresh_custom_data(handle_refresh(session));
             }
         } else {

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -310,7 +310,7 @@ private:
     }
     // }
     
-    static std::function<void(util::Optional<app::AppError>)> handle_refresh(std::weak_ptr<SyncSession>);
+    static std::function<void(util::Optional<app::AppError>)> handle_refresh(std::shared_ptr <SyncSession>);
     
     SyncSession(_impl::SyncClient&, std::string realm_path, SyncConfig, bool force_client_resync);
     

--- a/tests/sync/session/session.cpp
+++ b/tests/sync/session/session.cpp
@@ -415,8 +415,8 @@ TEMPLATE_TEST_CASE("sync: stop policy behavior", "[sync]", RegularUser) {
             std::error_code code = std::error_code{static_cast<int>(ProtocolError::bad_syntax), realm::sync::protocol_error_category()};
             SyncSession::OnlyForTesting::handle_error(*session, {code, "Not a real error message", true});
             CHECK(sessions_are_inactive(*session));
-            // The session will move from the dying state to inactive, the error handler should be invoked.
-            CHECK(error_handler_invoked);
+            // The session shouldn't report fatal errors when in the dying state.
+            CHECK(!error_handler_invoked);
         }
 
         SECTION("ignores non-fatal errors and does not transition to Inactive") {

--- a/tests/sync/session/session.cpp
+++ b/tests/sync/session/session.cpp
@@ -415,8 +415,8 @@ TEMPLATE_TEST_CASE("sync: stop policy behavior", "[sync]", RegularUser) {
             std::error_code code = std::error_code{static_cast<int>(ProtocolError::bad_syntax), realm::sync::protocol_error_category()};
             SyncSession::OnlyForTesting::handle_error(*session, {code, "Not a real error message", true});
             CHECK(sessions_are_inactive(*session));
-            // The session shouldn't report fatal errors when in the dying state.
-            CHECK(!error_handler_invoked);
+            // The session will move from the dying state to inactive, the error handler should be invoked.
+            CHECK(error_handler_invoked);
         }
 
         SECTION("ignores non-fatal errors and does not transition to Inactive") {


### PR DESCRIPTION
This PR addresses an issue where a sync session can not be established with an access token that is invalid. There is some small change in logic w.r.t how sync errors are handled and how a session is created once an error has been resolved.