### PR TITLE
resurrect realm caching

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -195,9 +195,47 @@ void RealmCoordinator::set_config(const Realm::Config& config)
             }
         }
 #endif
+        // Mixing cached and uncached Realms is allowed
+        m_config.cache = config.cache;
 
         // Realm::update_schema() handles complaining about schema mismatches
     }
+}
+
+std::shared_ptr<Realm> RealmCoordinator::get_cached_realm(Realm::Config const& config)
+{
+    if (!config.cache)
+        return nullptr;
+    util::CheckedUniqueLock lock(m_realm_mutex);
+    return do_get_cached_realm(config);
+}
+
+std::shared_ptr<Realm> RealmCoordinator::do_get_cached_realm(Realm::Config const& config)
+{
+    if (!config.cache)
+        return nullptr;
+
+    for (auto& cached_realm : m_weak_realm_notifiers) {
+        if (config.scheduler && !cached_realm.is_cached_for_scheduler(config.scheduler))
+            continue;
+        // can be null if we jumped in between ref count hitting zero and
+        // unregister_realm() getting the lock
+        if (auto realm = cached_realm.realm()) {
+            // If the file is uninitialized and was opened without a schema,
+            // do the normal schema init
+            if (realm->schema_version() == ObjectStore::NotVersioned)
+                break;
+
+            // Otherwise if we have a realm schema it needs to be an exact
+            // match (even having the same properties but in different
+            // orders isn't good enough)
+            if (config.schema && realm->schema() != *config.schema)
+                throw MismatchedConfigException("Realm at path '%1' already opened on current thread with different schema.", config.path);
+
+            return realm;
+        }
+    }
+    return nullptr;
 }
 
 std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config, util::Optional<VersionID> version)
@@ -210,6 +248,9 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config, util::O
     std::shared_ptr<Realm> realm;
     util::CheckedUniqueLock lock(m_realm_mutex);
     set_config(config);
+    if ((realm = do_get_cached_realm(config))) {
+        return realm;
+    }
     do_get_realm(std::move(config), realm, version, lock);
     return realm;
 }
@@ -217,9 +258,12 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config, util::O
 std::shared_ptr<Realm> RealmCoordinator::get_realm(std::shared_ptr<util::Scheduler> scheduler)
 {
     std::shared_ptr<Realm> realm;
-    util::CheckedUniqueLock lock(m_realm_mutex);
     auto config = m_config;
     config.scheduler = scheduler ? scheduler : util::Scheduler::make_default();
+    util::CheckedUniqueLock lock(m_realm_mutex);
+    if ((realm = do_get_cached_realm(config))) {
+        return realm;
+    }
     do_get_realm(std::move(config), realm, none, lock);
     return realm;
 }
@@ -254,7 +298,7 @@ void RealmCoordinator::do_get_realm(Realm::Config config, std::shared_ptr<Realm>
                                      get_path(), ex.code().message(), "");
         }
     }
-    m_weak_realm_notifiers.emplace_back(realm);
+    m_weak_realm_notifiers.emplace_back(realm, config.cache);
 
     if (realm->config().sync_config)
         create_sync_session(false);

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -80,6 +80,8 @@ public:
     void create_session(const Realm::Config& config) REQUIRES(!m_realm_mutex, !m_schema_cache_mutex);
 #endif
 
+    // Get the existing cached Realm if it exists
+    std::shared_ptr<Realm> get_cached_realm(Realm::Config const& config) REQUIRES(!m_realm_mutex);
     // Get a Realm which is not bound to the current execution context
     ThreadSafeReference get_unbound_realm() REQUIRES(!m_realm_mutex);
 
@@ -239,6 +241,7 @@ private:
 
     void set_config(const Realm::Config&) REQUIRES(m_realm_mutex, !m_schema_cache_mutex);
     void create_sync_session(bool force_client_resync);
+    std::shared_ptr<Realm> do_get_cached_realm(Realm::Config const& config) REQUIRES(m_realm_mutex);
     void do_get_realm(Realm::Config config, std::shared_ptr<Realm>& realm,
                       util::Optional<VersionID> version,
                       util::CheckedUniqueLock& realm_lock) REQUIRES(m_realm_mutex);

