### PR TITLE
ROBJSTORE-125 Move MongoClient under SyncUser

### DIFF
--- a/src/sync/app.cpp
+++ b/src/sync/app.cpp
@@ -21,13 +21,13 @@
 #include "realm/util/base64.hpp"
 #include "realm/util/uri.hpp"
 #include "sync/app_credentials.hpp"
+#include "sync/app_utils.hpp"
 #include "sync/generic_network_transport.hpp"
-#include "sync/sync_manager.hpp"
 #include "sync/impl/sync_client.hpp"
 #include "sync/impl/sync_file.hpp"
-#include "sync/remote_mongo_client.hpp"
-#include "sync/app_utils.hpp"
 #include "sync/impl/sync_metadata.hpp"
+#include "sync/sync_manager.hpp"
+#include "sync/sync_user.hpp"
 
 #include <json.hpp>
 #include <string>
@@ -1139,11 +1139,6 @@ Request App::make_streaming_request(std::shared_ptr<SyncUser> user,
         m_request_timeout_ms,
         {{"Accept", "text/event-stream"}},
     };
-}
-
-RemoteMongoClient App::remote_mongo_client(const std::string& service_name)
-{
-    return RemoteMongoClient(shared_from_this(), service_name);
 }
 
 PushClient App::push_notification_client(const std::string& service_name)

