### PR TITLE
Stop the sync client before tearing down the sync file manager

### DIFF
--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -208,9 +208,6 @@ bool SyncManager::run_file_action(const SyncFileActionMetadata& md)
 void SyncManager::reset_for_testing()
 {
     std::lock_guard<std::mutex> lock(m_file_system_mutex);
-    if (m_file_manager)
-        util::try_remove_dir_recursive(m_file_manager->base_path());
-    m_file_manager = nullptr;
     m_metadata_manager = nullptr;
     m_client_uuid = util::none;
 
@@ -250,6 +247,10 @@ void SyncManager::reset_for_testing()
 
         m_sync_route = "";
     }
+
+    if (m_file_manager)
+        util::try_remove_dir_recursive(m_file_manager->base_path());
+    m_file_manager = nullptr;
 }
 
 void SyncManager::set_log_level(util::Logger::Level level) noexcept


### PR DESCRIPTION
The sync client may still be using that directory so it needs to be stopped first. This is probably the source of occasional make_dir() errors in the Cocoa sync tests.