### PR TITLE
Allow revival of removed users

### DIFF
--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -348,11 +348,7 @@ std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& user_id,
         // if the order of these were flipped).
         user->update_access_token(std::move(access_token));
         user->update_refresh_token(std::move(refresh_token));
-
         user->set_state(SyncUser::State::LoggedIn);
-        if (!m_metadata_manager)
-            m_current_user = user;
-
         return user;
     }
 }

--- a/src/sync/sync_manager.cpp
+++ b/src/sync/sync_manager.cpp
@@ -322,7 +322,7 @@ std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& user_id,
     auto it = std::find_if(m_users.begin(),
                            m_users.end(),
                            [user_id, provider_type](const auto& user) {
-        return user->identity() == user_id && user->provider_type() == provider_type;
+        return user->identity() == user_id && user->provider_type() == provider_type && user->state() != SyncUser::State::Removed;
     });
     if (it == m_users.end()) {
         // No existing user.
@@ -338,8 +338,10 @@ std::shared_ptr<SyncUser> SyncManager::get_user(const std::string& user_id,
             m_current_user = new_user;
         return new_user;
     }
-    else { // LoggedOut || Removed => LoggedIn
+    else { // LoggedOut => LoggedIn
         auto user = *it;
+        REALM_ASSERT(user->state() != SyncUser::State::Removed);
+
         // It is important that the access token is set before the refresh token
         // as once each token is set it attempts to revive any pending sessions
         // (e.g. as user logs out and logs back in they would be using an empty access token with the sync client

--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -179,11 +179,10 @@ void SyncUser::update_refresh_token(std::string&& token)
     {
         std::unique_lock<std::mutex> lock(m_mutex);
         switch (m_state) {
-            case State::Removed:
-                return;
             case State::LoggedIn:
                 m_refresh_token = RealmJWT(std::move(token));
                 break;
+            case State::Removed:
             case State::LoggedOut: {
                 sessions_to_revive.reserve(m_waiting_sessions.size());
                 m_refresh_token = RealmJWT(std::move(token));
@@ -218,11 +217,10 @@ void SyncUser::update_access_token(std::string&& token)
     {
         std::unique_lock<std::mutex> lock(m_mutex);
         switch (m_state) {
-            case State::Removed:
-                return;
             case State::LoggedIn:
                 m_access_token = RealmJWT(std::move(token));
                 break;
+            case State::Removed:
             case State::LoggedOut: {
                 sessions_to_revive.reserve(m_waiting_sessions.size());
                 m_access_token = RealmJWT(std::move(token));

--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -179,10 +179,11 @@ void SyncUser::update_refresh_token(std::string&& token)
     {
         std::unique_lock<std::mutex> lock(m_mutex);
         switch (m_state) {
+            case State::Removed:
+                break;
             case State::LoggedIn:
                 m_refresh_token = RealmJWT(std::move(token));
                 break;
-            case State::Removed:
             case State::LoggedOut: {
                 sessions_to_revive.reserve(m_waiting_sessions.size());
                 m_refresh_token = RealmJWT(std::move(token));
@@ -217,10 +218,11 @@ void SyncUser::update_access_token(std::string&& token)
     {
         std::unique_lock<std::mutex> lock(m_mutex);
         switch (m_state) {
+            case State::Removed:
+                break;
             case State::LoggedIn:
                 m_access_token = RealmJWT(std::move(token));
                 break;
-            case State::Removed:
             case State::LoggedOut: {
                 sessions_to_revive.reserve(m_waiting_sessions.size());
                 m_access_token = RealmJWT(std::move(token));

--- a/src/sync/sync_user.cpp
+++ b/src/sync/sync_user.cpp
@@ -180,7 +180,7 @@ void SyncUser::update_refresh_token(std::string&& token)
         std::unique_lock<std::mutex> lock(m_mutex);
         switch (m_state) {
             case State::Removed:
-                break;
+                return;
             case State::LoggedIn:
                 m_refresh_token = RealmJWT(std::move(token));
                 break;
@@ -219,7 +219,7 @@ void SyncUser::update_access_token(std::string&& token)
         std::unique_lock<std::mutex> lock(m_mutex);
         switch (m_state) {
             case State::Removed:
-                break;
+                return;
             case State::LoggedIn:
                 m_access_token = RealmJWT(std::move(token));
                 break;

--- a/tests/sync/app.cpp
+++ b/tests/sync/app.cpp
@@ -467,7 +467,6 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
         REQUIRE(user);
         CHECK(user->user_profile().email == email);
 
-
         CHECK(user->state() == SyncUser::State::LoggedIn);
 
         app->remove_user(user, [&](Optional<app::AppError> error) {
@@ -484,10 +483,11 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
             });
         CHECK(processed);
         processed = false;
-        CHECK(user->state() == SyncUser::State::LoggedIn);
-
-        CHECK(app->current_user() == user);
+        CHECK(user->state() == SyncUser::State::Removed);
+        CHECK(app->current_user() != user);
+        user = app->current_user();
         CHECK(user->user_profile().email == email);
+        CHECK(user->state() == SyncUser::State::LoggedIn);
 
         app->remove_user(user, [&](Optional<app::AppError> error) {
             REQUIRE(!error);

--- a/tests/sync/app.cpp
+++ b/tests/sync/app.cpp
@@ -449,6 +449,56 @@ TEST_CASE("app: UsernamePasswordProviderClient integration", "[sync][app]") {
                 });
         CHECK(processed);
     }
+
+    SECTION("log in, remove, log in") {
+
+        CHECK(app->sync_manager()->all_users().size() == 0);
+        CHECK(app->sync_manager()->get_current_user() == nullptr);
+
+        app->log_in_with_credentials(realm::app::AppCredentials::username_password(email, password),
+            [&](std::shared_ptr<realm::SyncUser> user, Optional<app::AppError> error) {
+                REQUIRE(user);
+                CHECK(!error);
+                processed = true;
+            });
+        CHECK(processed);
+        processed = false;
+        auto user = app->current_user();
+        REQUIRE(user);
+        CHECK(user->user_profile().email == email);
+
+
+        CHECK(user->state() == SyncUser::State::LoggedIn);
+
+        app->remove_user(user, [&](Optional<app::AppError> error) {
+            CHECK(!error);
+        });
+
+        CHECK(user->state() == SyncUser::State::Removed);
+
+        app->log_in_with_credentials(realm::app::AppCredentials::username_password(email, password),
+            [&](std::shared_ptr<realm::SyncUser> user, Optional<app::AppError> error) {
+                REQUIRE(user);
+                CHECK(!error);
+                processed = true;
+            });
+        CHECK(processed);
+        processed = false;
+        CHECK(user->state() == SyncUser::State::LoggedIn);
+
+        CHECK(app->current_user() == user);
+        CHECK(user->user_profile().email == email);
+
+        app->remove_user(user, [&](Optional<app::AppError> error) {
+            REQUIRE(!error);
+            CHECK(app->sync_manager()->all_users().size() == 0);
+            processed = true;
+        });
+
+        CHECK(user->state() == SyncUser::State::Removed);
+        CHECK(processed);
+        CHECK(app->all_users().size() == 0);
+    }
 }
 
 // MARK: - UserAPIKeyProviderClient Tests
@@ -3173,7 +3223,6 @@ TEST_CASE("app: remove user with credentials", "[sync][app]") {
         CHECK(test_user->state() == SyncUser::State::Removed);
         CHECK(processed);
     }
-
 }
 
 TEST_CASE("app: link_user", "[sync][app]") {


### PR DESCRIPTION
Fixes https://github.com/realm/realm-core/issues/4142

I think this is all that is required, but I'm not super familiar with the Removed user state and how it differentiates from the logged out state. I also considered doing the user removal at this point, and creating a new object instance but I didn't want to deviate the behaviour from what the logged out state does. So I'll ask reviewers to please confirm that this seems correct.