### PR TITLE
Retain RealmCoordinator in ThreadSafeReference::Payload

### DIFF
--- a/src/thread_safe_reference.cpp
+++ b/src/thread_safe_reference.cpp
@@ -24,6 +24,8 @@
 #include "results.hpp"
 #include "shared_realm.hpp"
 
+#include "impl/realm_coordinator.hpp"
+
 #include <realm/db.hpp>
 #include <realm/keys.hpp>
 
@@ -33,6 +35,7 @@ public:
     virtual ~Payload() = default;
     Payload(Realm& realm)
     : m_transaction(realm.is_in_read_transaction() ? realm.duplicate() : nullptr)
+    , m_coordinator(Realm::Internal::get_coordinator(realm).shared_from_this())
     , m_created_in_write_transaction(realm.is_in_transaction())
     {
     }
@@ -43,7 +46,7 @@ protected:
     const TransactionRef m_transaction;
 
 private:
-    const VersionID m_target_version;
+    const std::shared_ptr<_impl::RealmCoordinator> m_coordinator;
     const bool m_created_in_write_transaction;
 };
 

--- a/src/thread_safe_reference.hpp
+++ b/src/thread_safe_reference.hpp
@@ -51,6 +51,9 @@ private:
     template<typename> class PayloadImpl;
     std::unique_ptr<Payload> m_payload;
 };
+
+template<> ThreadSafeReference::ThreadSafeReference(std::shared_ptr<Realm> const&);
+template<> std::shared_ptr<Realm> ThreadSafeReference::resolve(std::shared_ptr<Realm> const&);
 }
 
 #endif /* REALM_OS_THREAD_SAFE_REFERENCE_HPP */

--- a/tests/thread_safe_reference.cpp
+++ b/tests/thread_safe_reference.cpp
@@ -31,6 +31,7 @@
 #include "util/scheduler.hpp"
 
 #include "impl/object_accessor_impl.hpp"
+#include "impl/realm_coordinator.hpp"
 
 #include <realm/db.hpp>
 #include <realm/history.hpp>
@@ -858,9 +859,18 @@ TEST_CASE("thread safe reference") {
     SECTION("lifetime") {
         SECTION("retains source realm") { // else version will become unpinned
             auto ref = ThreadSafeReference(foo);
+            foo = {};
             r = nullptr;
             r = Realm::get_shared_realm(config);
             REQUIRE_NOTHROW(ref.resolve<Object>(r));
+        }
+
+        SECTION("retains source RealmCoordinator") {
+            auto ref = ThreadSafeReference(foo);
+            auto coordinator = _impl::RealmCoordinator::get_existing_coordinator(config.path).get();
+            foo = {};
+            r = nullptr;
+            REQUIRE(coordinator == _impl::RealmCoordinator::get_existing_coordinator(config.path).get());
         }
     }
 


### PR DESCRIPTION
Not doing this made it possible to end up with 2+ DB instances for the same Realm file in the same process if the ThreadSafeReference's Transaction was the last thing keeping a DB alive.

It's unclear if this had any consequences besides increased memory usage.