### PR TITLE
Use global id to compose Realm path

### DIFF
--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -229,16 +229,16 @@ std::string SyncFileManager::get_base_sync_directory() const
     return sync_path;
 }
 
-std::string SyncFileManager::user_directory(const std::string& local_user_identity) const
+std::string SyncFileManager::user_directory(const std::string& user_identity) const
 {
-    std::string user_path = get_user_directory_path(local_user_identity);
+    std::string user_path = get_user_directory_path(user_identity);
     util::try_make_dir(user_path);
     return user_path;
 }
 
-void SyncFileManager::remove_user_directory(const std::string& local_user_identity) const
+void SyncFileManager::remove_user_directory(const std::string& user_identity) const
 {
-    std::string user_path = get_user_directory_path(local_user_identity);
+    std::string user_path = get_user_directory_path(user_identity);
     util::try_remove_dir_recursive(user_path);
 }
 
@@ -429,18 +429,19 @@ std::string SyncFileManager::legacy_realm_file_path(const std::string& local_use
 std::string SyncFileManager::legacy_local_identity_path(const std::string& local_user_identity, const std::string& realm_file_name) const
 {
     auto escaped_file_name = validate_and_clean_path(realm_file_name);
-    std::string path_name = util::file_path_by_appending_component(user_directory(local_user_identity), escaped_file_name);
+    std::string user_path = get_user_directory_path(local_user_identity);
+    std::string path_name = util::file_path_by_appending_component(user_path, escaped_file_name);
     std::string path = path_name + c_realm_file_suffix;
 
     return path;
 }
 
-std::string SyncFileManager::get_user_directory_path(const std::string& local_user_identity) const {
+std::string SyncFileManager::get_user_directory_path(const std::string& user_identity) const {
     auto user_path = file_path_by_appending_component(get_base_sync_directory(),
                                                       validate_and_clean_path(m_app_id),
                                                       util::FilePathType::Directory);
     util::try_make_dir(user_path); // TODO: add a recursive util:mkdirs() in Core
-    return file_path_by_appending_component(user_path, validate_and_clean_path(local_user_identity), util::FilePathType::Directory);
+    return file_path_by_appending_component(user_path, validate_and_clean_path(user_identity), util::FilePathType::Directory);
 }
 
 } // realm

--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -296,10 +296,10 @@ bool SyncFileManager::copy_realm_file(const std::string& old_path, const std::st
     return true;
 }
 
-bool SyncFileManager::remove_realm(const std::string& local_user_identity, const std::string& raw_realm_path) const
+bool SyncFileManager::remove_realm(const std::string& user_identity, const std::string& raw_realm_path) const
 {
     auto escaped = validate_and_clean_path(raw_realm_path);
-    auto realm_path = util::file_path_by_appending_component(user_directory(local_user_identity), escaped);
+    auto realm_path = util::file_path_by_appending_component(user_directory(user_identity), escaped);
     return remove_realm(realm_path);
 }
 
@@ -324,10 +324,10 @@ static bool try_file_remove(const std::string& path) noexcept
     }
 }
 