--- a/src/impl/realm_coordinator.hpp
+++ b/src/impl/realm_coordinator.hpp
@@ -80,8 +80,8 @@ public:
     void create_session(const Realm::Config& config) REQUIRES(!m_realm_mutex, !m_schema_cache_mutex);
 #endif
 
-    // Get the existing cached Realm if it exists
-    std::shared_ptr<Realm> get_cached_realm(Realm::Config const& config) REQUIRES(!m_realm_mutex);
+    // Get the existing cached Realm if it exists for the specified scheduler or config.scheduler
+    std::shared_ptr<Realm> get_cached_realm(Realm::Config const& config, std::shared_ptr<Scheduler> scheduler = nullptr) REQUIRES(!m_realm_mutex);
     // Get a Realm which is not bound to the current execution context
     ThreadSafeReference get_unbound_realm() REQUIRES(!m_realm_mutex);
 
@@ -241,7 +241,7 @@ private:
 
     void set_config(const Realm::Config&) REQUIRES(m_realm_mutex, !m_schema_cache_mutex);
     void create_sync_session(bool force_client_resync);
-    std::shared_ptr<Realm> do_get_cached_realm(Realm::Config const& config) REQUIRES(m_realm_mutex);
+    std::shared_ptr<Realm> do_get_cached_realm(Realm::Config const& config, std::shared_ptr<Scheduler> scheduler = nullptr) REQUIRES(m_realm_mutex);
     void do_get_realm(Realm::Config config, std::shared_ptr<Realm>& realm,
                       util::Optional<VersionID> version,
                       util::CheckedUniqueLock& realm_lock) REQUIRES(m_realm_mutex);

--- a/src/impl/weak_realm_notifier.cpp
+++ b/src/impl/weak_realm_notifier.cpp
@@ -25,9 +25,10 @@ using namespace realm;
 using namespace realm::_impl;
 
 
-WeakRealmNotifier::WeakRealmNotifier(const std::shared_ptr<Realm>& realm)
+WeakRealmNotifier::WeakRealmNotifier(const std::shared_ptr<Realm>& realm, bool cache)
 : m_realm(realm)
 , m_realm_key(realm.get())
+, m_cache(cache)
 {
     bind_to_scheduler();
 }
@@ -51,4 +52,14 @@ void WeakRealmNotifier::bind_to_scheduler()
             }
         });
     }
+}
+
+bool WeakRealmNotifier::is_cached_for_scheduler(std::shared_ptr<util::Scheduler> scheduler) const
+{
+    return m_cache && (m_scheduler && scheduler) && (m_scheduler->is_same_as(scheduler.get()));
+}
+
+bool WeakRealmNotifier::scheduler_is_on_thread() const
+{
+    return m_scheduler && m_scheduler->is_on_thread();
 }

