### PR TITLE
ROBJSTORE-109: Don't construct LinkPathPart with invalid tableref

### DIFF
--- a/src/keypath_helpers.hpp
+++ b/src/keypath_helpers.hpp
@@ -94,7 +94,7 @@ inline IncludeDescriptor generate_include_from_keypaths(std::vector<StringData> 
                 cur_table = element.table; // advance through backlink
             }
             LinkPathPart link = element.is_backlink ? LinkPathPart(element.col_key, element.table) : LinkPathPart(element.col_key);
-            links.emplace_back(link);
+            links.emplace_back(std::move(link));
         }
         properties.push_back(std::move(links));
     }

--- a/src/keypath_helpers.hpp
+++ b/src/keypath_helpers.hpp
@@ -93,11 +93,8 @@ inline IncludeDescriptor generate_include_from_keypaths(std::vector<StringData> 
             else {
                 cur_table = element.table; // advance through backlink
             }
-            ConstTableRef tr;
-            if (element.is_backlink) {
-                tr = element.table;
-            }
-            links.emplace_back(element.col_key, tr);
+            LinkPathPart link = element.is_backlink ? LinkPathPart(element.col_key, element.table) : LinkPathPart(element.col_key);
+            links.emplace_back(link);
         }
         properties.push_back(std::move(links));
     }


### PR DESCRIPTION
Fixes #1072 

The `LinkPathPart` constructor throws `NoSuchTable` when `tr` is invalid. Due to that only being used in QBS code that's going away + my limited C++ skills, I haven't added any tests, but @ironage or @fealebenpae feel free to add if you feel it's worth it.