### PR TITLE
add a check to detect if an Object is created with an Obj, but without a valid Transaction.

### DIFF
--- a/src/object.cpp
+++ b/src/object.cpp
@@ -73,6 +73,7 @@ Object::Object(SharedRealm r, Obj const& o)
 , m_object_schema(&*m_realm->schema().find(ObjectStore::object_type_for_table_name(o.get_table()->get_name())))
 , m_obj(o)
 {
+  REALM_ASSERT(!m_obj.get_table() || (m_realm->get_group() == _impl::TableFriend::get_parent_group(*m_obj.get_table())));
 }
 
 Object::Object(SharedRealm r, StringData object_type, ObjKey key)

--- a/src/object.cpp
+++ b/src/object.cpp
@@ -73,7 +73,7 @@ Object::Object(SharedRealm r, Obj const& o)
 , m_object_schema(&*m_realm->schema().find(ObjectStore::object_type_for_table_name(o.get_table()->get_name())))
 , m_obj(o)
 {
-  REALM_ASSERT(!m_obj.get_table() || (m_realm->get_group() == _impl::TableFriend::get_parent_group(*m_obj.get_table())));
+    REALM_ASSERT(!m_obj.get_table() || (&m_realm->read_group() == _impl::TableFriend::get_parent_group(*m_obj.get_table())));
 }
 
 Object::Object(SharedRealm r, StringData object_type, ObjKey key)
@@ -81,6 +81,7 @@ Object::Object(SharedRealm r, StringData object_type, ObjKey key)
 , m_object_schema(&*m_realm->schema().find(object_type))
 , m_obj(ObjectStore::table_for_object_type(m_realm->read_group(), object_type)->get_object(key))
 {
+    REALM_ASSERT(!m_obj.get_table() || (&m_realm->read_group() == _impl::TableFriend::get_parent_group(*m_obj.get_table())));
 }
 
 Object::Object(SharedRealm r, StringData object_type, size_t index)
@@ -88,6 +89,7 @@ Object::Object(SharedRealm r, StringData object_type, size_t index)
 , m_object_schema(&*m_realm->schema().find(object_type))
 , m_obj(ObjectStore::table_for_object_type(m_realm->read_group(), object_type)->get_object(index))
 {
+    REALM_ASSERT(!m_obj.get_table() || (&m_realm->read_group() == _impl::TableFriend::get_parent_group(*m_obj.get_table())));
 }
 
 Object::Object() = default;

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -325,7 +325,7 @@ public:
 
     VersionID read_transaction_version() const;
     Group& read_group();
-
+    Group* get_group() const { return m_group.get(); }
     // Get the version of the current read or frozen transaction, or `none` if the Realm
     // is not in a read transaction
     util::Optional<VersionID> current_transaction_version() const;

--- a/src/shared_realm.hpp
+++ b/src/shared_realm.hpp
@@ -325,7 +325,6 @@ public:
 
     VersionID read_transaction_version() const;
     Group& read_group();
-    Group* get_group() const { return m_group.get(); }
     // Get the version of the current read or frozen transaction, or `none` if the Realm
     // is not in a read transaction
     util::Optional<VersionID> current_transaction_version() const;


### PR DESCRIPTION
This is an attempt to flush out some NoSuchTable exceptions which we do not understand.

It is based on the assumption that one way of getting a NoSuchTable exception, is when accessing an object after the associated Transaction object in Core has been released. The assert checks for any faulty association between the object accessor and the Realm object (representing/holding the transaction).