--- a/src/sync/app.hpp
+++ b/src/sync/app.hpp
@@ -39,15 +39,11 @@ namespace app {
 
 class App;
 
-class RemoteMongoClient;
 typedef std::shared_ptr<App> SharedApp;
 
 /// The `App` has the fundamental set of methods for communicating with a MongoDB Realm application backend.
 ///
 /// This class provides access to login and authentication.
-///
-/// Using `remote_mongo_client`, you can retrieve `RemoteMongoClient` for reading
-/// and writing on the database.
 ///
 /// You can also use it to execute [Functions](https://docs.mongodb.com/stitch/functions/).
 class App : public std::enable_shared_from_this<App>, public AuthRequestClient, public AppServiceClient {
@@ -290,10 +286,6 @@ public:
     T provider_client() {
         return T(this);
     }
-
-    /// Retrieves a general-purpose service client for the Realm Cloud service
-    /// @param service_name The name of the cluster
-    RemoteMongoClient remote_mongo_client(const std::string& service_name);
 
     void call_function(std::shared_ptr<SyncUser> user,
                        const std::string& name,

--- a/src/sync/remote_mongo_client.cpp
+++ b/src/sync/remote_mongo_client.cpp
@@ -22,14 +22,14 @@
 namespace realm {
 namespace app {
 
-RemoteMongoDatabase RemoteMongoClient::operator[](const std::string& name)
+MongoDatabase MongoClient::operator[](const std::string& name)
 {
-    return RemoteMongoDatabase(name, m_service, m_service_name);
+    return MongoDatabase(name, m_user, m_service, m_service_name);
 }
 
-RemoteMongoDatabase RemoteMongoClient::db(const std::string& name)
+MongoDatabase MongoClient::db(const std::string& name)
 {
-    return RemoteMongoDatabase(name, m_service, m_service_name);
+    return MongoDatabase(name, m_user, m_service, m_service_name);
 }
 
 } // namespace app

--- a/src/sync/remote_mongo_client.hpp
+++ b/src/sync/remote_mongo_client.hpp
@@ -21,37 +21,42 @@
 
 #include "sync/app_service_client.hpp"
 #include <string>
-#include <map>
 
 namespace realm {
+class SyncUser;
+
 namespace app {
 
-class RemoteMongoDatabase;
+class MongoDatabase;
 
 /// A client responsible for communication with the Stitch API
-class RemoteMongoClient {
+class MongoClient {
 public:
-    ~RemoteMongoClient() = default;
-    RemoteMongoClient(const RemoteMongoClient&) = default;
-    RemoteMongoClient(RemoteMongoClient&&) = default;
-    RemoteMongoClient& operator=(const RemoteMongoClient&) = default;
-    RemoteMongoClient& operator=(RemoteMongoClient&&) = default;
+    ~MongoClient() = default;
+    MongoClient(const MongoClient&) = default;
+    MongoClient(MongoClient&&) = default;
+    MongoClient& operator=(const MongoClient&) = default;
+    MongoClient& operator=(MongoClient&&) = default;
 
     /// Gets a `RemoteMongoDatabase` instance for the given database name.
     /// @param name the name of the database to retrieve
-    RemoteMongoDatabase operator[](const std::string& name);
+    MongoDatabase operator[](const std::string& name);
 
     /// Gets a `RemoteMongoDatabase` instance for the given database name.
     /// @param name the name of the database to retrieve
-    RemoteMongoDatabase db(const std::string& name);
+    MongoDatabase db(const std::string& name);
 
 private:
-    friend class App;
+    friend class realm::SyncUser;
 
-    RemoteMongoClient(std::shared_ptr<AppServiceClient> service, std::string service_name)
-    : m_service(service)
-    , m_service_name(service_name) {}
+    MongoClient(std::shared_ptr<SyncUser> user, std::shared_ptr<AppServiceClient> service, std::string service_name)
+        : m_user(std::move(user))
+        , m_service(std::move(service))
+        , m_service_name(std::move(service_name))
+    {
+    }
 
+    std::shared_ptr<SyncUser> m_user;
     std::shared_ptr<AppServiceClient> m_service;
     std::string m_service_name;
 };

--- a/src/sync/remote_mongo_collection.hpp
+++ b/src/sync/remote_mongo_collection.hpp
@@ -20,18 +20,23 @@
 #define REMOTE_MONGO_COLLECTION_HPP
 
 #include "sync/app_service_client.hpp"
-#include <realm/util/optional.hpp>
+#include "sync/generic_network_transport.hpp"
+#include "util/bson/bson.hpp"
+
 #include <json.hpp>
+#include <realm/util/optional.hpp>
 #include <string>
 #include <vector>
 
 namespace realm {
+class SyncUser;
+
 namespace app {
 
-class RemoteMongoCollection {
+class MongoCollection {
 public:
 
-    struct RemoteUpdateResult {
+    struct UpdateResult {
         /// The number of documents that matched the filter.
         int32_t matched_count;
         /// The number of documents modified.
@@ -41,7 +46,7 @@ public:
     };
 
     /// Options to use when executing a `find` command on a `RemoteMongoCollection`.
-    struct RemoteFindOptions {
+    struct FindOptions {
         /// The maximum number of documents to return.
         util::Optional<int64_t> limit;
 
@@ -54,7 +59,7 @@ public:
 
     /// Options to use when executing a `find_one_and_update`, `find_one_and_replace`,
     /// or `find_one_and_delete` command on a `remote_mongo_collection`.
-    struct RemoteFindOneAndModifyOptions {
+    struct FindOneAndModifyOptions {
         /// Limits the fields to return for all matching documents.
         util::Optional<bson::BsonDocument> projection_bson;
         /// The order in which to return matching documents.
@@ -87,11 +92,11 @@ public:
         }
     };
 
-    ~RemoteMongoCollection() = default;
-    RemoteMongoCollection(RemoteMongoCollection&&) = default;
-    RemoteMongoCollection(const RemoteMongoCollection&) = default;
-    RemoteMongoCollection& operator=(const RemoteMongoCollection& v) = default;
-    RemoteMongoCollection& operator=(RemoteMongoCollection&&) = default;
+    ~MongoCollection() = default;
+    MongoCollection(MongoCollection&&) = default;
+    MongoCollection(const MongoCollection&) = default;
+    MongoCollection& operator=(const MongoCollection& v) = default;
+    MongoCollection& operator=(MongoCollection&&) = default;
 
     const std::string& name() const
     {
@@ -108,7 +113,7 @@ public:
     /// @param options `RemoteFindOptions` to use when executing the command.
     /// @param completion_block The resulting bson array of documents or error if one occurs
     void find(const bson::BsonDocument& filter_bson,
-              RemoteFindOptions options,
+              FindOptions options,
               std::function<void(util::Optional<bson::BsonArray>, util::Optional<AppError>)> completion_block);
 
     /// Finds the documents in this collection which match the provided filter.
@@ -125,7 +130,7 @@ public:
     /// @param options `RemoteFindOptions` to use when executing the command.
     /// @param completion_block The resulting bson or error if one occurs
     void find_one(const bson::BsonDocument& filter_bson,
-                  RemoteFindOptions options,
+                  FindOptions options,
                   std::function<void(util::Optional<bson::BsonDocument>, util::Optional<AppError>)> completion_block);
 
     /// Returns one document from a collection or view which matches the
@@ -191,7 +196,7 @@ public:
     void update_one(const bson::BsonDocument& filter_bson,
                     const bson::BsonDocument& update_bson,
                     bool upsert,
-                    std::function<void(RemoteUpdateResult, util::Optional<AppError>)> completion_block);
+                    std::function<void(UpdateResult, util::Optional<AppError>)> completion_block);
 
     /// Updates a single document matching the provided filter in this collection.
     /// @param filter_bson  A bson `Document` representing the match criteria.
@@ -199,7 +204,7 @@ public:
     /// @param completion_block The result of the attempt to update a document.
     void update_one(const bson::BsonDocument& filter_bson,
                     const bson::BsonDocument& update_bson,
-                    std::function<void(RemoteUpdateResult, util::Optional<AppError>)> completion_block);
+                    std::function<void(UpdateResult, util::Optional<AppError>)> completion_block);
 
     /// Updates multiple documents matching the provided filter in this collection.
     /// @param filter_bson  A bson `Document` representing the match criteria.
@@ -209,7 +214,7 @@ public:
     void update_many(const bson::BsonDocument& filter_bson,
                      const bson::BsonDocument& update_bson,
                      bool upsert,
-                     std::function<void(RemoteUpdateResult, util::Optional<AppError>)> completion_block);
+                     std::function<void(UpdateResult, util::Optional<AppError>)> completion_block);
 
     /// Updates multiple documents matching the provided filter in this collection.
     /// @param filter_bson  A bson `Document` representing the match criteria.
@@ -217,7 +222,7 @@ public:
     /// @param completion_block The result of the attempt to update a document.
     void update_many(const bson::BsonDocument& filter_bson,
                      const bson::BsonDocument& update_bson,
-                     std::function<void(RemoteUpdateResult, util::Optional<AppError>)> completion_block);
+                     std::function<void(UpdateResult, util::Optional<AppError>)> completion_block);
 
     /// Updates a single document in a collection based on a query filter and
     /// returns the document in either its pre-update or post-update form. Unlike
@@ -231,7 +236,7 @@ public:
     /// @param completion_block The result of the attempt to update a document.
     void find_one_and_update(const bson::BsonDocument& filter_bson,
                              const bson::BsonDocument& update_bson,
-                             RemoteFindOneAndModifyOptions options,
+                             FindOneAndModifyOptions options,
                              std::function<void(util::Optional<bson::BsonDocument>, util::Optional<AppError>)> completion_block);
 
     /// Updates a single document in a collection based on a query filter and
@@ -259,7 +264,7 @@ public:
     /// @param completion_block The result of the attempt to replace a document.
     void find_one_and_replace(const bson::BsonDocument& filter_bson,
                               const bson::BsonDocument& replacement_bson,
-                              RemoteFindOneAndModifyOptions options,
+                              FindOneAndModifyOptions options,
                               std::function<void(util::Optional<bson::BsonDocument>, util::Optional<AppError>)> completion_block);
 
     /// Overwrites a single document in a collection based on a query filter and
@@ -285,7 +290,7 @@ public:
     /// @param options Optional `RemoteFindOneAndModifyOptions` to use when executing the command.
     /// @param completion_block The result of the attempt to delete a document.
     void find_one_and_delete(const bson::BsonDocument& filter_bson,
-                             RemoteFindOneAndModifyOptions options,
+                             FindOneAndModifyOptions options,
                              std::function<void(util::Optional<bson::BsonDocument>, util::Optional<AppError>)> completion_block);
 
     /// Removes a single document from a collection based on a query filter and
@@ -315,17 +320,16 @@ public:
      */
 
 private:
-    friend class RemoteMongoDatabase;
+    friend class MongoDatabase;
 
-    RemoteMongoCollection(std::string name,
-                          std::string database_name,
-                          std::shared_ptr<AppServiceClient> service,
-                          std::string service_name)
-    : m_name(name)
-    , m_database_name(database_name)
-    , m_base_operation_args({ { "database" , database_name }, { "collection" , name } })
-    , m_service(service)
-    , m_service_name(service_name)
+    MongoCollection(std::string name, std::string database_name, std::shared_ptr<SyncUser> user,
+                    std::shared_ptr<AppServiceClient> service, std::string service_name)
+    : m_name(std::move(name))
+    , m_database_name(std::move(database_name))
+    , m_base_operation_args({{"database", m_database_name}, {"collection", m_name}})
+    , m_user(std::move(user))
+    , m_service(std::move(service))
+    , m_service_name(std::move(service_name))
     {
     }
 
@@ -337,6 +341,8 @@ private:
 
     /// Returns a document of database name and collection name
     bson::BsonDocument m_base_operation_args;
+
+    std::shared_ptr<SyncUser> m_user;
 
     std::shared_ptr<AppServiceClient> m_service;
 

--- a/src/sync/remote_mongo_database.cpp
+++ b/src/sync/remote_mongo_database.cpp
@@ -17,19 +17,19 @@
 ////////////////////////////////////////////////////////////////////////////
 
 #include "sync/remote_mongo_database.hpp"
+#include "sync/remote_mongo_collection.hpp"
 
 namespace realm {
 namespace app {
 
-RemoteMongoCollection RemoteMongoDatabase::collection(const std::string& collection_name)
+MongoCollection MongoDatabase::collection(const std::string& collection_name)
 {
-    return RemoteMongoCollection(collection_name, m_name, m_service, m_service_name);
+    return MongoCollection(collection_name, m_name, m_user, m_service, m_service_name);
 }
 
-RemoteMongoCollection RemoteMongoDatabase::operator[](const std::string& collection_name)
+MongoCollection MongoDatabase::operator[](const std::string& collection_name)
 {
-    return RemoteMongoCollection(collection_name, m_name, m_service, m_service_name);
+    return MongoCollection(collection_name, m_name, m_user, m_service, m_service_name);
 }
-
 }
 }

--- a/src/sync/remote_mongo_database.hpp
+++ b/src/sync/remote_mongo_database.hpp
@@ -19,22 +19,23 @@
 #ifndef REMOTE_MONGO_DATABASE_HPP
 #define REMOTE_MONGO_DATABASE_HPP
 
-#include "sync/remote_mongo_collection.hpp"
 #include <json.hpp>
 #include <string>
 
 namespace realm {
+class SyncUser;
 namespace app {
 
 class AppServiceClient;
+class MongoCollection;
 
-class RemoteMongoDatabase {
+class MongoDatabase {
 public:
-    ~RemoteMongoDatabase() = default;
-    RemoteMongoDatabase(const RemoteMongoDatabase&) = default;
-    RemoteMongoDatabase(RemoteMongoDatabase&&) = default;
-    RemoteMongoDatabase& operator=(const RemoteMongoDatabase&) = default;
-    RemoteMongoDatabase& operator=(RemoteMongoDatabase&&) = default;
+    ~MongoDatabase() = default;
+    MongoDatabase(const MongoDatabase&) = default;
+    MongoDatabase(MongoDatabase&&) = default;
+    MongoDatabase& operator=(const MongoDatabase&) = default;
+    MongoDatabase& operator=(MongoDatabase&&) = default;
 
     /// The name of this database
     const std::string& name() const
@@ -45,24 +46,29 @@ public:
     /// Gets a collection.
     /// @param collection_name The name of the collection to return
     /// @returns The collection as json
-    RemoteMongoCollection collection(const std::string& collection_name);
+    MongoCollection collection(const std::string& collection_name);
 
     /// Gets a collection.
     /// @param collection_name The name of the collection to return
     /// @returns The collection as json
-    RemoteMongoCollection operator[](const std::string& collection_name);
+    MongoCollection operator[](const std::string& collection_name);
 
 private:
-    RemoteMongoDatabase(std::string name,
-                        std::shared_ptr<AppServiceClient> service,
-                        std::string service_name)
-    : m_name(name)
-    , m_service(service)
-    , m_service_name(service_name) { };
+    MongoDatabase(std::string name, 
+                  std::shared_ptr<SyncUser> user,
+                  std::shared_ptr<AppServiceClient> service,
+                  std::string service_name)
+    : m_name(std::move(name))
+    , m_user(std::move(user))
+    , m_service(std::move(service))
+    , m_service_name(std::move(service_name))
+    {
+    }
 
-    friend class RemoteMongoClient;
+    friend class MongoClient;
 
     std::string m_name;
+    std::shared_ptr<SyncUser> m_user;
     std::shared_ptr<AppServiceClient> m_service;
     std::string m_service_name;
 };

--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -21,6 +21,7 @@
 #include "sync/app_credentials.hpp"
 #include "sync/generic_network_transport.hpp"
 #include "sync/impl/sync_metadata.hpp"
+#include "sync/remote_mongo_client.hpp"
 #include "sync/sync_manager.hpp"
 #include "sync/sync_session.hpp"
 
@@ -404,6 +405,11 @@ void SyncUser::register_session(std::shared_ptr<SyncSession> session)
         case State::Removed:
             break;
     }
+}
+
+app::MongoClient SyncUser::mongo_client(const std::string& service_name)
+{
+    return app::MongoClient(shared_from_this(), m_sync_manager->app().lock(), service_name);
 }
 
 void SyncUser::set_binding_context_factory(SyncUserContextFactory factory)

--- a/src/sync/sync_user.hpp
+++ b/src/sync/sync_user.hpp
@@ -37,10 +37,12 @@
 namespace realm {
 namespace app {
     struct AppError;
+    class MongoClient;
 } // namespace app
 
 class SyncSession;
 class SyncManager;
+
 // A superclass that bindings can inherit from in order to store information
 // upon a `SyncUser` object.
 class SyncUserContext {
@@ -230,6 +232,11 @@ public:
     {
         return m_sync_manager;
     }
+
+    /// Retrieves a general-purpose service client for the Realm Cloud service
+    /// @param service_name The name of the cluster
+    app::MongoClient mongo_client(const std::string& service_name);
+
 private:
     static SyncUserContextFactory s_binding_context_factory;
     static std::mutex s_binding_context_factory_mutex;


### PR DESCRIPTION
This moves the factory for MongoClient to SyncUser from App so that mongo operations are performed by a specific user rather than whatever the current user of the App is. It also renamed RemoteMongoClient/DatabaseCollection to just MongoClient/Database/Collection.