-std::string SyncFileManager::realm_file_path(const std::string& local_user_identity, const std::string& realm_file_name) const
+std::string SyncFileManager::realm_file_path(const std::string& user_identity, const std::string& local_user_identity, const std::string& realm_file_name) const
 {
     auto escaped_file_name = validate_and_clean_path(realm_file_name);
-    std::string preferred_name = util::file_path_by_appending_component(user_directory(local_user_identity), escaped_file_name);
+    std::string preferred_name = util::file_path_by_appending_component(user_directory(user_identity), escaped_file_name);
     std::string preferred_path = preferred_name + c_realm_file_suffix;
 
     if (!try_file_exists(preferred_path)) {
@@ -345,6 +345,12 @@ std::string SyncFileManager::realm_file_path(const std::string& local_user_ident
         std::string old_path = legacy_realm_file_path(local_user_identity, realm_file_name);
         if (try_file_exists(old_path)) {
             return old_path;
+        }
+
+        // retain support for legacy local identity paths
+        std::string old_local_identity_path = legacy_local_identity_path(local_user_identity, realm_file_name);
+        if (try_file_exists(old_local_identity_path)) {
+            return old_local_identity_path;
         }
 
         // since this appears to be a new file, test the normal location
@@ -417,6 +423,15 @@ std::string SyncFileManager::legacy_realm_file_path(const std::string& local_use
     auto path = util::file_path_by_appending_component(m_base_path, c_legacy_sync_directory, util::FilePathType::Directory);
     path = util::file_path_by_appending_component(path, validate_and_clean_path(local_user_identity), util::FilePathType::Directory);
     path = util::file_path_by_appending_component(path, validate_and_clean_path(realm_file_name));
+    return path;
+}
+
+std::string SyncFileManager::legacy_local_identity_path(const std::string& local_user_identity, const std::string& realm_file_name) const
+{
+    auto escaped_file_name = validate_and_clean_path(realm_file_name);
+    std::string path_name = util::file_path_by_appending_component(user_directory(local_user_identity), escaped_file_name);
+    std::string path = path_name + c_realm_file_suffix;
+
     return path;
 }
 

--- a/src/sync/impl/sync_file.hpp
+++ b/src/sync/impl/sync_file.hpp
@@ -83,10 +83,10 @@ public:
     static bool try_file_exists(const std::string& path) noexcept;
 
     /// Return the path for a given Realm, creating the user directory if it does not already exist.
-    std::string realm_file_path(const std::string& local_user_identity, const std::string& realm_file_name) const;
+    std::string realm_file_path(const std::string& user_identity, const std::string& local_user_identity, const std::string& realm_file_name) const;
 
     /// Remove the Realm at a given path for a given user. Returns `true` if the remove operation fully succeeds.
-    bool remove_realm(const std::string& local_user_identity, const std::string& realm_file_name) const;
+    bool remove_realm(const std::string& user_identity, const std::string& realm_file_name) const;
 
     /// Remove the Realm whose primary Realm file is located at `absolute_path`. Returns `true` if the remove
     /// operation fully succeeds.
@@ -136,6 +136,7 @@ private:
     // Construct the absolute path to the users directory
     std::string get_user_directory_path(const std::string& local_user_identity) const;
     std::string legacy_realm_file_path(const std::string& local_user_identity, const std::string& realm_file_name) const;
+    std::string legacy_local_identity_path(const std::string& local_user_identity, const std::string& realm_file_name) const;
     std::string fallback_hashed_realm_file_path(const std::string& preferred_path) const;
 };
 

--- a/src/sync/impl/sync_file.hpp
+++ b/src/sync/impl/sync_file.hpp
@@ -22,7 +22,6 @@
 #include <string>
 
 #include "sync/app.hpp"
-#include "sync/sync_user.hpp"
 
 #include <realm/util/optional.hpp>
 
@@ -134,7 +133,7 @@ private:
     std::string get_base_sync_directory() const;
 
     // Construct the absolute path to the users directory
-    std::string get_user_directory_path(const std::string& local_user_identity) const;
+    std::string get_user_directory_path(const std::string& user_identity) const;
     std::string legacy_realm_file_path(const std::string& local_user_identity, const std::string& realm_file_name) const;
     std::string legacy_local_identity_path(const std::string& local_user_identity, const std::string& realm_file_name) const;
     std::string fallback_hashed_realm_file_path(const std::string& preferred_path) const;

--- a/src/sync/impl/sync_file.hpp
+++ b/src/sync/impl/sync_file.hpp
@@ -68,10 +68,10 @@ public:
         }
 
     /// Return the user directory for a given user, creating it if it does not already exist.
-    std::string user_directory(const std::string& local_identity) const;
+    std::string user_directory(const std::string& identity) const;
 
     /// Remove the user directory for a given user.
-    void remove_user_directory(const std::string& local_identity) const;       // throws
+    void remove_user_directory(const std::string& identity) const;       // throws
 
     /// Rename a user directory. Returns true if a directory at `old_name` existed
     /// and was successfully renamed to `new_name`. Returns false if no directory

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -140,7 +140,7 @@ void SyncManager::init_metadata(SyncClientConfig config, const std::string& app_
             // FIXME: delete user data in a different way? (This deletes a logged-out user's data as soon as the app
             // launches again, which might not be how some apps want to treat their data.)
             try {
-                m_file_manager->remove_user_directory(user.local_uuid());
+                m_file_manager->remove_user_directory(user.identity());
                 dead_users.emplace_back(std::move(user));
             } catch (util::File::AccessError const&) {
                 continue;

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -506,7 +506,7 @@ std::string SyncManager::path_for_realm(const SyncUser& user, const std::string&
 {
     std::lock_guard<std::mutex> lock(m_file_system_mutex);
     REALM_ASSERT(m_file_manager);
-    return m_file_manager->realm_file_path(user.local_identity(), realm_file_name);
+    return m_file_manager->realm_file_path(user.identity(), user.local_identity(), realm_file_name);
 }
 
 std::string SyncManager::path_for_realm(const SyncConfig& config, util::Optional<std::string> custom_file_name) const
@@ -520,7 +520,7 @@ std::string SyncManager::path_for_realm(const SyncConfig& config, util::Optional
     std::array<unsigned char, 32> hash;
     util::sha256(config.partition_value.data(), config.partition_value.size(), hash.data());
     std::string legacy_hashed_file_name = util::hex_dump(hash.data(), hash.size(), "");
-    std::string legacy_file_path = m_file_manager->realm_file_path(config.user->local_identity(), legacy_hashed_file_name);
+    std::string legacy_file_path = m_file_manager->realm_file_path(config.user->identity(), config.user->local_identity(), legacy_hashed_file_name);
     if (m_file_manager->try_file_exists(legacy_hashed_file_name)) {
         return legacy_file_path;
     }
@@ -528,7 +528,7 @@ std::string SyncManager::path_for_realm(const SyncConfig& config, util::Optional
     // Attempt to make a nicer filename which will ease debugging when
     // locating files in the filesystem.
     std::string file_name = (custom_file_name) ? custom_file_name.value() : string_from_partition(config.partition_value);
-    return m_file_manager->realm_file_path(config.user->local_identity(), file_name);
+    return m_file_manager->realm_file_path(config.user->identity(), config.user->local_identity(), file_name);
 }
 
 std::string SyncManager::recovery_directory_path(util::Optional<std::string> const& custom_dir_name) const

--- a/tests/sync/file.cpp
+++ b/tests/sync/file.cpp
@@ -156,29 +156,29 @@ TEST_CASE("sync_file: SyncFileManager APIs", "[sync]") {
     auto manager = SyncFileManager(manager_path, app_id);
 
     SECTION("user directory APIs") {
-        const std::string expected = manager_path + "mongodb-realm/" + expected_clean_app_id + "/" + local_identity + "/";
+        const std::string expected = manager_path + "mongodb-realm/" + expected_clean_app_id + "/" + identity + "/";
         SECTION("getting a user directory") {
             SECTION("that didn't exist before succeeds") {
-                auto actual = manager.user_directory(local_identity);
+                auto actual = manager.user_directory(identity);
                 REQUIRE(actual == expected);
                 REQUIRE_DIR_EXISTS(expected);
             }
             SECTION("that already existed succeeds") {
-                auto actual = manager.user_directory(local_identity);
+                auto actual = manager.user_directory(identity);
                 REQUIRE(actual == expected);
                 REQUIRE_DIR_EXISTS(expected);
             }
         }
 
         SECTION("deleting a user directory") {
-            manager.user_directory(local_identity);
+            manager.user_directory(identity);
             REQUIRE_DIR_EXISTS(expected);
             SECTION("that wasn't yet deleted succeeds") {
-                manager.remove_user_directory(local_identity);
+                manager.remove_user_directory(identity);
                 REQUIRE_DIR_DOES_NOT_EXIST(expected);
             }
             SECTION("that was already deleted succeeds") {
-                manager.remove_user_directory(local_identity);
+                manager.remove_user_directory(identity);
                 REQUIRE(opendir(expected.c_str()) == NULL);
                 REQUIRE_DIR_DOES_NOT_EXIST(expected);
             }

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -78,6 +78,7 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync]") {
     const std::string identity = "foobarbaz";
     auto user = SyncManager::shared().get_user(identity, ENCODE_FAKE_JWT("dummy_token"), ENCODE_FAKE_JWT("not_a_real_token"), auth_server_url, dummy_device_id);
     auto local_identity = user->local_identity();
+    auto server_identity = user->identity();
     REQUIRE(local_identity == identity);
 
     SECTION("should work properly without metadata") {
@@ -371,16 +372,21 @@ TEST_CASE("sync_manager: file actions", "[sync]") {
     SyncMetadataManager manager(file_manager.metadata_path(), false);
 
     const std::string realm_url = "https://example.realm.com/~/1";
+    const std::string uuid_1 = "uuid-foo-1";
+    const std::string uuid_2 = "uuid-bar-1";
+    const std::string uuid_3 = "uuid-baz-1";
+    const std::string uuid_4 = "uuid-baz-2";
+
     const std::string local_uuid_1 = "foo-1";
     const std::string local_uuid_2 = "bar-1";
     const std::string local_uuid_3 = "baz-1";
     const std::string local_uuid_4 = "baz-2";
 
     // Realm paths
-    const std::string realm_path_1 = file_manager.realm_file_path(local_uuid_1, realm_url);
-    const std::string realm_path_2 = file_manager.realm_file_path(local_uuid_2, realm_url);
-    const std::string realm_path_3 = file_manager.realm_file_path(local_uuid_3, realm_url);
-    const std::string realm_path_4 = file_manager.realm_file_path(local_uuid_4, realm_url);
+    const std::string realm_path_1 = file_manager.realm_file_path(uuid_1, local_uuid_1, realm_url);
+    const std::string realm_path_2 = file_manager.realm_file_path(uuid_2, local_uuid_2, realm_url);
+    const std::string realm_path_3 = file_manager.realm_file_path(uuid_3, local_uuid_3, realm_url);
+    const std::string realm_path_4 = file_manager.realm_file_path(uuid_4, local_uuid_4, realm_url);
 
     SECTION("Action::DeleteRealm") {
         // Create some file actions

--- a/tests/sync/sync_manager.cpp
+++ b/tests/sync/sync_manager.cpp
@@ -77,9 +77,8 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync]") {
     // Get a sync user
     const std::string identity = "foobarbaz";
     auto user = SyncManager::shared().get_user(identity, ENCODE_FAKE_JWT("dummy_token"), ENCODE_FAKE_JWT("not_a_real_token"), auth_server_url, dummy_device_id);
-    auto local_identity = user->local_identity();
     auto server_identity = user->identity();
-    REQUIRE(local_identity == identity);
+    REQUIRE(server_identity == identity);
 
     SECTION("should work properly without metadata") {
         TestSyncManager init_sync_manager("", base_path, SyncManager::MetadataMode::NoMetadata);
@@ -91,10 +90,10 @@ TEST_CASE("sync_manager: `path_for_realm` API", "[sync]") {
 
     SECTION("should work properly with metadata") {
         TestSyncManager init_sync_manager("", base_path, SyncManager::MetadataMode::NoEncryption);
-        const auto expected = base_path + "mongodb-realm/app_id/" + local_identity + "/realms%3A%2F%2Frealm.example.org%2Fa%2Fb%2F%7E%2F123456%2Fxyz.realm";
+        const auto expected = base_path + "mongodb-realm/app_id/" + server_identity + "/realms%3A%2F%2Frealm.example.org%2Fa%2Fb%2F%7E%2F123456%2Fxyz.realm";
         REQUIRE(SyncManager::shared().path_for_realm(*user, raw_url) == expected);
         // This API should also generate the directory if it doesn't already exist.
-        REQUIRE_DIR_EXISTS(base_path + "mongodb-realm/app_id/" + local_identity + "/");
+        REQUIRE_DIR_EXISTS(base_path + "mongodb-realm/app_id/" + server_identity + "/");
     }
 
     SECTION("should produce the expected path for a string partition") {
@@ -175,7 +174,7 @@ TEST_CASE("sync_manager: user state management", "[sync]") {
     const std::string r_token_2 = ENCODE_FAKE_JWT("bar_token");
     const std::string r_token_3 = ENCODE_FAKE_JWT("baz_token");
 
-    const std::string a_token_1 = ENCODE_FAKE_JWT("wibble");
+    const std::string a_token_1 = ENCODE_FAKE_JWT("wibble");    
     const std::string a_token_2 = ENCODE_FAKE_JWT("wobble");
     const std::string a_token_3 = ENCODE_FAKE_JWT("wubble");
 
@@ -333,9 +332,9 @@ TEST_CASE("sync_manager: persistent user state management", "[sync]") {
         u3->set_refresh_token(r_token_3);
         u3->set_device_id(dummy_device_id);
         // Pre-populate the user directories.
-        const auto user_dir_1 = file_manager.user_directory(u1->local_uuid());
-        const auto user_dir_2 = file_manager.user_directory(u2->local_uuid());
-        const auto user_dir_3 = file_manager.user_directory(u3->local_uuid());
+        const auto user_dir_1 = file_manager.user_directory(u1->identity());
+        const auto user_dir_2 = file_manager.user_directory(u2->identity());
+        const auto user_dir_3 = file_manager.user_directory(u3->identity());
         create_dummy_realm(user_dir_1 + "123456789");
         create_dummy_realm(user_dir_1 + "foo");
         create_dummy_realm(user_dir_2 + "123456789");


### PR DESCRIPTION
This PR refactor ObjectStore, so it only uses `local_uuid` for legacy Realms. For future Realms, it uses the global server UUID in the path.
