### PR TITLE
Fix bug where a users identities are not being set on init_metadata

### DIFF
--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -157,6 +157,7 @@ void SyncManager::init_metadata(SyncClientConfig config, const std::string& app_
                                                    user_data.access_token,
                                                    user_data.state,
                                                    user_data.device_id);
+            user->update_identities(user_data.identities);
             m_users.emplace_back(std::move(user));
         }
     }

--- a/tests/sync/user.cpp
+++ b/tests/sync/user.cpp
@@ -146,7 +146,11 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         const std::string refresh_token = ENCODE_FAKE_JWT("r-token-1");
         const std::string access_token = ENCODE_FAKE_JWT("a-token-1");
         const std::string server_url = "https://realm.example.org/1/";
+        const std::vector<SyncUserIdentity> identities {
+            { "12345", "test_case_provider" }
+        };
         auto user = SyncManager::shared().get_user(identity, refresh_token, access_token, server_url, dummy_device_id);
+        user->update_identities(identities);
         // Now try to pull the user out of the shadow manager directly.
         auto metadata = manager.get_or_make_user_metadata(identity, server_url, false);
         REQUIRE(metadata->is_valid());
@@ -154,6 +158,7 @@ TEST_CASE("sync_user: user persistence", "[sync]") {
         REQUIRE(metadata->access_token() == access_token);
         REQUIRE(metadata->refresh_token() == refresh_token);
         REQUIRE(metadata->device_id() == dummy_device_id);
+        REQUIRE(metadata->identities() == identities);
     }
 
     SECTION("properly persists a user's information when the user is updated") {


### PR DESCRIPTION
This PR addresses a bug where the `identities` of a user were not being set on creation of an `App` due to the fact that `SyncManager::init_metadata` did not call `update_identities` for each persisted user.

Fixes: https://github.com/realm/realm-cocoa/issues/6647