### PR TITLE
Add http_status_code as a param to AppError.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -115,6 +115,7 @@ if(REALM_ENABLE_SYNC)
         util/bson/mongo_timestamp.hpp)
     list(APPEND SOURCES
         sync/app.cpp
+        sync/app_utils.cpp
         sync/app_credentials.cpp
         sync/generic_network_transport.cpp
         sync/async_open_task.cpp

--- a/src/sync/app.cpp
+++ b/src/sync/app.cpp
@@ -978,7 +978,7 @@ void App::handle_auth_failure(const AppError& error,
     };
 
     // Only handle auth failures
-    if (*error.http_status_code && (*error.http_status_code).value() == 401) {
+    if (*error.http_status_code && *error.http_status_code == 401) {
         if (request.uses_refresh_token) {
             if (sync_user && sync_user->is_logged_in()) {
                 sync_user->log_out();

--- a/src/sync/app_utils.cpp
+++ b/src/sync/app_utils.cpp
@@ -53,12 +53,12 @@ util::Optional<AppError> AppUtils::check_for_errors(const Response& response)
                 return AppError(make_error_code(service_error_code_from_string(body["error_code"].get<std::string>())),
                                 message != body.end() ? message->get<std::string>() : "no error message",
                                 std::move(parsed_link),
-                                make_http_error_code(response.http_status_code));
+                                response.http_status_code);
             } else if (message != body.end()) {
                 return AppError(make_error_code(ServiceErrorCode::unknown),
                                 message->get<std::string>(),
                                 std::move(parsed_link),
-                                make_http_error_code(response.http_status_code));
+                                response.http_status_code);
             }
         }
     } catch (const std::exception&) {
@@ -70,7 +70,7 @@ util::Optional<AppError> AppUtils::check_for_errors(const Response& response)
         return AppError(make_custom_error_code(response.custom_status_code),
                         error_msg,
                         "",
-                        make_http_error_code(response.http_status_code));
+                        response.http_status_code);
     }
 
     if (http_status_code_is_fatal)
@@ -78,7 +78,7 @@ util::Optional<AppError> AppUtils::check_for_errors(const Response& response)
         return AppError(make_http_error_code(response.http_status_code),
                         "http error code considered fatal",
                         "",
-                        make_http_error_code(response.http_status_code));
+                        response.http_status_code);
     }
 
     return {};

--- a/src/sync/app_utils.cpp
+++ b/src/sync/app_utils.cpp
@@ -1,0 +1,88 @@
+////////////////////////////////////////////////////////////////////////////
+//
+// Copyright 2020 Realm Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or utilied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+////////////////////////////////////////////////////////////////////////////
+
+#include "sync/app_utils.hpp"
+
+namespace realm {
+namespace app {
+
+util::Optional<AppError> AppUtils::check_for_errors(const Response& response)
+{
+    bool http_status_code_is_fatal = response.http_status_code >= 300 ||
+        (response.http_status_code < 200 && response.http_status_code != 0);
+
+    auto find_case_insensitive_header = [&response](const std::string& needle) {
+        for (auto it = response.headers.begin(); it != response.headers.end(); ++it) {
+            if (std::equal(it->first.begin(), it->first.end(),
+                              needle.begin(), needle.end(),
+                              [](char a, char b) {
+                                  return tolower(a) == tolower(b);
+            })) {
+                return it;
+            }
+        }
+        return response.headers.end();
+    };
+
+    try {
+        auto ct = find_case_insensitive_header("content-type");
+        if (ct != response.headers.end() && ct->second == "application/json") {
+            auto body = nlohmann::json::parse(response.body);
+            auto message = body.find("error");
+            auto link = body.find("link");
+            std::string parsed_link = link == body.end() ? "" : link->get<std::string>();
+
+            if (auto error_code = body.find("error_code"); error_code != body.end() &&
+                !error_code->get<std::string>().empty())
+            {
+                return AppError(make_error_code(service_error_code_from_string(body["error_code"].get<std::string>())),
+                                message != body.end() ? message->get<std::string>() : "no error message",
+                                std::move(parsed_link),
+                                make_http_error_code(response.http_status_code));
+            } else if (message != body.end()) {
+                return AppError(make_error_code(ServiceErrorCode::unknown),
+                                message->get<std::string>(),
+                                std::move(parsed_link),
+                                make_http_error_code(response.http_status_code));
+            }
+        }
+    } catch (const std::exception&) {
+        // ignore parse errors from our attempt to read the error from json
+    }
+
+    if (response.custom_status_code != 0) {
+        std::string error_msg = (!response.body.empty()) ? response.body : "non-zero custom status code considered fatal";
+        return AppError(make_custom_error_code(response.custom_status_code),
+                        error_msg,
+                        "",
+                        make_http_error_code(response.http_status_code));
+    }
+
+    if (http_status_code_is_fatal)
+    {
+        return AppError(make_http_error_code(response.http_status_code),
+                        "http error code considered fatal",
+                        "",
+                        make_http_error_code(response.http_status_code));
+    }
+
+    return {};
+}
+
+} // namespace app
+} // namespace realm

