### PR TITLE
fix-win-paths

### DIFF
--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -127,24 +127,30 @@ std::string make_raw_string(const std::string& percent_encoded_string)
 
 std::string file_path_by_appending_component(const std::string& path, const std::string& component, FilePathType path_type)
 {
+#ifdef _WIN32
+    const char separator = '\\';
+#else
+    const char separator = '/';
+#endif
+
     // FIXME: Does this have to be changed to accomodate Windows platforms?
     std::string buffer;
     buffer.reserve(2 + path.length() + component.length());
     buffer.append(path);
     std::string terminal = "";
-    if (path_type == FilePathType::Directory && component[component.length() - 1] != '/') {
-        terminal = "/";
+    if (path_type == FilePathType::Directory && component[component.length() - 1] != separator) {
+        terminal = separator;
     }
     char path_last = path[path.length() - 1];
     char component_first = component[0];
-    if (path_last == '/' && component_first == '/') {
+    if (path_last == separator && component_first == separator) {
         buffer.append(component.substr(1));
         buffer.append(terminal);
-    } else if (path_last == '/' || component_first == '/') {
+    } else if (path_last == separator || component_first == separator) {
         buffer.append(component);
         buffer.append(terminal);
     } else {
-        buffer.append("/");
+        buffer.append(std::string(1, separator));
         buffer.append(component);
         buffer.append(terminal);
     }

--- a/src/sync/impl/sync_file.cpp
+++ b/src/sync/impl/sync_file.cpp
@@ -132,8 +132,6 @@ std::string file_path_by_appending_component(const std::string& path, const std:
 #else
     const char separator = '/';
 #endif
-
-    // FIXME: Does this have to be changed to accomodate Windows platforms?
     std::string buffer;
     buffer.reserve(2 + path.length() + component.length());
     buffer.append(path);


### PR DESCRIPTION
This fixes path generation on windows
the old version generates a path like so: c:\my_path/my_component/path
the pr version generates a path like so: c:\my_path\my_component\path