### PR TITLE
update embedded object cycle detection

### DIFF
--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -82,29 +82,35 @@ Schema::const_iterator Schema::find(ObjectSchema const& object) const noexcept
 namespace {
 
 struct CheckObjectPath {
-    const ObjectSchema& object;
-    std::string path;
+    const ObjectSchema& object; // the schema to check
+    std::string path; // a printable path for error messaging
+    std::unordered_set<std::string> visited; // the list of object types encountered along this path so far
 };
 
-// a non-recursive search that returns a path to any embedded object that has multiple paths from the start
+// a non-recursive search that returns a property path to the first embedded object cycle detected
 std::string do_check(Schema const& schema, const ObjectSchema& start)
 {
     std::queue<CheckObjectPath> to_visit;
-    std::unordered_set<std::string> visited;
-    to_visit.push(CheckObjectPath{start, start.name});
+    to_visit.push(CheckObjectPath{start, start.name, {start.name}});
 
     while (to_visit.size() > 0) {
         auto current = to_visit.front();
-        visited.insert(current.object.name);
         for (auto& prop : current.object.persisted_properties) {
             if (prop.type == PropertyType::Object) {
                 auto it = schema.find(prop.object_type);
                 REALM_ASSERT(it != schema.end()); // this succeeds if the schema is otherwise valid
-                auto next_path = current.path + "." + prop.name;
-                if (visited.find(prop.object_type) == visited.end()) {
-                    to_visit.push(CheckObjectPath{*it, next_path});
+                if (!it->is_embedded) {
+                    // the server does support links to top level objects (serialized as a PK)
+                    // so if we encounter this type of link, no need to check further along this path
+                    continue;
                 }
-                else if (it->is_embedded) {
+                auto next_path = current.path + "." + prop.name;
+                if (current.visited.find(prop.object_type) == current.visited.end()) {
+                    auto visited_copy = current.visited;
+                    visited_copy.insert(current.object.name);
+                    to_visit.push(CheckObjectPath{*it, next_path, std::move(visited_copy)});
+                }
+                else {
                     return next_path;
                 }
             }
@@ -116,6 +122,9 @@ std::string do_check(Schema const& schema, const ObjectSchema& start)
 
 void check_for_embedded_objects_loop(Schema const& schema, std::vector<ObjectSchemaValidationException>& exceptions)
 {
+    // A prerequisite for an embedded object loop is that there are links orginating from an embedded object
+    // so we only need to run this check from embedded objects. This is an optimization to exclude entire
+    // object graphs which do not contain embedded objects.
     for (auto const& object : schema) {
         if (object.is_embedded) {
             std::string loop = do_check(schema, object);

--- a/src/schema.cpp
+++ b/src/schema.cpp
@@ -105,14 +105,12 @@ std::string do_check(Schema const& schema, const ObjectSchema& start)
                     continue;
                 }
                 auto next_path = current.path + "." + prop.name;
-                if (current.visited.find(prop.object_type) == current.visited.end()) {
-                    auto visited_copy = current.visited;
-                    visited_copy.insert(current.object.name);
-                    to_visit.push(CheckObjectPath{*it, next_path, std::move(visited_copy)});
-                }
-                else {
+                if (current.visited.find(prop.object_type) != current.visited.end()) {
                     return next_path;
                 }
+                auto visited_copy = current.visited;
+                visited_copy.insert(current.object.name);
+                to_visit.push(CheckObjectPath{*it, next_path, std::move(visited_copy)});
             }
         }
         to_visit.pop();

--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -329,7 +329,7 @@ TEST_CASE("Schema") {
             REQUIRE_NOTHROW(schema.validate());
         }
 
-        SECTION("rejects embedded objects self loop via top level object") {
+        SECTION("does not reject an embedded object loop via top level object") {
             Schema schema = {
                 {"TopLevelObject", {
                     {"link_to_embedded_object", PropertyType::Object|PropertyType::Nullable, "EmbeddedObject"}
@@ -338,7 +338,19 @@ TEST_CASE("Schema") {
                     {"link_to_top_level_object", PropertyType::Object|PropertyType::Nullable, "TopLevelObject"}
                 }}
             };
-            REQUIRE_THROWS_CONTAINING(schema.validate(), "Cycles containing embedded objects are not currently supported: 'EmbeddedObject.link_to_top_level_object.link_to_embedded_object'");
+            REQUIRE_NOTHROW(schema.validate());
+        }
+
+        SECTION("does not reject a top level loop via embedded object link") {
+            Schema schema = {
+                {"TopLevelObject", {
+                    {"link_to_self", PropertyType::Object|PropertyType::Nullable, "TopLevelObject"}
+                }},
+                {"EmbeddedObject", ObjectSchema::IsEmbedded{true}, {
+                    {"link_to_top_level_object", PropertyType::Object|PropertyType::Nullable, "TopLevelObject"}
+                }}
+            };
+            REQUIRE_NOTHROW(schema.validate());
         }
 
         SECTION("rejects embedded objects loop to itself") {
@@ -353,7 +365,19 @@ TEST_CASE("Schema") {
             REQUIRE_THROWS_CONTAINING(schema.validate(), "Cycles containing embedded objects are not currently supported: 'EmbeddedObject.link_to_self'");
         }
 
-        SECTION("rejects embedded objects self loop via different embedded object") {
+        SECTION("rejects embedded objects loop to itself from a list") {
+            Schema schema = {
+                {"TopLevelObject", {
+                    {"link_to_embedded_object", PropertyType::Object|PropertyType::Nullable, "EmbeddedObject"}
+                }},
+                {"EmbeddedObject", ObjectSchema::IsEmbedded{true}, {
+                    {"link_to_self", PropertyType::Object|PropertyType::Array, "EmbeddedObject"}
+                }}
+            };
+            REQUIRE_THROWS_CONTAINING(schema.validate(), "Cycles containing embedded objects are not currently supported: 'EmbeddedObject.link_to_self'");
+        }
+
+        SECTION("rejects embedded objects loop via different embedded object") {
             Schema schema = {
                 {"TopLevelObject", {
                     {"link_to_embedded_object", PropertyType::Object|PropertyType::Nullable, "EmbeddedObjectA"}
@@ -391,11 +415,15 @@ TEST_CASE("Schema") {
             catch(const std::exception& e) {
                 message = e.what();
             }
-            bool found_loop_on_a = message.find("Cycles containing embedded objects are not currently supported: 'EmbeddedObjectA.link_to_c.link_to_a'") != std::string::npos
-                                || message.find("Cycles containing embedded objects are not currently supported: 'EmbeddedObjectA.link_to_b.link_to_a'") != std::string::npos;
+            bool found_loop_on_a = message.find("EmbeddedObjectA.link_to_c.link_to_a") != std::string::npos
+                                || message.find("EmbeddedObjectA.link_to_b.link_to_a") != std::string::npos;
+            bool found_loop_on_b = message.find("EmbeddedObjectB.link_to_a.link_to_b") != std::string::npos
+                                || message.find("EmbeddedObjectB.link_to_a.link_to_c.link_to_a") != std::string::npos;
+            bool found_loop_on_c = message.find("EmbeddedObjectC.link_to_a.link_to_c") != std::string::npos
+                                || message.find("EmbeddedObjectC.link_to_a.link_to_b.link_to_a") != std::string::npos;
             REQUIRE(found_loop_on_a);
-            REQUIRE(message.find("Cycles containing embedded objects are not currently supported: 'EmbeddedObjectB.link_to_a.link_to_b'") != std::string::npos);
-            REQUIRE(message.find("Cycles containing embedded objects are not currently supported: 'EmbeddedObjectC.link_to_a.link_to_c'") != std::string::npos);
+            REQUIRE(found_loop_on_b);
+            REQUIRE(found_loop_on_c);
         }
 
         SECTION("allows top level loops") {
@@ -412,6 +440,40 @@ TEST_CASE("Schema") {
                 {"EmbeddedObjectB", ObjectSchema::IsEmbedded{true}, {
                     {"link_to_a", PropertyType::Object|PropertyType::Nullable, "EmbeddedObjectA"}
                 }}
+            };
+            REQUIRE_NOTHROW(schema.validate());
+        }
+
+        SECTION("distinct paths to an embedded object is not a loop") {
+            Schema schema = {
+                {"TopLevelObjectA", {
+                    {"link1_to_embedded", PropertyType::Object|PropertyType::Nullable, "EmbeddedObjectA"},
+                    {"link2_to_embedded", PropertyType::Object|PropertyType::Nullable, "EmbeddedObjectA"}
+                }},
+                {"EmbeddedObjectA", ObjectSchema::IsEmbedded{true}, {
+                    {"prop", PropertyType::Int}
+                }},
+            };
+            REQUIRE_NOTHROW(schema.validate());
+        }
+
+        SECTION("linked distinct paths to an embedded object is not a loop") {
+            Schema schema = {
+                {"TopLevelObjectA", {
+                    {"link_to_embedded_A", PropertyType::Object|PropertyType::Nullable, "EmbeddedObjectA"},
+                    {"link_to_embedded_B", PropertyType::Object|PropertyType::Nullable, "EmbeddedObjectB"}
+                }},
+                {"EmbeddedObjectA", ObjectSchema::IsEmbedded{true}, {
+                    {"link_to_c", PropertyType::Object|PropertyType::Nullable, "EmbeddedObjectC"},
+                    {"link_to_b", PropertyType::Object|PropertyType::Nullable, "EmbeddedObjectB"}
+                }},
+                {"EmbeddedObjectB", ObjectSchema::IsEmbedded{true}, {
+                    {"link_to_c", PropertyType::Object|PropertyType::Nullable, "EmbeddedObjectC"},
+                }},
+                {"EmbeddedObjectC", ObjectSchema::IsEmbedded{true}, {
+                    {"prop", PropertyType::Int}
+                }}
+
             };
             REQUIRE_NOTHROW(schema.validate());
         }

--- a/tests/schema.cpp
+++ b/tests/schema.cpp
@@ -344,7 +344,8 @@ TEST_CASE("Schema") {
         SECTION("does not reject a top level loop via embedded object link") {
             Schema schema = {
                 {"TopLevelObject", {
-                    {"link_to_self", PropertyType::Object|PropertyType::Nullable, "TopLevelObject"}
+                    {"link_to_self", PropertyType::Object|PropertyType::Nullable, "TopLevelObject"},
+                    {"link_to_embedded_object", PropertyType::Object|PropertyType::Nullable, "EmbeddedObject"}
                 }},
                 {"EmbeddedObject", ObjectSchema::IsEmbedded{true}, {
                     {"link_to_top_level_object", PropertyType::Object|PropertyType::Nullable, "TopLevelObject"}


### PR DESCRIPTION
It was [reported](https://jira.mongodb.org/browse/RJAVA-710) that a cycle is incorrectly detected in the case of a diamond pattern of paths; eg. given the relationship graph A->B->C, and A->D->C. 

Also fixed detecting cycles through top level objects, as this should be allowed by the server. Eg. Given a top level object with an embedded object which also has a link to the same top level object, this is not considered a loop we should restrict.