--- a/src/sync/app_utils.hpp
+++ b/src/sync/app_utils.hpp
@@ -27,57 +27,11 @@
 
 namespace realm {
 namespace app {
-static util::Optional<AppError> check_for_errors(const Response& response)
-{
-    bool http_status_code_is_fatal = response.http_status_code >= 300 ||
-        (response.http_status_code < 200 && response.http_status_code != 0);
 
-    auto find_case_insensitive_header = [&response](const std::string& needle) {
-        for (auto it = response.headers.begin(); it != response.headers.end(); ++it) {
-            if (std::equal(it->first.begin(), it->first.end(),
-                              needle.begin(), needle.end(),
-                              [](char a, char b) {
-                                  return tolower(a) == tolower(b);
-            })) {
-                return it;
-            }
-        }
-        return response.headers.end();
-    };
-
-    try {
-        auto ct = find_case_insensitive_header("content-type");
-        if (ct != response.headers.end() && ct->second == "application/json") {
-            auto body = nlohmann::json::parse(response.body);
-            auto message = body.find("error");
-            auto link = body.find("link");
-            std::string parsed_link = link == body.end() ? "" : link->get<std::string>();
-
-            if (auto error_code = body.find("error_code"); error_code != body.end() &&
-                !error_code->get<std::string>().empty())
-            {
-                return AppError(make_error_code(service_error_code_from_string(body["error_code"].get<std::string>())),
-                                message != body.end() ? message->get<std::string>() : "no error message", std::move(parsed_link));
-            } else if (message != body.end()) {
-                return AppError(make_error_code(ServiceErrorCode::unknown), message->get<std::string>(), std::move(parsed_link));
-            }
-        }
-    } catch (const std::exception&) {
-        // ignore parse errors from our attempt to read the error from json
-    }
-
-    if (response.custom_status_code != 0) {
-        std::string error_msg = (!response.body.empty()) ? response.body : "non-zero custom status code considered fatal";
-        return AppError(make_custom_error_code(response.custom_status_code), error_msg);
-    }
-
-    if (http_status_code_is_fatal)
-    {
-        return AppError(make_http_error_code(response.http_status_code), "http error code considered fatal");
-    }
-
-    return {};
-}
+class AppUtils {
+public:
+    static util::Optional<AppError> check_for_errors(const Response& response);
+};
 } // namespace app
 } // namespace realm
 

--- a/src/sync/generic_network_transport.hpp
+++ b/src/sync/generic_network_transport.hpp
@@ -21,6 +21,7 @@
 #define REALM_GENERIC_NETWORK_TRANSPORT_HPP
 
 #include <realm/util/to_string.hpp>
+#include <realm/util/optional.hpp>
 
 #include <functional>
 #include <iosfwd>
@@ -123,11 +124,17 @@ std::error_code make_client_error_code(ClientErrorCode) noexcept;
 struct AppError {
 
     std::error_code error_code;
+    util::Optional<std::error_code> http_status_code;
+
     std::string message;
     std::string link_to_server_logs;
 
-    AppError(std::error_code error_code, std::string message, std::string link = "")
+    AppError(std::error_code error_code,
+             std::string message,
+             std::string link = "",
+             util::Optional<std::error_code> http_error_code = util::none)
     : error_code(error_code)
+    , http_status_code(http_error_code)
     , message(message)
     , link_to_server_logs(link)
     {

--- a/src/sync/generic_network_transport.hpp
+++ b/src/sync/generic_network_transport.hpp
@@ -124,7 +124,7 @@ std::error_code make_client_error_code(ClientErrorCode) noexcept;
 struct AppError {
 
     std::error_code error_code;
-    util::Optional<std::error_code> http_status_code;
+    util::Optional<int> http_status_code;
 
     std::string message;
     std::string link_to_server_logs;
@@ -132,7 +132,7 @@ struct AppError {
     AppError(std::error_code error_code,
              std::string message,
              std::string link = "",
-             util::Optional<std::error_code> http_error_code = util::none)
+             util::Optional<int> http_error_code = util::none)
     : error_code(error_code)
     , http_status_code(http_error_code)
     , message(message)

--- a/src/sync/push_client.cpp
+++ b/src/sync/push_client.cpp
@@ -27,7 +27,7 @@ void PushClient::register_device(const std::string& registration_token,
                                  std::function<void(util::Optional<AppError>)> completion_block)
 {
     auto handler = [completion_block](const Response& response) {
-        if (auto error = check_for_errors(response)) {
+        if (auto error = AppUtils::check_for_errors(response)) {
             return completion_block(error);
         } else {
             return completion_block({});
@@ -59,7 +59,7 @@ void PushClient::deregister_device(std::shared_ptr<SyncUser> sync_user,
                                    std::function<void(util::Optional<AppError>)> completion_block)
 {
     auto handler = [completion_block](const Response& response) {
-        if (auto error = check_for_errors(response)) {
+        if (auto error = AppUtils::check_for_errors(response)) {
             return completion_block(error);
         } else {
             return completion_block({});


### PR DESCRIPTION
This PR addresses an uncaught bug. The bug is where a http response which contains `application/json` would not write the http status to an AppError object. Therefor if the user got a 401 http response because of a bad token we would never be able to catch it in `App::handle_auth_failure` as there is no http status code to look up.

In this PR I've added `http_status_code` as an optional attribute of `AppError`. I have also wrapped the static `check_for_errors` method in a class.

Addresses: https://github.com/realm/realm-object-store/issues/1119