### PR TITLE
Don't pass bogus length to string_view::substr()

### DIFF
--- a/src/sync/remote_mongo_collection.cpp
+++ b/src/sync/remote_mongo_collection.cpp
@@ -507,9 +507,12 @@ void WatchStream::feed_sse(ServerSentEvent sse) {
         size_t start = 0;
         while (true) {
             auto percent = start == 0 ? first_percent : sse.data.find('%', start);
-            buffer += sse.data.substr(start, percent - start);
-            if (percent == std::string::npos)
+            if (percent == std::string::npos) {
+                buffer += sse.data.substr(start);
                 break;
+            }
+
+            buffer += sse.data.substr(start, percent - start);
 
             auto encoded = sse.data.substr(percent, 3); // may be smaller than 3 if string ends with %
             if (encoded == "%25") {


### PR DESCRIPTION
This would never actually change behavior since it would always pass a length
larger than desired which would automatically be interpreted as stopping at
the end of the string. But it seems better to either pass the real desired
length, or use the default of npos. This was an issue in the JS port of this
code for realm-web, and I'd prefer to keep the differences between the
implementations to a minimum.