### PR TITLE
Don't try to deliver async query results inside a write transaction

### DIFF
--- a/src/impl/results_notifier.cpp
+++ b/src/impl/results_notifier.cpp
@@ -85,6 +85,8 @@ bool ResultsNotifier::get_tableview(TableView& out)
     if (!m_delivered_tv)
         return false;
     auto& transaction = source_shared_group();
+    if (transaction.get_transact_stage() != DB::transact_Reading)
+        return false;
     if (m_delivered_transaction->get_version_of_current_transaction() != transaction.get_version_of_current_transaction())
         return false;
 

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -1086,12 +1086,43 @@ TEST_CASE("notifications: TableView delivery") {
         REQUIRE(results.size() == 0);
     }
 
-    SECTION("TV can be delivered in a write transaction") {
-        make_remote_change();
-        advance_and_notify(*r);
-        r->begin_transaction();
-        REQUIRE(results.size() == 11);
-        r->cancel_transaction();
+    SECTION("TV can't be delivered in a write transaction") {
+        SECTION("no changes") {
+            make_remote_change();
+            advance_and_notify(*r);
+            r->begin_transaction();
+            REQUIRE(results.size() == 0);
+            r->cancel_transaction();
+        }
+
+        SECTION("local change with automatic updates disabled") {
+            advance_and_notify(*r);
+            REQUIRE(results.size() == 10);
+            make_remote_change();
+            advance_and_notify(*r);
+
+            r->begin_transaction();
+            r->read_group().get_table("class_object")->create_object();
+            REQUIRE(results.size() == 10);
+            r->cancel_transaction();
+        }
+
+        SECTION("local change with automatic updates enabled") {
+            // Use a new Results because AsyncOnly leaves the Results in a
+            // weird state and switching back to Auto doesn't work.
+            Results results(r, table->where());
+            results.evaluate_query_if_needed();
+            static_cast<void>(results.add_notification_callback([&](CollectionChangeSet, std::exception_ptr) {}));
+            advance_and_notify(*r);
+            REQUIRE(results.size() == 10);
+            make_remote_change();
+            advance_and_notify(*r);
+
+            r->begin_transaction();
+            r->read_group().get_table("class_object")->create_object();
+            REQUIRE(results.size() == 12);
+            r->cancel_transaction();
+        }
     }
 
     SECTION("unused background TVs do not pin old versions forever") {


### PR DESCRIPTION
When we import a TableView into an active write transaction we don't actually know if the TV is up to date, as we don't keep track of which tables have been modified so far in the transaction. This means that we just can't use the background TV if it isn't picked up before starting the write transaction, or it may have stale results if it's imported after a change that effects it.

Fixes https://github.com/realm/realm-cocoa/issues/6721.