--- a/src/impl/weak_realm_notifier.hpp
+++ b/src/impl/weak_realm_notifier.hpp
@@ -37,7 +37,7 @@ namespace _impl {
 // a Realm instance is released from within a function holding the cache lock.
 class WeakRealmNotifier {
 public:
-    WeakRealmNotifier(const std::shared_ptr<Realm>& realm);
+    WeakRealmNotifier(const std::shared_ptr<Realm>& realm, bool cache);
     ~WeakRealmNotifier();
 
     // Get a strong reference to the cached realm
@@ -48,6 +48,8 @@ public:
 
     // Is this a WeakRealmNotifier for the given Realm instance?
     bool is_for_realm(Realm* realm) const { return realm == m_realm_key; }
+    bool is_cached_for_scheduler(std::shared_ptr<util::Scheduler> scheduler) const;
+    bool scheduler_is_on_thread() const;
 
     // Invoke m_realm.notify() on the Realm's thread via the scheduler.
     void notify();
@@ -58,6 +60,7 @@ public:
 private:
     std::weak_ptr<Realm> m_realm;
     void* m_realm_key;
+    bool m_cache = false;
     std::shared_ptr<util::Scheduler> m_scheduler;
 };
 

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -158,8 +158,11 @@ SharedRealm Realm::get_shared_realm(ThreadSafeReference ref, std::shared_ptr<uti
         scheduler = util::Scheduler::make_default();
     SharedRealm realm = ref.resolve<std::shared_ptr<Realm>>(nullptr);
     REALM_ASSERT(realm);
-    auto& config = realm->config();
+    auto config = realm->config();
     auto coordinator = RealmCoordinator::get_coordinator(config.path);
+    config.scheduler = scheduler;
+    if (auto realm = coordinator->get_cached_realm(config))
+        return realm;
     realm->m_scheduler = scheduler;
     coordinator->bind_to_context(*realm);
     return realm;

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -158,10 +158,9 @@ SharedRealm Realm::get_shared_realm(ThreadSafeReference ref, std::shared_ptr<uti
         scheduler = util::Scheduler::make_default();
     SharedRealm realm = ref.resolve<std::shared_ptr<Realm>>(nullptr);
     REALM_ASSERT(realm);
-    auto config = realm->config();
+    auto& config = realm->config();
     auto coordinator = RealmCoordinator::get_coordinator(config.path);
-    config.scheduler = scheduler;
-    if (auto realm = coordinator->get_cached_realm(config))
+    if (auto realm = coordinator->get_cached_realm(config, scheduler))
         return realm;
     realm->m_scheduler = scheduler;
     coordinator->bind_to_context(*realm);

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -232,7 +232,7 @@ public:
         // that Realm instance for other requests for a cached Realm. Useful
         // for dynamic Realms and for tests that need multiple instances on
         // one thread
-        bool cache = true;
+        bool cache = false;
 
         // Throw an exception rather than automatically upgrading the file
         // format. Used by the browser to warn the user that it'll modify

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -228,6 +228,12 @@ public:
         // The following are intended for internal/testing purposes and
         // should not be publicly exposed in binding APIs
 
+        // If false, always return a new Realm instance, and don't return
+        // that Realm instance for other requests for a cached Realm. Useful
+        // for dynamic Realms and for tests that need multiple instances on
+        // one thread
+        bool cache = true;
+
         // Throw an exception rather than automatically upgrading the file
         // format. Used by the browser to warn the user that it'll modify
         // the file.

--- a/src/util/android/scheduler.hpp
+++ b/src/util/android/scheduler.hpp
@@ -117,7 +117,7 @@ public:
     }
     bool is_same_as(const Scheduler* other) const noexcept override
     {
-        const ALooperScheduler* o = dynamic_cast<const ALooperScheduler*>(other);
+        auto o = dynamic_cast<const ALooperScheduler*>(other);
         return (o && (o->m_thread == m_thread));
     }
 

--- a/src/util/android/scheduler.hpp
+++ b/src/util/android/scheduler.hpp
@@ -115,6 +115,11 @@ public:
     {
         return m_thread == pthread_self();
     }
+    bool is_same_as(const Scheduler* other) const noexcept override
+    {
+        const ALooperScheduler* o = dynamic_cast<const ALooperScheduler*>(other);
+        return (o && (o->m_thread == m_thread));
+    }
 
 private:
     std::function<void()> m_callback;

--- a/src/util/apple/scheduler.hpp
+++ b/src/util/apple/scheduler.hpp
@@ -110,7 +110,7 @@ bool RunLoopScheduler::is_on_thread() const noexcept
 
 bool RunLoopScheduler::is_same_as(const Scheduler* other) const noexcept
 {
-    const RunLoopScheduler* o = dynamic_cast<const RunLoopScheduler*>(other);
+    auto o = dynamic_cast<const RunLoopScheduler*>(other);
     return (o && (o->m_runloop == m_runloop));
 }
 
@@ -193,7 +193,7 @@ bool DispatchQueueScheduler::is_on_thread() const noexcept
 
 bool DispatchQueueScheduler::is_same_as(const Scheduler* other) const noexcept
 {
-    const DispatchQueueScheduler* o = dynamic_cast<const DispatchQueueScheduler*>(other);
+    auto o = dynamic_cast<const DispatchQueueScheduler*>(other);
     return (o && (o->m_queue == m_queue));
 }
 

--- a/src/util/apple/scheduler.hpp
+++ b/src/util/apple/scheduler.hpp
@@ -35,6 +35,7 @@ public:
     void set_notify_callback(std::function<void()>) override;
 
     bool is_on_thread() const noexcept override;
+    bool is_same_as(const Scheduler* other) const noexcept override;
     bool can_deliver_notifications() const noexcept override;
 
 private:
@@ -107,6 +108,12 @@ bool RunLoopScheduler::is_on_thread() const noexcept
     return CFRunLoopGetCurrent() == m_runloop;
 }
 
+bool RunLoopScheduler::is_same_as(const Scheduler* other) const noexcept
+{
+    const RunLoopScheduler* o = dynamic_cast<const RunLoopScheduler*>(other);
+    return (o && (o->m_runloop == m_runloop));
+}
+
 bool RunLoopScheduler::can_deliver_notifications() const noexcept
 {
     // The main thread may not be in a run loop yet if we're called from
@@ -133,6 +140,7 @@ public:
     void set_notify_callback(std::function<void()>) override;
 
     bool is_on_thread() const noexcept override;
+    bool is_same_as(const Scheduler* other) const noexcept override;
     bool can_deliver_notifications() const noexcept override { return true; }
 
 private:
@@ -182,6 +190,13 @@ bool DispatchQueueScheduler::is_on_thread() const noexcept
 {
     return dispatch_get_specific(c_queue_key) == m_queue;
 }
+
+bool DispatchQueueScheduler::is_same_as(const Scheduler* other) const noexcept
+{
+    const DispatchQueueScheduler* o = dynamic_cast<const DispatchQueueScheduler*>(other);
+    return (o && (o->m_queue == m_queue));
+}
+
 } // anonymous namespace
 
 namespace realm {

--- a/src/util/generic/scheduler.hpp
+++ b/src/util/generic/scheduler.hpp
@@ -28,7 +28,7 @@ public:
     bool is_on_thread() const noexcept override { return m_id == std::this_thread::get_id(); }
     bool is_same_as(const Scheduler* other) const noexcept override
     {
-        const GenericScheduler* o = dynamic_cast<const GenericScheduler*>(other);
+        auto o = dynamic_cast<const GenericScheduler*>(other);
         return (o && (o->m_id == m_id));
     }
     bool can_deliver_notifications() const noexcept override { return false; }

--- a/src/util/generic/scheduler.hpp
+++ b/src/util/generic/scheduler.hpp
@@ -26,6 +26,11 @@ public:
     GenericScheduler() = default;
 
     bool is_on_thread() const noexcept override { return m_id == std::this_thread::get_id(); }
+    bool is_same_as(const Scheduler* other) const noexcept override
+    {
+        const GenericScheduler* o = dynamic_cast<const GenericScheduler*>(other);
+        return (o && (o->m_id == m_id));
+    }
     bool can_deliver_notifications() const noexcept override { return false; }
 
     void set_notify_callback(std::function<void()>) override { }

--- a/src/util/scheduler.cpp
+++ b/src/util/scheduler.cpp
@@ -36,6 +36,7 @@ public:
     void notify() override {}
     void set_notify_callback(std::function<void()>) override {}
     bool is_on_thread() const noexcept override { return true; }
+    bool is_same_as(const Scheduler* other) const noexcept override { return dynamic_cast<const FrozenScheduler*>(other); }
     bool can_deliver_notifications() const noexcept override { return false; }
 };
 } // anonymous namespace

