### PR TITLE
hold the mutex while calling notify_all

### DIFF
--- a/src/impl/windows/external_commit_helper.cpp
+++ b/src/impl/windows/external_commit_helper.cpp
@@ -86,7 +86,9 @@ void ExternalCommitHelper::listen()
     while (m_keep_listening) {
         m_commit_available.wait(m_mutex, nullptr);
         if (m_keep_listening) {
+            m_mutex.unlock();
 			m_parent.on_change();
+            m_mutex.lock();
         }
     }
 }

--- a/src/impl/windows/external_commit_helper.cpp
+++ b/src/impl/windows/external_commit_helper.cpp
@@ -57,7 +57,7 @@ ExternalCommitHelper::ExternalCommitHelper(RealmCoordinator& parent)
     m_commit_available.set_shared_part(m_condvar_shared.get(), 
         normalize_realm_path_for_windows_kernel_object_name(parent.get_path()),
         "ExternalCommitHelper_CommitCondVar",
-        std::filesystem::temp_directory_path().u8string());
+        normalize_realm_path_for_windows_kernel_object_name(std::filesystem::temp_directory_path().u8string()));
 
     m_thread = std::async(std::launch::async, [this]() { listen(); });
 }

--- a/src/impl/windows/external_commit_helper.cpp
+++ b/src/impl/windows/external_commit_helper.cpp
@@ -76,6 +76,7 @@ ExternalCommitHelper::~ExternalCommitHelper()
 
 void ExternalCommitHelper::notify_others()
 {
+    std::lock_guard<InterprocessMutex> lock(m_mutex);
     m_commit_available.notify_all();
 }
 


### PR DESCRIPTION
This is a precondition when calling notify_all and fixes a dead lock in Electron on Windows