### PR TITLE
Add support for Bson documents to auth custom functions.

### DIFF
--- a/src/sync/app_credentials.cpp
+++ b/src/sync/app_credentials.cpp
@@ -16,10 +16,11 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#include "util.hpp"
 #include "sync/app_credentials.hpp"
+#include "util/bson/bson.hpp"
 
 #include <json.hpp>
+#include <sstream>
 
 namespace realm {
 namespace app {
@@ -150,7 +151,7 @@ AppCredentials AppCredentials::username_password(std::string username,
                           });
 }
 
-AppCredentials AppCredentials::function(bson::BsonDocument payload)
+AppCredentials AppCredentials::function(bson::BsonDocument& payload)
 {
     return AppCredentials(AuthProvider::FUNCTION,
                           [=] {

--- a/src/sync/app_credentials.cpp
+++ b/src/sync/app_credentials.cpp
@@ -16,9 +16,11 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
+#include "util.hpp"
 #include "sync/app_credentials.hpp"
 
 #include <json.hpp>
+#include <string>
 
 namespace realm {
 namespace app {
@@ -149,11 +151,13 @@ AppCredentials AppCredentials::username_password(std::string username,
                           });
 }
 
-AppCredentials AppCredentials::function(std::string payload_json)
+AppCredentials AppCredentials::function(bson::BsonDocument payload)
 {
     return AppCredentials(AuthProvider::FUNCTION,
                           [=] {
-                            return payload_json;
+                              std::stringstream output;
+                              output << bson::Bson(payload);
+                              return output.str();
                           });
 }
 

--- a/src/sync/app_credentials.cpp
+++ b/src/sync/app_credentials.cpp
@@ -20,7 +20,6 @@
 #include "sync/app_credentials.hpp"
 
 #include <json.hpp>
-#include <string>
 
 namespace realm {
 namespace app {

--- a/src/sync/app_credentials.cpp
+++ b/src/sync/app_credentials.cpp
@@ -151,7 +151,7 @@ AppCredentials AppCredentials::username_password(std::string username,
                           });
 }
 
-AppCredentials AppCredentials::function(bson::BsonDocument& payload)
+AppCredentials AppCredentials::function(const bson::BsonDocument& payload)
 {
     return AppCredentials(AuthProvider::FUNCTION,
                           [=] {

--- a/src/sync/app_credentials.hpp
+++ b/src/sync/app_credentials.hpp
@@ -100,7 +100,7 @@ struct AppCredentials {
 
     // Construct and return credentials with the payload.
     // The payload is a MongoDB document as json
-    static AppCredentials function(bson::BsonDocument& payload);
+    static AppCredentials function(const bson::BsonDocument& payload);
 
     // Construct and return credentials with the user api key.
     static AppCredentials user_api_key(std::string api_key);

--- a/src/sync/app_credentials.hpp
+++ b/src/sync/app_credentials.hpp
@@ -21,9 +21,13 @@
 
 #include <functional>
 #include <string>
-#include <object-store/src/util/bson/bson.hpp>
 
 namespace realm {
+namespace bson {
+class Bson;
+template <typename> class IndexedMap;
+using BsonDocument = IndexedMap<Bson>;
+}
 namespace app {
 
 typedef std::string IdentityProvider;
@@ -96,7 +100,7 @@ struct AppCredentials {
 
     // Construct and return credentials with the payload.
     // The payload is a MongoDB document as json
-    static AppCredentials function(bson::BsonDocument payload);
+    static AppCredentials function(bson::BsonDocument& payload);
 
     // Construct and return credentials with the user api key.
     static AppCredentials user_api_key(std::string api_key);

--- a/src/sync/app_credentials.hpp
+++ b/src/sync/app_credentials.hpp
@@ -21,6 +21,7 @@
 
 #include <functional>
 #include <string>
+#include <object-store/src/util/bson/bson.hpp>
 
 namespace realm {
 namespace app {
@@ -95,8 +96,8 @@ struct AppCredentials {
 
     // Construct and return credentials with the payload.
     // The payload is a MongoDB document as json
-    static AppCredentials function(std::string payload_json);
-    
+    static AppCredentials function(bson::BsonDocument payload);
+
     // Construct and return credentials with the user api key.
     static AppCredentials user_api_key(std::string api_key);
 

--- a/tests/sync/app.cpp
+++ b/tests/sync/app.cpp
@@ -789,8 +789,8 @@ TEST_CASE("app: auth providers function integration", "[sync][app]") {
     bool processed = false;
     
     SECTION("auth providers function integration") {
-        
-        auto credentials = realm::app::AppCredentials::function(nlohmann::json({{"realmCustomAuthFuncUserId", "123456"}}).dump());
+        bson::BsonDocument function_params { {"realmCustomAuthFuncUserId", "123456"} };
+        auto credentials = realm::app::AppCredentials::function(function_params);
         
         app->log_in_with_credentials(credentials,
                                      [&](std::shared_ptr<realm::SyncUser> user, Optional<app::AppError> error) {
@@ -3081,7 +3081,8 @@ TEST_CASE("app: auth providers", "[sync][app]") {
     }
     
     SECTION("auth providers function") {
-        auto credentials = realm::app::AppCredentials::function(nlohmann::json({{"name", "mongo"}}).dump());
+        bson::BsonDocument function_params { {"name", "mongo"} };
+        auto credentials = realm::app::AppCredentials::function(function_params);
         CHECK(credentials.provider() == AuthProvider::FUNCTION);
         CHECK(credentials.provider_as_string() == IdentityProviderFunction);
         CHECK(credentials.serialize_as_json() == "{\"name\":\"mongo\"}");


### PR DESCRIPTION
Closes:
https://github.com/realm/realm-object-store/issues/1040

The current implementation receives a string payload, which is outdated. It should be a BsonDocument instead.