### PR TITLE
Disable sync metadata storage for most tests

### DIFF
--- a/CMake/CodeCoverage.cmake
+++ b/CMake/CodeCoverage.cmake
@@ -20,8 +20,7 @@ find_program(LCOV_PATH lcov)
 find_program(GENHTML_PATH genhtml)
 find_program(GCOVR_PATH gcovr PATHS ${CMAKE_SOURCE_DIR}/tests)
 
-set(CMAKE_CXX_FLAGS_COVERAGE "-g -O0 -fprofile-arcs -ftest-coverage -DCATCH_CONFIG_FAST_COMPILE"
-    CACHE STRING "Flags used by the C++ compiler during coverage builds.")
+set(CMAKE_CXX_FLAGS_COVERAGE "-g -O0 -fprofile-arcs -ftest-coverage -DCATCH_CONFIG_FAST_COMPILE")
 mark_as_advanced(CMAKE_CXX_FLAGS_COVERAGE)
 
 if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
@@ -50,7 +49,7 @@ if(CMAKE_BUILD_TYPE STREQUAL "Coverage")
 
     add_custom_target(${targetname}-cobertura
       COMMAND ${testrunner}
-      COMMAND ${GCOVR_PATH} -x -r ${CMAKE_SOURCE_DIR}/src ./src -o coverage.xml
+      COMMAND ${GCOVR_PATH} -x -o coverage.xml -f 'src/.*' -f "${CMAKE_SOURCE_DIR}/src.*" --exclude-directories "${CMAKE_BINARY_DIR}/tests" --exclude-directories="${CMAKE_SOURCE_DIR}/\.tmp" --exclude ".*realm\-core.*" --exclude ".*realm\-sync.*"
       COMMAND echo Code coverage report written to coverage.xml
 
       WORKING_DIRECTORY ${CMAKE_BINARY_DIR}

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -23,6 +23,7 @@
 #include "sync/impl/sync_metadata.hpp"
 #include "sync/sync_session.hpp"
 #include "sync/sync_user.hpp"
+#include "util/uuid.hpp"
 
 using namespace realm;
 using namespace realm::_impl;
@@ -68,6 +69,9 @@ void SyncManager::configure(SyncClientConfig config)
 
         // Set up the metadata manager, and perform initial loading/purging work.
         if (m_metadata_manager || m_config.metadata_mode == MetadataMode::NoMetadata) {
+            // No metadata means we use a new client uuid each time
+            if (!m_metadata_manager)
+                m_client_uuid = uuid_string();
             return;
         }
 

--- a/src/sync/sync_user.hpp
+++ b/src/sync/sync_user.hpp
@@ -172,7 +172,7 @@ private:
     // FIXME: remove this flag once bindings take responsible for admin token users
     TokenType m_token_type;
 
-    bool m_is_admin;
+    bool m_is_admin = false;
 
     // The user's refresh token.
     std::string m_refresh_token;

--- a/tests/util/test_file.hpp
+++ b/tests/util/test_file.hpp
@@ -142,7 +142,7 @@ struct SyncTestFile : TestFile {
 };
 
 struct TestSyncManager {
-    TestSyncManager(std::string const& base_path="", realm::SyncManager::MetadataMode = realm::SyncManager::MetadataMode::NoEncryption);
+    TestSyncManager(std::string const& base_path="", realm::SyncManager::MetadataMode = realm::SyncManager::MetadataMode::NoMetadata);
     ~TestSyncManager();
     static void configure(std::string const& base_path, realm::SyncManager::MetadataMode);
 };

--- a/workflow/test_coverage.sh
+++ b/workflow/test_coverage.sh
@@ -6,11 +6,6 @@
 sync=${1}
 deps_suffix="${2}"
 
-nprocs=1
-if [ "$(uname)" = "Linux" ]; then
-  nprocs=$(grep -c ^processor /proc/cpuinfo)
-fi
-
 : ${OPENSSL_ROOT_DIR:=/usr/local}
 
 set -e
@@ -30,7 +25,7 @@ if [ "${sync}" = "sync" ]; then
     cmake_flags="${cmake_flags} -DREALM_ENABLE_SYNC=1 -DREALM_ENABLE_SERVER=1 -DOPENSSL_ROOT_DIR=${OPENSSL_ROOT_DIR}"
 fi
 
-cmake ${cmake_flags} -DCMAKE_BUILD_TYPE=Coverage -DDEPENDENCIES_FILE="dependencies${deps_suffix}.list" ..
-make VERBOSE=1 -j${nprocs} generate-coverage-cobertura
+cmake ${cmake_flags} -G Ninja -DCMAKE_BUILD_TYPE=Coverage -DDEPENDENCIES_FILE="dependencies${deps_suffix}.list" ..
+ninja -v generate-coverage-cobertura
 
 find $TMPDIR -name 'realm*' -exec rm -rf "{}" \+ || true


### PR DESCRIPTION
This cuts the runtime of the sync-enabled test suite from 4 minutes to 4 *seconds* since nearly all of the time was spent creating, opening, closing, and then deleting the metadata realm without ever actually reading anything from it.

I also ported over the changes to fix code coverage generation from v10 as I wanted to make sure that there wasn't any sync metadata functions only accidentally being covered by other tests.