### PR TITLE
Fix a version pinning issue with Results

### DIFF
--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -980,6 +980,7 @@ TEST_CASE("notifications: TableView delivery") {
 
     InMemoryTestFile config;
     config.automatic_change_notifications = false;
+    config.max_number_of_active_versions = 5;
 
     auto r = Realm::get_shared_realm(config);
     r->update_schema({
@@ -1091,6 +1092,15 @@ TEST_CASE("notifications: TableView delivery") {
         r->begin_transaction();
         REQUIRE(results.size() == 11);
         r->cancel_transaction();
+    }
+
+    SECTION("unused background TVs do not pin old versions forever") {
+        // This will exceed the maximum active version count (5) if any
+        // transactions are being pinned, resulting in make_remote_change() throwing
+        for (int i = 0; i < 10; ++i) {
+            REQUIRE_NOTHROW(make_remote_change());
+            advance_and_notify(*r);
+        }
     }
 }
 


### PR DESCRIPTION
Core 6 changed how TableViews were passed from ResultsNotifier to Results to be pull-based rather than push based. With Core 5, ResultsNotifier mutated the parent Results to update the TableView as part of change notification delivery, while now Results gets the TableView from the ResultsNotifier when the user reads from the Results and forces a re-evaluation of the query. This change simplified the data flow a lot, but meant that if the Results is never actually read from, the TableView would sit around in the ResultsNotifier forever, and continue to pin that version.

To fix this, add a check to see if there's a stale TV that went unused and if so discard it and release the version pin.