### PR TITLE
hold the mutex while calling notify_all

### DIFF
--- a/src/impl/windows/external_commit_helper.cpp
+++ b/src/impl/windows/external_commit_helper.cpp
@@ -54,6 +54,7 @@ ExternalCommitHelper::~ExternalCommitHelper()
 
 void ExternalCommitHelper::notify_others()
 {
+    std::lock_guard<InterprocessMutex> lock(m_mutex);
     m_commit_available.notify_all();
 }
 


### PR DESCRIPTION
according to this https://github.com/realm/realm-core/blob/master/src/realm/util/interprocess_condvar.cpp#L459-L461
the caller should be holding the mutex before calling `notify_all`

In what other branch/repo this changes should be cherry-picked ?