### PR TITLE
Refactor remote_mongo_collection to expose raw bson callbacks

### DIFF
--- a/src/sync/remote_mongo_collection.hpp
+++ b/src/sync/remote_mongo_collection.hpp
@@ -299,6 +299,60 @@ public:
     void find_one_and_delete(const bson::BsonDocument& filter_bson,
                              std::function<void(util::Optional<bson::BsonDocument>, util::Optional<AppError>)> completion_block);
 
+    // The following methods are equivalent to the ones without _bson suffix with the exception
+    // that they return the raw bson response from the function instead of attempting to parse it.
+
+    void find_bson(const bson::BsonDocument& filter_bson,
+        RemoteFindOptions options,
+        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block);
+
+    void find_one_bson(const bson::BsonDocument& filter_bson,
+        RemoteFindOptions options,
+        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block);
+
+    void aggregate_bson(const bson::BsonArray& pipeline,
+        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block);
+
+    void count_bson(const bson::BsonDocument& filter_bson,
+        int64_t limit,
+        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block);
+
+    void insert_one_bson(const bson::BsonDocument& value_bson,
+        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block);
+
+    void insert_many_bson(bson::BsonArray documents,
+        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block);
+
+    void delete_one_bson(const bson::BsonDocument& filter_bson,
+        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block);
+
+    void delete_many_bson(const bson::BsonDocument& filter_bson,
+        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block);
+
+    void update_one_bson(const bson::BsonDocument& filter_bson,
+        const bson::BsonDocument& update_bson,
+        bool upsert,
+        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block);
+
+    void update_many_bson(const bson::BsonDocument& filter_bson,
+        const bson::BsonDocument& update_bson,
+        bool upsert,
+        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block);
+
+    void find_one_and_update_bson(const bson::BsonDocument& filter_bson,
+        const bson::BsonDocument& update_bson,
+        RemoteFindOneAndModifyOptions options,
+        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block);
+
+    void find_one_and_replace_bson(const bson::BsonDocument& filter_bson,
+        const bson::BsonDocument& replacement_bson,
+        RemoteFindOneAndModifyOptions options,
+        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block);
+
+    void find_one_and_delete_bson(const bson::BsonDocument& filter_bson,
+        RemoteFindOneAndModifyOptions options,
+        std::function<void(util::Optional<AppError>, util::Optional<bson::Bson>)> completion_block);
+
     /*
      * SDKs should also support a watch method with the following 3 overloads:
      *      watch()


### PR DESCRIPTION
This PR exposes `RemoteMongoCollection` API that return the raw bson rather than attempt to parse it into a concrete C++ type. This has the following benefits (mainly for .NET):

1. In .NET we don't have a way to interop with the c++ API, which means that we need to wrap every return type in its own struct with a native and managed counterpart. By returning the raw bson, we are just going to transmit the string which dramatically reduces the complexity of the feature.
2. For a lot of the return types, we're going to have to serialize them anyway since they're unstructured or of unknown type (e.g. the inserted id).
3. The post processing OS does on the raw response is quite minimal and can easily be replicated in .NET.

The PR may seem fairly massive, but in reality all of it is moving code from the `collection::XXX` methods to `collection::XXX_bson` methods and no new functionality has been introduced.

Additionally, I changed the `handle_xxx_response` methods to return a func as that cleaned up the API quite nicely, but don't have strong feelings about this change.