### PR TITLE
Expose credentials::function with string argument

### DIFF
--- a/src/sync/app_credentials.cpp
+++ b/src/sync/app_credentials.cpp
@@ -161,6 +161,15 @@ AppCredentials AppCredentials::function(const bson::BsonDocument& payload)
                           });
 }
 
+AppCredentials AppCredentials::function(const std::string serialized_document)
+{
+    return AppCredentials(AuthProvider::FUNCTION, 
+        [=] { 
+            return serialized_document; 
+        });
+}
+
+
 AppCredentials AppCredentials::user_api_key(std::string api_key)
 {
     return AppCredentials(AuthProvider::USER_API_KEY,

--- a/src/sync/app_credentials.cpp
+++ b/src/sync/app_credentials.cpp
@@ -161,11 +161,11 @@ AppCredentials AppCredentials::function(const bson::BsonDocument& payload)
                           });
 }
 
-AppCredentials AppCredentials::function(const std::string serialized_document)
+AppCredentials AppCredentials::function(const std::string& serialized_payload)
 {
-    return AppCredentials(AuthProvider::FUNCTION, 
-        [=] { 
-            return serialized_document; 
+    return AppCredentials(AuthProvider::FUNCTION,
+        [=] {
+            return serialized_payload;
         });
 }
 

--- a/src/sync/app_credentials.hpp
+++ b/src/sync/app_credentials.hpp
@@ -102,6 +102,10 @@ struct AppCredentials {
     // The payload is a MongoDB document as json
     static AppCredentials function(const bson::BsonDocument& payload);
 
+    // Construct and return credentials with the payload.
+    // The payload is a MongoDB document as json
+    static AppCredentials function(const std::string serialized_document);
+
     // Construct and return credentials with the user api key.
     static AppCredentials user_api_key(std::string api_key);
 

--- a/src/sync/app_credentials.hpp
+++ b/src/sync/app_credentials.hpp
@@ -104,7 +104,7 @@ struct AppCredentials {
 
     // Construct and return credentials with the payload.
     // The payload is a MongoDB document as json
-    static AppCredentials function(const std::string serialized_document);
+    static AppCredentials function(const std::string& serialized_payload);
 
     // Construct and return credentials with the user api key.
     static AppCredentials user_api_key(std::string api_key);


### PR DESCRIPTION
.NET doesn't have a way to pass a bson document down to native without essentially serializing it to json in managed code, then parsing it in the native wrappers, only to have OS serialize it back to json. This introduces an overload that eliminates the extra deserialization and serialization step.

Based on #1094, but will rebase on v10 once that goes in.