### PR TITLE
Rename remote_mongo_x files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -99,9 +99,9 @@ if(REALM_ENABLE_SYNC)
         sync/sync_user.hpp
         sync/app_service_client.hpp
         sync/auth_request_client.hpp
-        sync/remote_mongo_client.hpp
-        sync/remote_mongo_collection.hpp
-        sync/remote_mongo_database.hpp
+        sync/mongo_client.hpp
+        sync/mongo_collection.hpp
+        sync/mongo_database.hpp
         sync/push_client.hpp
 
         sync/impl/sync_client.hpp
@@ -122,9 +122,9 @@ if(REALM_ENABLE_SYNC)
         sync/sync_manager.cpp
         sync/sync_session.cpp
         sync/sync_user.cpp
-        sync/remote_mongo_client.cpp
-        sync/remote_mongo_collection.cpp
-        sync/remote_mongo_database.cpp
+        sync/mongo_client.cpp
+        sync/mongo_collection.cpp
+        sync/mongo_database.cpp
         sync/push_client.cpp
         sync/impl/sync_file.cpp
         sync/impl/sync_metadata.cpp

--- a/src/sync/mongo_client.cpp
+++ b/src/sync/mongo_client.cpp
@@ -16,8 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#include "sync/remote_mongo_client.hpp"
-#include "sync/remote_mongo_database.hpp"
+#include "sync/mongo_client.hpp"
+#include "sync/mongo_database.hpp"
 
 namespace realm {
 namespace app {

--- a/src/sync/mongo_client.hpp
+++ b/src/sync/mongo_client.hpp
@@ -16,8 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#ifndef REMOTE_MONGO_CLIENT_HPP
-#define REMOTE_MONGO_CLIENT_HPP
+#ifndef MONGO_CLIENT_HPP
+#define MONGO_CLIENT_HPP
 
 #include "sync/app_service_client.hpp"
 #include <string>
@@ -29,7 +29,7 @@ namespace app {
 
 class MongoDatabase;
 
-/// A client responsible for communication with the Stitch API
+/// A client responsible for communication with a remote MongoDB database.
 class MongoClient {
 public:
     ~MongoClient() = default;
@@ -38,11 +38,11 @@ public:
     MongoClient& operator=(const MongoClient&) = default;
     MongoClient& operator=(MongoClient&&) = default;
 
-    /// Gets a `RemoteMongoDatabase` instance for the given database name.
+    /// Gets a `MongoDatabase` instance for the given database name.
     /// @param name the name of the database to retrieve
     MongoDatabase operator[](const std::string& name);
 
-    /// Gets a `RemoteMongoDatabase` instance for the given database name.
+    /// Gets a `MongoDatabase` instance for the given database name.
     /// @param name the name of the database to retrieve
     MongoDatabase db(const std::string& name);
 
@@ -64,4 +64,4 @@ private:
 } // namespace app
 } // namespace realm
 
-#endif /* remote_mongo_client_hpp */
+#endif /* mongo_client_hpp */

--- a/src/sync/mongo_collection.cpp
+++ b/src/sync/mongo_collection.cpp
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#include "sync/remote_mongo_collection.hpp"
+#include "sync/mongo_collection.hpp"
 #include "realm/util/uri.hpp"
 
 namespace realm {

--- a/src/sync/mongo_collection.hpp
+++ b/src/sync/mongo_collection.hpp
@@ -16,8 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#ifndef REMOTE_MONGO_COLLECTION_HPP
-#define REMOTE_MONGO_COLLECTION_HPP
+#ifndef MONGO_COLLECTION_HPP
+#define MONGO_COLLECTION_HPP
 
 #include "sync/app_service_client.hpp"
 #include "sync/generic_network_transport.hpp"
@@ -45,7 +45,7 @@ public:
         util::Optional<ObjectId> upserted_id;
     };
 
-    /// Options to use when executing a `find` command on a `RemoteMongoCollection`.
+    /// Options to use when executing a `find` command on a `MongoCollection`.
     struct FindOptions {
         /// The maximum number of documents to return.
         util::Optional<int64_t> limit;
@@ -58,7 +58,7 @@ public:
     };
 
     /// Options to use when executing a `find_one_and_update`, `find_one_and_replace`,
-    /// or `find_one_and_delete` command on a `remote_mongo_collection`.
+    /// or `find_one_and_delete` command on a `mongo_collection`.
     struct FindOneAndModifyOptions {
         /// Limits the fields to return for all matching documents.
         util::Optional<bson::BsonDocument> projection_bson;
@@ -497,5 +497,5 @@ private:
 } // namespace app
 } // namespace realm
 
-#endif /* remote_mongo_collection_h */
+#endif /* mongo_collection_h */
 

--- a/src/sync/mongo_database.cpp
+++ b/src/sync/mongo_database.cpp
@@ -16,8 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#include "sync/remote_mongo_database.hpp"
-#include "sync/remote_mongo_collection.hpp"
+#include "sync/mongo_database.hpp"
+#include "sync/mongo_collection.hpp"
 
 namespace realm {
 namespace app {

--- a/src/sync/mongo_database.hpp
+++ b/src/sync/mongo_database.hpp
@@ -16,8 +16,8 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#ifndef REMOTE_MONGO_DATABASE_HPP
-#define REMOTE_MONGO_DATABASE_HPP
+#ifndef MONGO_DATABASE_HPP
+#define MONGO_DATABASE_HPP
 
 #include <json.hpp>
 #include <string>
@@ -76,4 +76,4 @@ private:
 } // namespace app
 } // namespace realm
 
-#endif /* remote_mongo_database_h */
+#endif /* mongo_database_h */

--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -21,7 +21,7 @@
 #include "sync/app_credentials.hpp"
 #include "sync/generic_network_transport.hpp"
 #include "sync/impl/sync_metadata.hpp"
-#include "sync/remote_mongo_client.hpp"
+#include "sync/mongo_client.hpp"
 #include "sync/sync_manager.hpp"
 #include "sync/sync_session.hpp"
 

--- a/tests/mongodb/graphql/config.json
+++ b/tests/mongodb/graphql/config.json
@@ -1,0 +1,3 @@
+{
+    "use_natural_pluralization": false
+}

--- a/tests/mongodb/graphql/config.json
+++ b/tests/mongodb/graphql/config.json
@@ -1,3 +1,0 @@
-{
-    "use_natural_pluralization": false
-}

--- a/tests/sync/app.cpp
+++ b/tests/sync/app.cpp
@@ -22,9 +22,9 @@
 #include "sync/app.hpp"
 #include "sync/app_credentials.hpp"
 #include "sync/async_open_task.hpp"
-#include "sync/remote_mongo_client.hpp"
-#include "sync/remote_mongo_database.hpp"
-#include "sync/remote_mongo_collection.hpp"
+#include "sync/mongo_client.hpp"
+#include "sync/mongo_database.hpp"
+#include "sync/mongo_collection.hpp"
 #include "sync/sync_session.hpp"
 
 #include "util/event_loop.hpp"

--- a/tests/sync/remote_mongo_tests.cpp
+++ b/tests/sync/remote_mongo_tests.cpp
@@ -16,7 +16,7 @@
 //
 ////////////////////////////////////////////////////////////////////////////
 
-#include "sync/remote_mongo_collection.hpp"
+#include "sync/mongo_collection.hpp"
 
 #include <sstream>
 #include "catch2/catch.hpp"


### PR DESCRIPTION
This PR just renames the remote_mongo_x files to mongo_x for clarity, as we have now remove the 'Remote' prefix from any remote MongoDB classes.