### PR TITLE
Normalize Windows kernel object names casing

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,16 @@
+﻿{
+  "configurations": [
+    {
+      "name": "x64-Debug",
+      "generator": "Visual Studio 16 2019 Win64",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": []
+    }
+  ]
+}

--- a/src/impl/realm_coordinator.cpp
+++ b/src/impl/realm_coordinator.cpp
@@ -796,6 +796,14 @@ void RealmCoordinator::on_change()
     for (auto& realm : m_weak_realm_notifiers) {
         realm.notify();
     }
+
+#if REALM_ENABLE_SYNC
+    // Invoke realm sync if another process has notified for a change
+    if (m_sync_session) {
+        auto version = m_db->get_version_of_latest_snapshot();
+        SyncSession::Internal::nonsync_transact_notify(*m_sync_session, version);
+    }
+#endif
 }
 
 namespace {


### PR DESCRIPTION
Normalize Windows kernel object names casing to account for windows drive letter case-insenstivity

added Visual Studio generated CMakeSettings.json to allow building and runing tests.exe from whithin Visual Studio