--- a/src/util/scheduler.hpp
+++ b/src/util/scheduler.hpp
@@ -58,6 +58,11 @@ public:
     // This function can be called from any thread.
     virtual bool is_on_thread() const noexcept = 0;
 
+    // Checks if this scheduler instance wraps the same underlying instance.
+    // This is up to the platforms to define, but if this method returns true,
+    // caching may occur.
+    virtual bool is_same_as(const Scheduler* other) const noexcept = 0;
+
     // Check if this scehduler actually can support notify(). Notify may be
     // either not implemented, not applicable to a scheduler type, or simply not
     // be possible currently (e.g. if the associated event loop is not actually

--- a/src/util/uv/scheduler.hpp
+++ b/src/util/uv/scheduler.hpp
@@ -39,6 +39,11 @@ public:
     }
 
     bool is_on_thread() const noexcept override { return m_id == std::this_thread::get_id(); }
+    bool is_same_as(const Scheduler* other) const noexcept override
+    {
+        const UvMainLoopScheduler* o = dynamic_cast<const UvMainLoopScheduler*>(other);
+        return (o && (o->m_id == m_id));
+    }
     bool can_deliver_notifications() const noexcept override { return true; }
 
     void set_notify_callback(std::function<void()> fn) override

--- a/src/util/uv/scheduler.hpp
+++ b/src/util/uv/scheduler.hpp
@@ -41,7 +41,7 @@ public:
     bool is_on_thread() const noexcept override { return m_id == std::this_thread::get_id(); }
     bool is_same_as(const Scheduler* other) const noexcept override
     {
-        const UvMainLoopScheduler* o = dynamic_cast<const UvMainLoopScheduler*>(other);
+        auto o = dynamic_cast<const UvMainLoopScheduler*>(other);
         return (o && (o->m_id == m_id));
     }
     bool can_deliver_notifications() const noexcept override { return true; }

