### PR TITLE
Don't cache realms without a scheduler

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -218,8 +218,12 @@ std::shared_ptr<Realm> RealmCoordinator::do_get_cached_realm(Realm::Config const
     if (!scheduler) {
         scheduler = config.scheduler;
     }
+
+    if (!scheduler)
+        return nullptr;
+
     for (auto& cached_realm : m_weak_realm_notifiers) {
-        if (!scheduler || !cached_realm.is_cached_for_scheduler(scheduler))
+        if (!cached_realm.is_cached_for_scheduler(scheduler))
             continue;
         // can be null if we jumped in between ref count hitting zero and
         // unregister_realm() getting the lock

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -219,7 +219,7 @@ std::shared_ptr<Realm> RealmCoordinator::do_get_cached_realm(Realm::Config const
         scheduler = config.scheduler;
     }
     for (auto& cached_realm : m_weak_realm_notifiers) {
-        if (scheduler && !cached_realm.is_cached_for_scheduler(scheduler))
+        if (!scheduler || !cached_realm.is_cached_for_scheduler(scheduler))
             continue;
         // can be null if we jumped in between ref count hitting zero and
         // unregister_realm() getting the lock


### PR DESCRIPTION
While debugging some caching issues, I noticed that we always return a cached Realm when there's no scheduler, which is probably not what we want to do.