### PR TITLE
fix SharedMemory on Win32 platforms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ compile_commands.json
 
 # vim
 *.swp
+/openssl/
+/out/build/

--- a/src/impl/windows/external_commit_helper.cpp
+++ b/src/impl/windows/external_commit_helper.cpp
@@ -55,7 +55,6 @@ ExternalCommitHelper::~ExternalCommitHelper()
 
 void ExternalCommitHelper::notify_others()
 {
-    std::lock_guard<InterprocessMutex> lock(m_mutex);
     m_commit_available.notify_all();
 }
 

--- a/src/impl/windows/external_commit_helper.cpp
+++ b/src/impl/windows/external_commit_helper.cpp
@@ -55,6 +55,7 @@ ExternalCommitHelper::~ExternalCommitHelper()
 
 void ExternalCommitHelper::notify_others()
 {
+    std::lock_guard<InterprocessMutex> lock(m_mutex);
     m_commit_available.notify_all();
 }
 

--- a/src/impl/windows/external_commit_helper.hpp
+++ b/src/impl/windows/external_commit_helper.hpp
@@ -26,7 +26,7 @@ namespace _impl {
 class RealmCoordinator;
 
 namespace win32 {
-#if REALM_WINDOWS
+// #if REALM_WINDOWS
 #define OpenFileMappingInternal(dwDesiredAccess, bInheritHandle, lpName)\
         OpenFileMappingW(dwDesiredAccess, bInheritHandle, lpName);
 
@@ -36,19 +36,19 @@ namespace win32 {
 #define MapViewOfFileInternal(hFileMappingObject, dwDesiredAccess, dwFileOffsetHigh, dwFileOffsetLow, dwNumberOfBytesToMap)\
         MapViewOfFile(hFileMappingObject, dwDesiredAccess, dwFileOffsetHigh, dwFileOffsetLow, dwNumberOfBytesToMap);
 
-#elif REALM_UWP
-#define OpenFileMappingInternal(dwDesiredAccess, bInheritHandle, lpName)\
-        OpenFileMappingFromApp(dwDesiredAccess, bInheritHandle, lpName);
+// // #elif REALM_UWP
+// // #define OpenFileMappingInternal(dwDesiredAccess, bInheritHandle, lpName)\
+// //         OpenFileMappingFromApp(dwDesiredAccess, bInheritHandle, lpName);
 
-#define CreateFileMappingInternal(hFile, lpFileMappingAttributes, flProtect, dwMaximumSizeHigh, dwMaximumSizeLow, lpName)\
-        CreateFileMappingFromApp(hFile, lpFileMappingAttributes, flProtect, dwMaximumSizeHigh, dwMaximumSizeLow, lpName);
+// // #define CreateFileMappingInternal(hFile, lpFileMappingAttributes, flProtect, dwMaximumSizeHigh, dwMaximumSizeLow, lpName)\
+// //         CreateFileMappingFromApp(hFile, lpFileMappingAttributes, flProtect, dwMaximumSizeHigh, dwMaximumSizeLow, lpName);
 
-#define MapViewOfFileInternal(hFileMappingObject, dwDesiredAccess, dwFileOffsetHigh, dwFileOffsetLow, dwNumberOfBytesToMap)\
-        MapViewOfFileFromApp(hFileMappingObject, dwDesiredAccess, dwFileOffsetHigh, dwFileOffsetLow, dwNumberOfBytesToMap);
+// // #define MapViewOfFileInternal(hFileMappingObject, dwDesiredAccess, dwFileOffsetHigh, dwFileOffsetLow, dwNumberOfBytesToMap)\
+// //         MapViewOfFileFromApp(hFileMappingObject, dwDesiredAccess, dwFileOffsetHigh, dwFileOffsetLow, dwNumberOfBytesToMap);
 
-#elif
-#error Unknown win32 platform
-#endif
+// #elif
+// #error Unknown win32 platform
+// #endif
 
 template <class T, void (*Initializer)(T&)>
 class SharedMemory {

--- a/src/impl/windows/external_commit_helper.hpp
+++ b/src/impl/windows/external_commit_helper.hpp
@@ -26,30 +26,6 @@ namespace _impl {
 class RealmCoordinator;
 
 namespace win32 {
-// #if REALM_WINDOWS
-#define OpenFileMappingInternal(dwDesiredAccess, bInheritHandle, lpName)\
-        OpenFileMappingW(dwDesiredAccess, bInheritHandle, lpName);
-
-#define CreateFileMappingInternal(hFile, lpFileMappingAttributes, flProtect, dwMaximumSizeHigh, dwMaximumSizeLow, lpName)\
-        CreateFileMappingW(hFile, lpFileMappingAttributes, flProtect, dwMaximumSizeHigh, dwMaximumSizeLow, lpName);
-
-#define MapViewOfFileInternal(hFileMappingObject, dwDesiredAccess, dwFileOffsetHigh, dwFileOffsetLow, dwNumberOfBytesToMap)\
-        MapViewOfFile(hFileMappingObject, dwDesiredAccess, dwFileOffsetHigh, dwFileOffsetLow, dwNumberOfBytesToMap);
-
-// // #elif REALM_UWP
-// // #define OpenFileMappingInternal(dwDesiredAccess, bInheritHandle, lpName)\
-// //         OpenFileMappingFromApp(dwDesiredAccess, bInheritHandle, lpName);
-
-// // #define CreateFileMappingInternal(hFile, lpFileMappingAttributes, flProtect, dwMaximumSizeHigh, dwMaximumSizeLow, lpName)\
-// //         CreateFileMappingFromApp(hFile, lpFileMappingAttributes, flProtect, dwMaximumSizeHigh, dwMaximumSizeLow, lpName);
-
-// // #define MapViewOfFileInternal(hFileMappingObject, dwDesiredAccess, dwFileOffsetHigh, dwFileOffsetLow, dwNumberOfBytesToMap)\
-// //         MapViewOfFileFromApp(hFileMappingObject, dwDesiredAccess, dwFileOffsetHigh, dwFileOffsetLow, dwNumberOfBytesToMap);
-
-// #elif
-// #error Unknown win32 platform
-// #endif
-
 template <class T, void (*Initializer)(T&)>
 class SharedMemory {
 public:
@@ -57,11 +33,11 @@ public:
         //assume another process have already initialzied the shared memory
         bool shouldInit = false;
 
-        HANDLE mapping = OpenFileMappingInternal(FILE_MAP_ALL_ACCESS, FALSE, name);
+        HANDLE mapping = OpenFileMappingW(FILE_MAP_ALL_ACCESS, FALSE, name);
         auto error = GetLastError();
 
         if (mapping == NULL) {
-            mapping = CreateFileMappingInternal(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, sizeof(T), name);
+            mapping = CreateFileMappingW(INVALID_HANDLE_VALUE, nullptr, PAGE_READWRITE, 0, sizeof(T), name);
             error = GetLastError();
 
             //init since this is the first process creating the shared memory
@@ -72,7 +48,7 @@ public:
             throw std::system_error(error, std::system_category());
         }
 
-        LPVOID view = MapViewOfFileInternal(mapping, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(T));
+        LPVOID view = MapViewOfFile(mapping, FILE_MAP_ALL_ACCESS, 0, 0, sizeof(T));
         error = GetLastError();
         if (view == NULL) {
             throw std::system_error(error, std::system_category());


### PR DESCRIPTION
don't close the mapped file handle cause the mapped file can not be opened from another process. This fixes the sharing of memory needed to synchronize realm file access between windows processes
