### PR TITLE
Added Realm::shutdown_sync() which waits for Realm file to be closed

### DIFF
--- a/src/sync/impl/sync_client.hpp
+++ b/src/sync/impl/sync_client.hpp
@@ -115,6 +115,11 @@ struct SyncClient {
         return m_client.decompose_server_url(url, protocol, address, port, path);
     }
 
+    void wait_for_session_terminations()
+    {
+        m_client.wait_for_session_terminations_or_client_stopped();
+    }
+
     ~SyncClient()
     {
         stop();

--- a/src/sync/sync_session.hpp
+++ b/src/sync/sync_session.hpp
@@ -199,6 +199,10 @@ public:
     // Inform the sync session that it should log out.
     void log_out();
 
+    // Shut down the synchronization session (sync::Session) and wait for the Realm file to no
+    // longer be open on behalf of it.
+    void shutdown_and_wait();
+
     // Override the address and port of the server that this `SyncSession` is connected to. If the
     // session is already connected, it will disconnect and then reconnect to the specified address.
     // If it's not already connected, future connection attempts will be to the specified address.


### PR DESCRIPTION
I am proposing this new feature as a solution to a problem identified by @RedBeard0531, namely that when a unit test needs to delete a Realm file, it has no way of ensuring that the Realm file is closed by everyone before deleting.

One way to solve the problem in Realm JS, is to expose `Realm::shutdown_and_wait()` for the purpose of testing, and have tests call it before deleting Realm files. If done this way, it will be necessary to call `shutdown_sync()` before calling `close()`.