### PR TITLE
Add the version to the frozen scheduler

### DIFF
--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -256,6 +256,9 @@ std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config, util::O
     util::CheckedUniqueLock lock(m_realm_mutex);
     set_config(config);
     if ((realm = do_get_cached_realm(config))) {
+        if (version) {
+            REALM_ASSERT(realm->read_transaction_version() == version.value());
+        }
         return realm;
     }
     do_get_realm(std::move(config), realm, version, lock);

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -248,7 +248,7 @@ std::shared_ptr<Realm> RealmCoordinator::do_get_cached_realm(Realm::Config const
 std::shared_ptr<Realm> RealmCoordinator::get_realm(Realm::Config config, util::Optional<VersionID> version)
 {
     if (!config.scheduler)
-        config.scheduler = version ? util::Scheduler::get_frozen() : util::Scheduler::make_default();
+        config.scheduler = version ? util::Scheduler::get_frozen(version.value()) : util::Scheduler::make_default();
     // realm must be declared before lock so that the mutex is released before
     // we release the strong reference to realm, as Realm's destructor may want
     // to acquire the same lock

--- a/src/shared_realm.cpp
+++ b/src/shared_realm.cpp
@@ -904,8 +904,9 @@ bool Realm::is_frozen() const
 SharedRealm Realm::freeze()
 {
     auto config = m_config;
-    config.scheduler = util::Scheduler::get_frozen();
-    return Realm::get_frozen_realm(std::move(config), read_transaction_version());
+    auto version = read_transaction_version();
+    config.scheduler = util::Scheduler::get_frozen(version);
+    return Realm::get_frozen_realm(std::move(config), version);
 }
 
 void Realm::close()

--- a/src/util/scheduler.cpp
+++ b/src/util/scheduler.cpp
@@ -17,6 +17,7 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #include "util/scheduler.hpp"
+#include <realm/version_id.hpp>
 
 #if REALM_USE_UV
 #include "util/uv/scheduler.hpp"
@@ -33,22 +34,33 @@ using namespace realm;
 
 class FrozenScheduler : public util::Scheduler {
 public:
+    FrozenScheduler(VersionID version)
+    : m_version(version)
+    { }
+
     void notify() override {}
     void set_notify_callback(std::function<void()>) override {}
     bool is_on_thread() const noexcept override { return true; }
-    bool is_same_as(const Scheduler* other) const noexcept override { return dynamic_cast<const FrozenScheduler*>(other); }
+    bool is_same_as(const Scheduler* other) const noexcept override 
+    { 
+        auto o = dynamic_cast<const FrozenScheduler*>(other);
+        return (o && (o->m_version == m_version));
+    }
     bool can_deliver_notifications() const noexcept override { return false; }
+
+private:
+    VersionID m_version;
 };
 } // anonymous namespace
 
 namespace realm {
 namespace util {
+
 Scheduler::~Scheduler() = default;
 
-std::shared_ptr<Scheduler> Scheduler::get_frozen()
+std::shared_ptr<Scheduler> Scheduler::get_frozen(VersionID version)
 {
-    static auto s_shared = std::make_shared<FrozenScheduler>();
-    return s_shared;
+    return std::make_shared<FrozenScheduler>(version);
 }
 } // namespace util
 } // namespace realm

--- a/src/util/scheduler.cpp
+++ b/src/util/scheduler.cpp
@@ -41,8 +41,8 @@ public:
     void notify() override {}
     void set_notify_callback(std::function<void()>) override {}
     bool is_on_thread() const noexcept override { return true; }
-    bool is_same_as(const Scheduler* other) const noexcept override 
-    { 
+    bool is_same_as(const Scheduler* other) const noexcept override
+    {
         auto o = dynamic_cast<const FrozenScheduler*>(other);
         return (o && (o->m_version == m_version));
     }

--- a/src/util/scheduler.hpp
+++ b/src/util/scheduler.hpp
@@ -20,6 +20,7 @@
 #define REALM_OS_UTIL_SCHEDULER
 
 #include <realm/util/features.h>
+#include <realm/version_id.hpp>
 
 #include <functional>
 #include <memory>
@@ -77,7 +78,7 @@ public:
 
     // Get the scheduler for frozen Realms. This scheduler does not support
     // notifications and does not perform any thread checking.
-    static std::shared_ptr<Scheduler> get_frozen();
+    static std::shared_ptr<Scheduler> get_frozen(VersionID version);
 
     // Create a new instance of the default scheduler for the current platform.
     // This normally will be a thread-confined scheduler using the current

--- a/src/util/scheduler.hpp
+++ b/src/util/scheduler.hpp
@@ -78,7 +78,7 @@ public:
 
     // Get the scheduler for frozen Realms. This scheduler does not support
     // notifications and does not perform any thread checking.
-    static std::shared_ptr<Scheduler> get_frozen(VersionID version);
+    static std::shared_ptr<Scheduler> get_frozen(VersionID version = VersionID());
 
     // Create a new instance of the default scheduler for the current platform.
     // This normally will be a thread-confined scheduler using the current

--- a/src/util/scheduler.hpp
+++ b/src/util/scheduler.hpp
@@ -78,7 +78,7 @@ public:
 
     // Get the scheduler for frozen Realms. This scheduler does not support
     // notifications and does not perform any thread checking.
-    static std::shared_ptr<Scheduler> get_frozen(VersionID version = VersionID());
+    static std::shared_ptr<Scheduler> get_frozen(VersionID version);
 
     // Create a new instance of the default scheduler for the current platform.
     // This normally will be a thread-confined scheduler using the current

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -474,6 +474,26 @@ protected:
         Realm::get_shared_realm(config);
         REQUIRE(object_schema == &*realm->schema().find("object"));
     }
+
+    SECTION("should not use cached frozen Realm if versions don't match") {
+        auto realm = Realm::get_shared_realm(config);
+        realm->read_group();
+        auto frozen1 = realm->freeze();
+        frozen1->read_group();
+        REQUIRE(realm->read_transaction_version() == frozen1->read_transaction_version());
+
+        auto table = realm->read_group().get_table("class_object");
+        realm->begin_transaction();
+        Obj obj = table->create_object();
+        realm->commit_transaction();
+
+        REQUIRE(realm->read_transaction_version() > frozen1->read_transaction_version());
+
+        auto frozen2 = realm->freeze();
+        frozen2->read_group();
+        REQUIRE(realm->read_transaction_version() == frozen2->read_transaction_version());
+        REQUIRE(frozen2->read_transaction_version() > frozen1->read_transaction_version());
+    }
 }
 
 #if REALM_ENABLE_SYNC
