### PR TITLE
Update API calls to use the new Realm endpoints as per Stitch rebranding

### DIFF
--- a/src/sync/app.cpp
+++ b/src/sync/app.cpp
@@ -80,7 +80,7 @@ static std::map<std::string, std::string> get_request_headers(std::shared_ptr<Sy
     return headers;
 }
 
-const static std::string default_base_url = "https://stitch.mongodb.com";
+const static std::string default_base_url = "https://realm.mongodb.com";
 const static std::string base_path = "/api/client/v2.0";
 const static std::string app_path = "/app";
 const static std::string auth_path = "/auth";

--- a/src/sync/app.cpp
+++ b/src/sync/app.cpp
@@ -1127,9 +1127,9 @@ Request App::make_streaming_request(std::shared_ptr<SyncUser> user,
     auto args_base64 = std::string(util::base64_encoded_size(args_json.size()), '\0');
     util::base64_encode(args_json.data(), args_json.size(), args_base64.data(), args_base64.size());
 
-    auto url = function_call_url_path() + "?stitch_request=" + util::uri_percent_encode(args_base64);
+    auto url = function_call_url_path() + "?baas_request=" + util::uri_percent_encode(args_base64);
     if (user) {
-        url += "&stitch_at=";
+        url += "&baas_at=";
         url += user->access_token(); // doesn't need url encoding
     }
 

--- a/tests/sync/app.cpp
+++ b/tests/sync/app.cpp
@@ -3459,7 +3459,7 @@ TEST_CASE("app: make_streaming_request", "[sync][app]") {
 
     using Headers = decltype(Request().headers);
 
-    const auto url_prefix = "field/api/client/v2.0/app/django/functions/call?stitch_request="sv;
+    const auto url_prefix = "field/api/client/v2.0/app/django/functions/call?baas_request="sv;
     const auto get_request_args = [&] (const Request& req) {
         REQUIRE(req.url.substr(0, url_prefix.size()) == url_prefix);
         auto args = req.url.substr(url_prefix.size());
@@ -3535,6 +3535,6 @@ TEST_CASE("app: make_streaming_request", "[sync][app]") {
         auto amp = req.url.find('&');
         REQUIRE(amp != std::string::npos);
         auto tail = req.url.substr(amp);
-        REQUIRE(tail == ("&stitch_at=" + user->access_token()));
+        REQUIRE(tail == ("&baas_at=" + user->access_token()));
     }
 }


### PR DESCRIPTION
Updated parameters as per the Stitch rebrand to Realm Deprecation/EOL Notes:
- `stitch_request` to `baas_request`
- `stitch_at ` to `baas_at`