### PR TITLE
fix-crash-with-optional-primary-key

### DIFF
--- a/src/object_accessor.hpp
+++ b/src/object_accessor.hpp
@@ -248,7 +248,7 @@ Object Object::create(ContextType& ctx, std::shared_ptr<Realm> const& realm,
             if (!created && !policy.update) {
                 if (!realm->is_in_migration()) {
                     throw std::logic_error(util::format("Attempting to create an object of type '%1' with an existing primary key value '%2'.",
-                                                        object_schema.name, ctx.print(*primary_value)));
+                                                        object_schema.name, primary_value ? ctx.print(*primary_value) : "null"));
                 }
                 table->set_primary_key_column(ColKey{});
                 skip_primary = false;


### PR DESCRIPTION
Fixes a crash when trying to build an error message with a null primary key default value. 
The crash is due to assert in realm::util::Optional `Assertion failed: m_engaged`