@@ -1142,7 +1162,7 @@ TEST_CASE("SharedRealm: coordinator schema cache") {
         ExternalWriter(Realm::Config const& config)
         : m_realm([&] {
             auto c = config;
-            c.scheduler = util::Scheduler::get_frozen();
+            c.scheduler = util::Scheduler::get_frozen(VersionID());
             return _impl::RealmCoordinator::get_coordinator(c.path)->get_realm(c, util::none);
         }())
         , wt(TestHelper::get_db(m_realm))
@@ -1526,7 +1546,7 @@ TEST_CASE("SharedRealm: compact on launch") {
     }
 
     SECTION("compact function does not get invoked if realm is open on another thread") {
-        config.scheduler = util::Scheduler::get_frozen();
+        config.scheduler = util::Scheduler::get_frozen(VersionID());
         r = Realm::get_shared_realm(config);
         REQUIRE(num_opens == 2);
         std::thread([&]{
@@ -1663,7 +1683,7 @@ TEST_CASE("BindingContext is notified about delivery of change notifications") {
             binding_context_start_notify_calls = 0;
             binding_context_end_notify_calls = 0;
             JoiningThread([&] {
-                auto r2 = coordinator->get_realm(util::Scheduler::get_frozen());
+                auto r2 = coordinator->get_realm(util::Scheduler::get_frozen(VersionID()));
                 r2->begin_transaction();
                 auto table2 = r2->read_group().get_table("class_object");
                 table2->create_object();
@@ -1728,7 +1748,7 @@ TEST_CASE("BindingContext is notified about delivery of change notifications") {
             binding_context_end_notify_calls = 0;
             notification_calls = 0;
             JoiningThread([&] {
-                auto r2 = coordinator->get_realm(util::Scheduler::get_frozen());
+                auto r2 = coordinator->get_realm(util::Scheduler::get_frozen(VersionID()));
                 r2->begin_transaction();
                 auto table2 = r2->read_group().get_table("class_object");
                 table2->create_object();
@@ -1777,7 +1797,7 @@ TEST_CASE("BindingContext is notified about delivery of change notifications") {
             do_close = true;
 
             JoiningThread([&] {
-                auto r = coordinator->get_realm(util::Scheduler::get_frozen());
+                auto r = coordinator->get_realm(util::Scheduler::get_frozen(VersionID()));
                 r->begin_transaction();
                 r->read_group().get_table("class_object")->create_object();
                 r->commit_transaction();
@@ -1801,7 +1821,7 @@ TEST_CASE("BindingContext is notified about delivery of change notifications") {
             do_close = true;
 
             JoiningThread([&] {
-                auto r = coordinator->get_realm(util::Scheduler::get_frozen());
+                auto r = coordinator->get_realm(util::Scheduler::get_frozen(VersionID()));
                 r->begin_transaction();
                 r->read_group().get_table("class_object")->create_object();
                 r->commit_transaction();

--- a/tests/realm.cpp
+++ b/tests/realm.cpp
@@ -480,6 +480,8 @@ protected:
         realm->read_group();
         auto frozen1 = realm->freeze();
         frozen1->read_group();
+
+        REQUIRE(frozen1 != realm);
         REQUIRE(realm->read_transaction_version() == frozen1->read_transaction_version());
 
         auto table = realm->read_group().get_table("class_object");
@@ -491,6 +493,9 @@ protected:
 
         auto frozen2 = realm->freeze();
         frozen2->read_group();
+
+        REQUIRE(frozen2 != frozen1);
+        REQUIRE(frozen2 != realm);
         REQUIRE(realm->read_transaction_version() == frozen2->read_transaction_version());
         REQUIRE(frozen2->read_transaction_version() > frozen1->read_transaction_version());
     }

--- a/tests/results.cpp
+++ b/tests/results.cpp
@@ -112,7 +112,7 @@ TEST_CASE("notifications: async delivery") {
     };
 
     auto make_remote_change = [&] {
-        auto r2 = coordinator->get_realm(util::Scheduler::get_frozen());
+        auto r2 = coordinator->get_realm(util::Scheduler::get_frozen(VersionID()));
         r2->begin_transaction();
         r2->read_group().get_table("class_object")->begin()->set(col, 5);
         r2->commit_transaction();
@@ -785,7 +785,7 @@ TEST_CASE("notifications: skip") {
     };
 
     auto make_remote_change = [&] {
-        auto r2 = coordinator->get_realm(util::Scheduler::get_frozen());
+        auto r2 = coordinator->get_realm(util::Scheduler::get_frozen(VersionID()));
         r2->begin_transaction();
         r2->read_group().get_table("class_object")->create_object();
         r2->commit_transaction();
@@ -1021,7 +1021,7 @@ TEST_CASE("notifications: TableView delivery") {
     };
 
     auto make_remote_change = [&] {
-        auto r2 = coordinator->get_realm(util::Scheduler::get_frozen());
+        auto r2 = coordinator->get_realm(util::Scheduler::get_frozen(VersionID()));
         r2->begin_transaction();
         r2->read_group().get_table("class_object")->create_object();
         r2->commit_transaction();
@@ -2061,7 +2061,7 @@ TEST_CASE("results: notifier with no callbacks") {
         // create a notifier
         results.add_notification_callback([](CollectionChangeSet const&, std::exception_ptr) {});
 
-        auto r2 = coordinator->get_realm(util::Scheduler::get_frozen());
+        auto r2 = coordinator->get_realm(util::Scheduler::get_frozen(VersionID()));
         r2->begin_transaction();
         r2->read_group().get_table("class_object")->create_object();
         r2->commit_transaction();
@@ -3166,7 +3166,7 @@ TEST_CASE("results: set property value on all objects", "[batch_updates]") {
 
         r.set_property_value(ctx, "string array", util::Any(AnyVec{"a"s, "b"s, "c"s}));
         check_array(table->get_column_key("string array"), StringData("a"), StringData("b"), StringData("c"));
- 
+
         r.set_property_value(ctx, "data array", util::Any(AnyVec{"d"s, "e"s, "f"s}));
         check_array(table->get_column_key("data array"), BinaryData("d",1), BinaryData("e",1), BinaryData("f",1));
 

--- a/tests/thread_safe_reference.cpp
+++ b/tests/thread_safe_reference.cpp
@@ -489,7 +489,7 @@ TEST_CASE("thread safe reference") {
             REQUIRE(results.get<int64_t>(2) == 2);
             auto ref = ThreadSafeReference(results);
             std::thread([ref = std::move(ref), config]() mutable {
-                config.scheduler = util::Scheduler::get_frozen();
+                config.scheduler = util::Scheduler::get_frozen(VersionID());
                 SharedRealm r = Realm::get_shared_realm(config);
                 Results results = ref.resolve<Results>(r);
 
@@ -541,7 +541,7 @@ TEST_CASE("thread safe reference") {
 
             auto ref = ThreadSafeReference(results);
             std::thread([ref = std::move(ref), config]() mutable {
-                config.scheduler = util::Scheduler::get_frozen();
+                config.scheduler = util::Scheduler::get_frozen(VersionID());
                 SharedRealm r = Realm::get_shared_realm(config);
                 Results results = ref.resolve<Results>(r);
 


### PR DESCRIPTION
Without this change, we would always use the first cached frozen Realm, regardless of whether it's frozen at the required version or not.

Alternatively, we could pass the version in `do_get_cached_realm`, but felt that using the scheduler was a cleaner solution.