--- a/tests/list.cpp
+++ b/tests/list.cpp
@@ -41,6 +41,7 @@ using namespace realm;
 
 TEST_CASE("list") {
     InMemoryTestFile config;
+    config.cache = false;
     config.automatic_change_notifications = false;
     auto r = Realm::get_shared_realm(config);
     r->update_schema({

--- a/tests/migrations.cpp
+++ b/tests/migrations.cpp
@@ -1670,6 +1670,7 @@ TEST_CASE("migration: Additive") {
 
     TestFile config;
     config.schema_mode = SchemaMode::Additive;
+    config.cache = false;
     config.schema = schema;
     auto realm = Realm::get_shared_realm(config);
     realm->update_schema(schema);

--- a/tests/object.cpp
+++ b/tests/object.cpp
@@ -80,6 +80,7 @@ TEST_CASE("object") {
     _impl::RealmCoordinator::assert_no_open_realms();
 
     InMemoryTestFile config;
+    config.cache = false;
     config.automatic_change_notifications = false;
     config.schema = Schema{
         {"table", {

--- a/tests/primitive_list.cpp
+++ b/tests/primitive_list.cpp
@@ -293,6 +293,7 @@ TEMPLATE_TEST_CASE("primitive list", "[primitives]", ::Int, ::Bool, ::Float, ::D
     using Boxed = typename TestType::Boxed;
 
     InMemoryTestFile config;
+    config.cache = false;
     config.automatic_change_notifications = false;
     config.schema = Schema{
         {"object", {

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -59,6 +59,7 @@ using namespace realm;
 
 TEST_CASE("SharedRealm: get_shared_realm()") {
     TestFile config;
+    config.cache = true;
     config.schema_version = 1;
     config.schema = Schema{
         {"object", {
@@ -1906,6 +1907,7 @@ TEST_CASE("BindingContext is notified in case of notifier errors") {
 
 TEST_CASE("RealmCoordinator: get_unbound_realm()") {
     TestFile config;
+    config.cache = true;
     config.schema = Schema{
         {"object", {
             {"value", PropertyType::Int}

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -66,6 +66,19 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
         }},
     };
 
+    SECTION("should return the same instance when caching is enabled") {
+        auto realm1 = Realm::get_shared_realm(config);
+        auto realm2 = Realm::get_shared_realm(config);
+        REQUIRE(realm1.get() == realm2.get());
+    }
+
+    SECTION("should return different instances when caching is disabled") {
+        config.cache = false;
+        auto realm1 = Realm::get_shared_realm(config);
+        auto realm2 = Realm::get_shared_realm(config);
+        REQUIRE(realm1.get() != realm2.get());
+    }
+
     SECTION("should validate that the config is sensible") {
         SECTION("bad encryption key") {
             config.encryption_key = std::vector<char>(2, 0);
@@ -109,6 +122,9 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
     }
 
     SECTION("should reject mismatched config") {
+        SECTION("cached") { }
+        SECTION("uncached") { config.cache = false; }
+
         SECTION("schema version") {
             auto realm = Realm::get_shared_realm(config);
             config.schema_version = 2;
@@ -269,6 +285,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
         Realm::get_shared_realm(config);
 
         config.schema = util::none;
+        config.cache = false;
         config.schema_mode = SchemaMode::Additive;
         config.schema_version = 0;
 
@@ -300,6 +317,9 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
     }
 
     SECTION("should sensibly handle opening an uninitialized file without a schema specified") {
+        SECTION("cached") { }
+        SECTION("uncached") { config.cache = false; }
+
         // create an empty file
         File(config.path, File::mode_Write);
 
@@ -334,6 +354,7 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
     }
 
     SECTION("should support using different table subsets on different threads") {
+        config.cache = false;
         auto realm1 = Realm::get_shared_realm(config);
 
         config.schema = Schema{
@@ -379,10 +400,70 @@ TEST_CASE("SharedRealm: get_shared_realm()") {
     }
 #endif
 
+    SECTION("should get different instances on different threads") {
+        auto realm1 = Realm::get_shared_realm(config);
+        std::thread([&]{
+            auto realm2 = Realm::get_shared_realm(config);
+            REQUIRE(realm1 != realm2);
+        }).join();
+    }
+
     SECTION("should detect use of Realm on incorrect thread") {
         auto realm = Realm::get_shared_realm(config);
         std::thread([&]{
             REQUIRE_THROWS_AS(realm->verify_thread(), IncorrectThreadException);
+        }).join();
+    }
+
+// Our test scheduler uses a simple integer identifier to allow cross thread scheduling
+class SimpleScheduler : public Scheduler {
+public:
+    SimpleScheduler(size_t id)
+    : Scheduler()
+    , m_id(id) {};
+
+    bool is_on_thread() const noexcept override {
+        return true;
+    }
+    bool is_same_as(const Scheduler* other) const noexcept override
+    {
+        const SimpleScheduler* o = dynamic_cast<const SimpleScheduler*>(other);
+        return (o && (o->m_id == m_id));
+    }
+    bool can_deliver_notifications() const noexcept override { return false; }
+    void set_notify_callback(std::function<void()>) override { }
+    void notify() override { }
+protected:
+    size_t m_id;
+};
+
+    SECTION("should get different instances for different explicitly different schedulers") {
+        config.scheduler = std::make_shared<SimpleScheduler>(1);
+        auto realm1 = Realm::get_shared_realm(config);
+        config.scheduler = std::make_shared<SimpleScheduler>(2);
+        auto realm2 = Realm::get_shared_realm(config);
+        REQUIRE(realm1 != realm2);
+
+        config.scheduler = nullptr;
+        auto realm3 = Realm::get_shared_realm(config);
+        REQUIRE(realm1 != realm3);
+        REQUIRE(realm2 != realm3);
+    }
+
+    SECTION("can use Realm with explicit scheduler on different thread") {
+        config.scheduler = std::make_shared<SimpleScheduler>(1);
+        auto realm = Realm::get_shared_realm(config);
+        std::thread([&]{
+            REQUIRE_NOTHROW(realm->verify_thread());
+        }).join();
+    }
+
+    SECTION("should get same instance for same explicit execution context on different thread") {
+        config.scheduler = std::make_shared<SimpleScheduler>(1);
+        auto realm1 = Realm::get_shared_realm(config);
+        std::thread([&]{
+            auto realm2 = Realm::get_shared_realm(config);
+            REQUIRE(realm1 == realm2);
         }).join();
     }
 
@@ -411,6 +492,7 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
 
     SyncServer server;
     SyncTestFile config(server, "default");
+    config.cache = false;
     config.schema = Schema{
         {"object", {
             {"value", PropertyType::Int},
@@ -418,6 +500,7 @@ TEST_CASE("Get Realm using Async Open", "[asyncOpen]") {
     };
     SyncTestFile config2(server, "default");
     config2.schema = config.schema;
+    config2.cache = false;
 
     std::mutex mutex;
     SECTION("can open synced Realms that don't already exist") {
@@ -538,6 +621,7 @@ TEST_CASE("SharedRealm: notifications") {
         return;
 
     TestFile config;
+    config.cache = false;
     config.schema_version = 0;
     config.schema = Schema{
         {"object", {
@@ -856,6 +940,7 @@ TEST_CASE("ShareRealm: in-memory mode from buffer") {
 TEST_CASE("ShareRealm: realm closed in did_change callback") {
     TestFile config;
     config.schema_version = 1;
+    config.cache = false;
     config.schema = Schema{
         {"object", {
             {"value", PropertyType::Int}
@@ -1292,6 +1377,7 @@ TEST_CASE("SharedRealm: SchemaChangedFunction") {
     size_t schema_changed_called = 0;
     Schema changed_fixed_schema;
     TestFile config;
+    config.cache = false;
     auto dynamic_config = config;
 
     config.schema = Schema{
@@ -1849,7 +1935,14 @@ TEST_CASE("RealmCoordinator: get_unbound_realm()") {
         util::EventLoop::main().run_until([&] { return called; });
     }
 
+    SECTION("resolves to existing cached Realm for the thread if caching is enabled") {
+        auto r1 = Realm::get_shared_realm(config);
+        auto r2 = Realm::get_shared_realm(std::move(ref));
+        REQUIRE(r1 == r2);
+    }
+
     SECTION("resolves to a new Realm if caching is disabled") {
+        config.cache = false;
         auto r1 = Realm::get_shared_realm(config);
         auto r2 = Realm::get_shared_realm(std::move(ref));
         REQUIRE(r1 != r2);
@@ -1859,5 +1952,10 @@ TEST_CASE("RealmCoordinator: get_unbound_realm()") {
         auto r3 = Realm::get_shared_realm(std::move(ref));
         REQUIRE(r1 != r3);
         REQUIRE(r2 != r3);
+
+        // New local with cache enabled should grab the resolved unbound
+        config.cache = true;
+        auto r4 = Realm::get_shared_realm(config);
+        REQUIRE(r4 == r2);
     }
 }

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -748,6 +748,7 @@ TEST_CASE("notifications: skip") {
     _impl::RealmCoordinator::assert_no_open_realms();
 
     InMemoryTestFile config;
+    config.cache = false;
     config.automatic_change_notifications = false;
 
     auto r = Realm::get_shared_realm(config);
@@ -1110,6 +1111,7 @@ TEST_CASE("notifications: async error handling") {
     _impl::RealmCoordinator::assert_no_open_realms();
 
     InMemoryTestFile config;
+    config.cache = false;
     config.automatic_change_notifications = false;
 
     auto r = Realm::get_shared_realm(config);
@@ -1315,6 +1317,7 @@ TEST_CASE("notifications: sync") {
 
     SyncServer server(false);
     SyncTestFile config(server);
+    config.cache = false;
     config.schema = Schema{
         {"object", {
             {"value", PropertyType::Int},
@@ -1358,6 +1361,7 @@ TEST_CASE("notifications: results") {
     _impl::RealmCoordinator::assert_no_open_realms();
 
     InMemoryTestFile config;
+    config.cache = false;
     config.automatic_change_notifications = false;
 
     auto r = Realm::get_shared_realm(config);
@@ -2005,6 +2009,7 @@ TEST_CASE("results: notifier with no callbacks") {
     _impl::RealmCoordinator::assert_no_open_realms();
 
     InMemoryTestFile config;
+    config.cache = false;
     config.automatic_change_notifications = false;
 
     auto coordinator = _impl::RealmCoordinator::get_coordinator(config.path);
@@ -2104,6 +2109,7 @@ TEST_CASE("results: error messages") {
 
 TEST_CASE("results: snapshots") {
     InMemoryTestFile config;
+    config.cache = false;
     config.automatic_change_notifications = false;
     config.schema = Schema{
         {"object", {
@@ -2431,6 +2437,7 @@ TEST_CASE("results: snapshots") {
 TEST_CASE("results: distinct") {
     const int N = 10;
     InMemoryTestFile config;
+    config.cache = false;
     config.automatic_change_notifications = false;
 
     auto r = Realm::get_shared_realm(config);
@@ -2642,6 +2649,7 @@ TEST_CASE("results: distinct") {
 
 TEST_CASE("results: sort") {
     InMemoryTestFile config;
+    config.cache = false;
     config.schema = Schema{
         {"object", {
             {"value", PropertyType::Int},

--- a/tests/thread_safe_reference.cpp
+++ b/tests/thread_safe_reference.cpp
@@ -72,6 +72,7 @@ TEST_CASE("thread safe reference") {
 
     InMemoryTestFile config;
     config.automatic_change_notifications = false;
+    config.cache = false;
     SharedRealm r = Realm::get_shared_realm(config);
     r->update_schema(schema);
 

--- a/tests/transaction_log_parsing.cpp
+++ b/tests/transaction_log_parsing.cpp
@@ -910,6 +910,7 @@ TEST_CASE("Transaction log parsing: changeset calcuation") {
     }
 
     SECTION("object change information") {
+        config.cache = false;
         auto realm = Realm::get_shared_realm(config);
         realm->update_schema({
             {"origin", {


### PR DESCRIPTION
A cached realm will now be returned from `RealmCoordinator::get_shared_realm()` if these conditions are met:
- config.cache is true (default)
- config.scheduler identifies itself as meeting the comparison criteria, this is implementation dependant, but can be a thread id check for example.

Fixes https://github.com/realm/realm-object-store/issues/1069