### PR TITLE
Null support when calculating paths

### DIFF
--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -502,6 +502,9 @@ static std::string string_from_partition(const std::string& partition)
             case bson::Bson::Type::ObjectId:
                 ss << "o_" << static_cast<ObjectId>(partition_value);
                 break;
+            case bson::Bson::Type::Null:
+                ss << "null";
+                break;
             default:
                 ss << partition_value;
                 throw UnsupportedBsonPartition(util::format("Unsupported partition key value: '%1'. Only int, string and ObjectId types are currently supported.", ss.str()));

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -151,12 +151,15 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync]") {
         REQUIRE_DIR_EXISTS(base_path + "mongodb-realm/app_id/foobarbaz/");
     }
 
-    SECTION("should throw for a null partition") {
+    SECTION("should produce the expected path for a Null partition") {
         TestSyncManager init_sync_manager("", base_path, SyncManager::MetadataMode::NoMetadata);
         const bson::Bson partition;
         REQUIRE(partition.type() == bson::Bson::Type::Null);
         SyncConfig config(user, partition);
-        REQUIRE_THROWS_WITH(SyncManager::shared().path_for_realm(config), "Unsupported partition key value: 'null'. Only int, string and ObjectId types are currently supported.");
+        const auto expected = base_path + "mongodb-realm/app_id/foobarbaz/null.realm";
+        REQUIRE(SyncManager::shared().path_for_realm(config) == expected);
+        // This API should also generate the directory if it doesn't already exist.
+        REQUIRE_DIR_EXISTS(base_path + "mongodb-realm/app_id/foobarbaz/");
     }
 }
 


### PR DESCRIPTION
Add support to Realm defined by the Bson value `null`.

We cannot prefix null with the type since Bson looses that type information. This means in the worst case where:

1) Server defines optional partition key as String
2) Client opens a Realm with a null String
3) Server stops sync and create a new partition key as Integer.
3) Client opens a Realm with a null Integer

Then they will see a Client Reset. Trying to prefix the null Realm with the type prefix doesn't seem worth the effort since this is very unlikely to happen.